### PR TITLE
Add toggle/disable database checks (#20)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -316,6 +316,11 @@
             width: auto;
             margin: 0;
         }
+        .db-toggles {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.4rem 1.5rem;
+        }
         input[type="text"][readonly] {
             background-color: var(--input-readonly-bg);
             color: var(--input-readonly-text);
@@ -948,6 +953,24 @@
                     <span class="label-hint">(off by default due to false positives)</span>
                 </label>
             </div>
+            <div class="form-group">
+                <label>
+                    Database Sources
+                    <span class="label-hint">(uncheck to skip — <a href="#" id="dbToggleAll">select/unselect all</a>)</span>
+                </label>
+                <div class="db-toggles">
+                    <label class="checkbox-label"><input type="checkbox" data-db="CrossRef" checked><span>CrossRef</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="arXiv" checked><span>arXiv</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="DBLP" checked><span>DBLP</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="Semantic Scholar" checked><span>Semantic Scholar</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="SSRN" checked><span>SSRN</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="ACL Anthology" checked><span>ACL Anthology</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="NeurIPS" checked><span>NeurIPS</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="Europe PMC" checked><span>Europe PMC</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="PubMed" checked><span>PubMed</span></label>
+                    <label class="checkbox-label"><input type="checkbox" data-db="OpenAlex" checked><span>OpenAlex</span></label>
+                </div>
+            </div>
             <button type="submit" id="submitBtn">Analyze References</button>
         </form>
         <div class="progress-section" id="progressSection">
@@ -1097,6 +1120,29 @@
         if (savedCheckOpenalexAuthors === 'true') {
             checkOpenalexAuthorsInput.checked = true;
         }
+
+        // Restore disabled databases from localStorage
+        const savedDisabledDbs = localStorage.getItem('disabledDbs');
+        if (savedDisabledDbs) {
+            try {
+                const disabledSet = new Set(JSON.parse(savedDisabledDbs));
+                document.querySelectorAll('[data-db]').forEach(cb => {
+                    if (disabledSet.has(cb.getAttribute('data-db'))) {
+                        cb.checked = false;
+                    }
+                });
+            } catch (e) {
+                localStorage.removeItem('disabledDbs');
+            }
+        }
+
+        // Select/unselect all database toggles
+        document.getElementById('dbToggleAll').addEventListener('click', (e) => {
+            e.preventDefault();
+            const boxes = document.querySelectorAll('[data-db]');
+            const allChecked = Array.from(boxes).every(cb => cb.checked);
+            boxes.forEach(cb => cb.checked = !allChecked);
+        });
 
         // Cookie helpers
         function getCookie(name) {
@@ -3157,6 +3203,20 @@ https://github.com/idramalab/hallucinator
                 localStorage.setItem('checkOpenalexAuthors', 'true');
             } else {
                 localStorage.removeItem('checkOpenalexAuthors');
+            }
+
+            // Collect disabled databases and save to localStorage + FormData
+            const disabledDbs = [];
+            document.querySelectorAll('[data-db]').forEach(cb => {
+                if (!cb.checked) {
+                    disabledDbs.push(cb.getAttribute('data-db'));
+                }
+            });
+            if (disabledDbs.length > 0) {
+                localStorage.setItem('disabledDbs', JSON.stringify(disabledDbs));
+                formData.append('disabled_dbs', JSON.stringify(disabledDbs));
+            } else {
+                localStorage.removeItem('disabledDbs');
             }
 
             // Reset UI


### PR DESCRIPTION
## Summary

- Adds `ALL_DATABASES` canonical constant as single source of truth for database identifiers
- Threads `enabled_dbs` parameter through the full call chain: `query_all_databases_concurrent()` → `check_references()` → `main()` / `analyze_pdf()` / `analyze_single_pdf()`
- **Web GUI**: 10 database toggle checkboxes in a 2-column grid with select/unselect all link, persisted via localStorage
- **CLI**: `--disable-dbs=DB1,DB2` flag with validation against known database names

Users can now selectively disable slow or unnecessary databases to speed up analysis (e.g., skip Semantic Scholar when no API key is available).

## Test plan

- [ ] Start `python app.py`, open http://localhost:5001
- [ ] Verify all 10 database checkboxes appear, all checked by default
- [ ] Uncheck a few databases, submit a PDF, confirm server logs show only enabled databases queried
- [ ] Refresh page, confirm unchecked state persists via localStorage
- [ ] Test select/unselect all link toggles all checkboxes
- [ ] CLI: `python check_hallucinated_references.py --disable-dbs="Semantic Scholar,SSRN" test.pdf` — verify disabled DBs printed and skipped
- [ ] CLI: `python check_hallucinated_references.py --disable-dbs="FakeDB" test.pdf` — verify error message with valid DB list

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)