### PR TITLE
Refactor CLI from flat flags to clap subcommands

### DIFF
--- a/hallucinator-rs/crates/hallucinator-web/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-web/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
                     if let Ok(staleness) = db.check_staleness(30) {
                         if staleness.is_stale {
                             eprintln!(
-                                "Warning: DBLP offline database is {} days old. Consider updating with --update-dblp",
+                                "Warning: DBLP offline database is {} days old. Consider updating with: hallucinator-cli update-dblp <path>",
                                 staleness.age_days.unwrap_or(0)
                             );
                         }


### PR DESCRIPTION
Restructure hallucinator-cli to use `check` and `update-dblp` as proper subcommands instead of having `--update-dblp` as an "exclusive mode" flag. This makes pdf_path required on `check` (no more Option), gives each command its own --help, and sets up the CLI for future subcommands.