### PR TITLE
add Docker support for web interface

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.git/
+.gitignore
+venv/
+.env
+*.pdf
+CLAUDE.md
+README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@ python check_hallucinated_references.py --output log.txt <pdf>
 python app.py  # Starts on http://localhost:5001
 ```
 
+### Docker
+```bash
+docker build -t hallucinator .
+docker run -p 5001:5001 hallucinator
+```
+
 ## Architecture
 
 ### Processing Pipeline

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application files
+COPY check_hallucinated_references.py .
+COPY app.py .
+COPY templates/ templates/
+COPY static/ static/
+
+EXPOSE 5001
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Created by Gianluca Stringhini with the help of Claude Code and ChatGPT
 
 ## Installation
 
+### pip
+
 ```bash
 # Create a virtual environment (recommended)
 python3 -m venv venv
@@ -34,6 +36,28 @@ source venv/bin/activate
 # Install dependencies
 pip install -r requirements.txt
 ```
+
+### Docker
+
+Run the web interface in a container:
+
+```bash
+# Build the image
+docker build -t hallucinator .
+
+# Run the container
+docker run -p 5001:5001 hallucinator
+```
+
+Then open `http://localhost:5001` in your browser.
+
+To enable debug mode:
+
+```bash
+docker run -p 5001:5001 -e FLASK_DEBUG=1 hallucinator
+```
+
+
 
 ## Usage
 
@@ -94,6 +118,8 @@ The server will start at `http://localhost:5001`.
    - Google Scholar links for manual verification
 
 The web interface displays the same information as the command-line tool but provides clickable Google Scholar links to quickly verify flagged references.
+
+
 
 ## Example Output
 

--- a/app.py
+++ b/app.py
@@ -164,4 +164,5 @@ def analyze():
 
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5001)
+    debug = os.environ.get('FLASK_DEBUG', '').lower() in ('1', 'true')
+    app.run(host='0.0.0.0', port=5001, debug=debug)


### PR DESCRIPTION
## Summary
- Adds Dockerfile (Python 3.11-slim) to run the web interface in a container
- Adds .dockerignore to exclude unnecessary files from builds
- Modifies app.py to bind to 0.0.0.0 (required for container networking)
- Adds FLASK_DEBUG environment variable for debug mode control
- Updates README.md and CLAUDE.md with Docker instructions

## Usage
```bash
docker build -t hallucinator .
docker run -p 5001:5001 hallucinator
```

Then visit http://localhost:5001

## Test plan
- [x] Docker image builds successfully
- [x] Container starts and Flask serves on port 5001
- [x] Web interface responds with HTTP 200

🤖 Generated with [Claude Code](https://claude.ai/claude-code)