### PR TITLE
Show DBLP offline DB path in web UI when DBLP_OFFLINE_PATH is set

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,7 +272,11 @@ def analyze_pdf(pdf_path, openalex_key=None, s2_api_key=None, on_progress=None, 
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    dblp_offline_path = os.environ.get("DBLP_OFFLINE_PATH", "")
+    return render_template(
+        "index.html",
+        dblp_offline_path=dblp_offline_path
+    )
 
 
 def analyze_single_pdf(pdf_path, filename, openalex_key=None, s2_api_key=None, dblp_offline_path=None, check_openalex_authors=False):

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,8 @@
             --drop-zone-bg: #f9fafb;
             --drop-zone-active-bg: #eff6ff;
             --drop-zone-active-border: #2563eb;
+            --input-readonly-bg: #f3f4f6;
+            --input-readonly-text: #6b7280;
         }
         .dark {
             --bg-primary: #1a1a1a;
@@ -36,6 +38,8 @@
             --drop-zone-bg: #252525;
             --drop-zone-active-bg: #1e3a5f;
             --drop-zone-active-border: #60a5fa;
+            --input-readonly-bg: #2a2a2a;
+            --input-readonly-text: #9ca3af;
         }
         * {
             box-sizing: border-box;
@@ -311,6 +315,12 @@
         .checkbox-label input[type="checkbox"] {
             width: auto;
             margin: 0;
+        }
+        input[type="text"][readonly] {
+            background-color: var(--input-readonly-bg);
+            color: var(--input-readonly-text);
+            cursor: not-allowed;
+            opacity: 0.85;
         }
         button {
             background: #2563eb;
@@ -866,6 +876,13 @@
                     <div class="drop-zone-hint">or click to browse</div>
                     <div class="drop-zone-file" id="selectedFile" style="display: none;"></div>
                 </div>
+            </div>
+            <div class="form-group">
+                <label for="dblpOfflinePath">
+                    DBLP Database Offline Path
+                    <span class="label-hint">(optional, if  <code>DBLP_OFFLINE_PATH</code> is set it will be shown here)</span>
+                </label>
+                <input type="text" id="dblpOfflinePath" name="dblp_offline_path" value="{{ dblp_offline_path }}" placeholder="unset" readonly />
             </div>
             <div class="form-group">
                 <label for="openalexKey">


### PR DESCRIPTION
**Description**
This PR makes the web interface surface the configured offline DBLP database path (if present), so users can quickly confirm whether the app is running with an offline DBLP database. The field is intentionally readonly because the effective path is controlled by server environment configuration, not client input.

**Changes**

* `app.py`: read `DBLP_OFFLINE_PATH` from the environment and pass it to the template as `dblp_offline_path`. ([GitHub][1])
* `templates/index.html`:

  * add a readonly “DBLP Database Offline Path” field populated from `dblp_offline_path`
  * add small CSS tweaks for readonly input styling (light/dark mode variables + readonly input styles). ([GitHub][2])

**Testing**

* Ran the web app locally and verified:

  * with `DBLP_OFFLINE_PATH` unset, field shows `unset`
  * with `DBLP_OFFLINE_PATH=/tmp/cristian/hallucinator/dblp.db`, field displays that value and remains readonly.

**Screenshots**

Light mode
<img width="1920" height="1046" alt="light mode screenshot" src="https://github.com/user-attachments/assets/3cb8a7e7-34ef-485d-8ca1-f8c80dd5b0da" />

Dark mode
<img width="1920" height="1046" alt="dark mode screenshot" src="https://github.com/user-attachments/assets/829a927f-301e-433c-b48b-1a4fb363ec59" />

[1]: https://github.com/CristianCantoro/hallucinator/commit/c291dca82c2c033f90b3ef279f6d51e1611c662a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R275
[2]: https://github.com/CristianCantoro/hallucinator/commit/c291dca82c2c033f90b3ef279f6d51e1611c662a#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R880