### PR TITLE
Preserve partial results when analysis is cancelled

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3141,6 +3141,49 @@ https://github.com/idramalab/hallucinator
             return html;
         }
 
+        function renderCancelledResults() {
+            progressSection.classList.remove('visible');
+
+            if (liveResults.length === 0) {
+                errorMessage.textContent = 'Analysis cancelled.';
+                errorMessage.classList.add('visible');
+                return;
+            }
+
+            // Build summary from partial results
+            const verified = liveResults.filter(r => r.status === 'verified').length;
+            const notFound = liveResults.filter(r => r.status === 'not_found').length;
+            const mismatched = liveResults.filter(r => r.status === 'author_mismatch').length;
+            const checked = liveResults.length;
+
+            const summary = {
+                total: totalRefs || checked,
+                verified: verified,
+                not_found: notFound,
+                mismatched: mismatched,
+                skipped: 0,
+                skipped_url: 0,
+                skipped_short_title: 0,
+                title_only: 0,
+            };
+
+            document.getElementById('hallucinations').querySelector('h2').style.display = 'block';
+
+            renderSingleFileResults({
+                summary: summary,
+                results: liveResults,
+            });
+
+            // Show a warning banner that results are partial
+            const resultsSection = document.getElementById('hallucinations');
+            const cancelBanner = document.createElement('div');
+            cancelBanner.style.cssText = 'margin-bottom: 1rem; padding: 0.5rem 1rem; background: #fef3c7; border: 1px solid #f59e0b; border-radius: 0.375rem; color: #92400e; font-size: 0.9rem;';
+            cancelBanner.textContent = `Analysis cancelled. Showing partial results: ${checked} of ${totalRefs || '?'} references checked.`;
+            resultsSection.insertBefore(cancelBanner, resultsSection.children[1]);
+
+            results.classList.add('visible');
+        }
+
         function resetProgressUI() {
             liveResults = [];
             totalRefs = 0;
@@ -3384,9 +3427,7 @@ https://github.com/idramalab/hallucinator
 
                         results.classList.add('visible');
                     } else if (eventType === 'cancelled') {
-                        progressSection.classList.remove('visible');
-                        errorMessage.textContent = 'Analysis cancelled.';
-                        errorMessage.classList.add('visible');
+                        renderCancelledResults();
                         return;
                     } else if (eventType === 'error') {
                         throw new Error(eventData.message || 'Analysis failed');
@@ -3411,13 +3452,13 @@ https://github.com/idramalab/hallucinator
                 }
 
             } catch (err) {
-                progressSection.classList.remove('visible');
                 if (err.name === 'AbortError') {
-                    errorMessage.textContent = 'Analysis cancelled.';
+                    renderCancelledResults();
                 } else {
+                    progressSection.classList.remove('visible');
                     errorMessage.textContent = err.message;
+                    errorMessage.classList.add('visible');
                 }
-                errorMessage.classList.add('visible');
             } finally {
                 currentAbortController = null;
                 submitBtn.disabled = false;


### PR DESCRIPTION
## Summary
- When the user cancels an ongoing analysis, previously all intermediate results were discarded
- Now partial results are rendered in the normal results view instead of being hidden
- A yellow banner indicates the analysis was incomplete and shows how many references were checked
- If cancelled before any results arrive, falls back to the simple "Analysis cancelled" message

## Test plan
- [ ] Upload a PDF with many references, let it run for a few checks, then cancel
- [ ] Verify partial results are displayed in the results table (not hidden)
- [ ] Verify yellow banner shows "Analysis cancelled. Showing partial results: X of Y references checked."
- [ ] Cancel immediately before any results arrive — should show "Analysis cancelled." message
- [ ] Let a full analysis complete normally — verify no regression in normal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)