### PR TITLE
Add CrossRef Polite Pool support

### DIFF
--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -260,6 +260,7 @@ async fn check(
         db_timeout_short_secs,
         disabled_dbs: disable_dbs,
         check_openalex_authors,
+        crossref_mailto: None,
     };
 
     // Set up progress callback

--- a/hallucinator-rs/crates/hallucinator-core/src/checker.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/checker.rs
@@ -227,7 +227,7 @@ async fn check_single_reference(
                 doi_authors,
             } => {
                 // Check retraction
-                let retraction = check_retraction(doi, client, timeout).await;
+                let retraction = check_retraction(doi, client, timeout, config.crossref_mailto.as_deref()).await;
                 let retraction_info = if retraction.retracted {
                     Some(RetractionInfo {
                         is_retracted: true,
@@ -308,7 +308,7 @@ async fn check_single_reference(
 
     // Step 3: Check retraction by title if verified
     let retraction_info = if db_result.status == Status::Verified {
-        let retraction = check_retraction_by_title(title, client, timeout).await;
+        let retraction = check_retraction_by_title(title, client, timeout, config.crossref_mailto.as_deref()).await;
         if retraction.retracted {
             Some(RetractionInfo {
                 is_retracted: true,

--- a/hallucinator-rs/crates/hallucinator-core/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/lib.rs
@@ -157,6 +157,7 @@ pub struct Config {
     pub db_timeout_short_secs: u64,
     pub disabled_dbs: Vec<String>,
     pub check_openalex_authors: bool,
+    pub crossref_mailto: Option<String>,
 }
 
 impl std::fmt::Debug for Config {
@@ -179,6 +180,7 @@ impl std::fmt::Debug for Config {
             .field("db_timeout_short_secs", &self.db_timeout_short_secs)
             .field("disabled_dbs", &self.disabled_dbs)
             .field("check_openalex_authors", &self.check_openalex_authors)
+            .field("crossref_mailto", &self.crossref_mailto.as_ref().map(|_| "***"))
             .finish()
     }
 }
@@ -197,6 +199,7 @@ impl Default for Config {
             db_timeout_short_secs: 5,
             disabled_dbs: vec![],
             check_openalex_authors: false,
+            crossref_mailto: None,
         }
     }
 }

--- a/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
@@ -225,7 +225,9 @@ fn build_database_list(
     };
 
     if should_include("CrossRef") {
-        databases.push(Box::new(crossref::CrossRef));
+        databases.push(Box::new(crossref::CrossRef {
+            mailto: config.crossref_mailto.clone(),
+        }));
     }
     if should_include("arXiv") {
         databases.push(Box::new(arxiv::Arxiv));

--- a/hallucinator-rs/crates/hallucinator-core/src/retraction.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/retraction.rs
@@ -26,18 +26,21 @@ pub async fn check_retraction(
     doi: &str,
     client: &reqwest::Client,
     timeout: Duration,
+    mailto: Option<&str>,
 ) -> RetractionResult {
     if doi.is_empty() {
         return RetractionResult::default();
     }
 
+    let user_agent = match mailto {
+        Some(email) => format!("HallucinatedReferenceChecker/1.0 (mailto:{})", email),
+        None => "HallucinatedReferenceChecker/1.0 (mailto:hallucination-checker@example.com)".to_string(),
+    };
+
     let url = format!("https://api.crossref.org/works/{}", doi);
     let resp = match client
         .get(&url)
-        .header(
-            "User-Agent",
-            "HallucinatedReferenceChecker/1.0 (mailto:hallucination-checker@example.com)",
-        )
+        .header("User-Agent", &user_agent)
         .timeout(timeout)
         .send()
         .await
@@ -122,6 +125,7 @@ pub async fn check_retraction_by_title(
     title: &str,
     client: &reqwest::Client,
     timeout: Duration,
+    mailto: Option<&str>,
 ) -> RetractionResult {
     if title.len() < 10 {
         return RetractionResult::default();
@@ -132,12 +136,14 @@ pub async fn check_retraction_by_title(
         urlencoding::encode(title)
     );
 
+    let user_agent = match mailto {
+        Some(email) => format!("HallucinatedReferenceChecker/1.0 (mailto:{})", email),
+        None => "HallucinatedReferenceChecker/1.0 (mailto:hallucination-checker@example.com)".to_string(),
+    };
+
     let resp = match client
         .get(&url)
-        .header(
-            "User-Agent",
-            "HallucinatedReferenceChecker/1.0 (mailto:hallucination-checker@example.com)",
-        )
+        .header("User-Agent", &user_agent)
         .timeout(timeout)
         .send()
         .await

--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -458,6 +458,11 @@ impl App {
             db_timeout_short_secs: self.config_state.db_timeout_short_secs,
             disabled_dbs,
             check_openalex_authors: false,
+            crossref_mailto: if self.config_state.crossref_mailto.is_empty() {
+                None
+            } else {
+                Some(self.config_state.crossref_mailto.clone())
+            },
         }
     }
 
@@ -1262,7 +1267,7 @@ impl App {
     fn config_section_item_count(&self) -> usize {
         use crate::model::config::ConfigSection;
         match self.config_state.section {
-            ConfigSection::ApiKeys => 2,
+            ConfigSection::ApiKeys => 3,
             ConfigSection::Databases => 2 + self.config_state.disabled_dbs.len(),
             ConfigSection::Concurrency => 5,
             ConfigSection::Display => 2, // theme + fps
@@ -1277,6 +1282,7 @@ impl App {
                 let value = match self.config_state.item_cursor {
                     0 => self.config_state.openalex_key.clone(),
                     1 => self.config_state.s2_api_key.clone(),
+                    2 => self.config_state.crossref_mailto.clone(),
                     _ => return,
                 };
                 self.config_state.editing = true;
@@ -1371,6 +1377,7 @@ impl App {
             ConfigSection::ApiKeys => match self.config_state.item_cursor {
                 0 => self.config_state.openalex_key = buf,
                 1 => self.config_state.s2_api_key = buf,
+                2 => self.config_state.crossref_mailto = buf,
                 _ => {}
             },
             ConfigSection::Concurrency => match self.config_state.item_cursor {

--- a/hallucinator-rs/crates/hallucinator-tui/src/config_file.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/config_file.rs
@@ -18,6 +18,7 @@ pub struct ConfigFile {
 pub struct ApiKeysConfig {
     pub openalex_key: Option<String>,
     pub s2_api_key: Option<String>,
+    pub crossref_mailto: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -80,6 +81,11 @@ fn merge(base: ConfigFile, overlay: ConfigFile) -> ConfigFile {
                 .as_ref()
                 .and_then(|a| a.s2_api_key.clone())
                 .or_else(|| base.api_keys.as_ref().and_then(|a| a.s2_api_key.clone())),
+            crossref_mailto: overlay
+                .api_keys
+                .as_ref()
+                .and_then(|a| a.crossref_mailto.clone())
+                .or_else(|| base.api_keys.as_ref().and_then(|a| a.crossref_mailto.clone())),
         }),
         databases: Some(DatabasesConfig {
             dblp_offline_path: overlay
@@ -191,6 +197,11 @@ pub fn apply_to_config_state(file_cfg: &ConfigFile, state: &mut ConfigState) {
                 state.s2_api_key = key.clone();
             }
         }
+        if let Some(ref email) = api.crossref_mailto {
+            if !email.is_empty() {
+                state.crossref_mailto = email.clone();
+            }
+        }
     }
     if let Some(db) = &file_cfg.databases {
         if let Some(ref path) = db.dblp_offline_path {
@@ -260,6 +271,11 @@ pub fn from_config_state(state: &ConfigState) -> ConfigFile {
                 None
             } else {
                 Some(state.s2_api_key.clone())
+            },
+            crossref_mailto: if state.crossref_mailto.is_empty() {
+                None
+            } else {
+                Some(state.crossref_mailto.clone())
             },
         }),
         databases: Some(DatabasesConfig {

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -323,6 +323,12 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         );
     }
+    if app.config_state.crossref_mailto.is_empty() {
+        app.activity.log_warn(
+            "No CrossRef mailto set. Set your email in Config > API Keys for better rate limits."
+                .to_string(),
+        );
+    }
 
     // Initialize results persistence directory
     let run_dir = persistence::run_dir();

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/config.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/config.rs
@@ -40,6 +40,7 @@ pub struct ConfigState {
     // Editable fields
     pub openalex_key: String,
     pub s2_api_key: String,
+    pub crossref_mailto: String,
     pub disabled_dbs: Vec<(String, bool)>, // (name, enabled)
     pub dblp_offline_path: String,
     pub acl_offline_path: String,
@@ -76,6 +77,7 @@ impl Default for ConfigState {
             prev_screen: None,
             openalex_key: String::new(),
             s2_api_key: String::new(),
+            crossref_mailto: String::new(),
             disabled_dbs: all_dbs,
             dblp_offline_path: String::new(),
             acl_offline_path: String::new(),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
@@ -116,16 +116,21 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_api_keys(lines: &mut Vec<Line>, config: &ConfigState, theme: &Theme) {
-    let items = [
-        ("OpenAlex", &config.openalex_key),
-        ("Semantic Scholar", &config.s2_api_key),
+    let items: Vec<(&str, String)> = vec![
+        ("OpenAlex", ConfigState::mask_key(&config.openalex_key)),
+        ("Semantic Scholar", ConfigState::mask_key(&config.s2_api_key)),
+        ("CrossRef Mailto", if config.crossref_mailto.is_empty() {
+            "(not set)".to_string()
+        } else {
+            config.crossref_mailto.clone()
+        }),
     ];
-    for (i, (label, value)) in items.iter().enumerate() {
+    for (i, (label, display_default)) in items.iter().enumerate() {
         let cursor = if config.item_cursor == i { "> " } else { "  " };
         let display_val = if config.editing && config.item_cursor == i {
             format!("{}\u{2588}", config.edit_buffer)
         } else {
-            ConfigState::mask_key(value)
+            display_default.clone()
         };
         let val_style = if config.editing && config.item_cursor == i {
             Style::default().fg(theme.active)


### PR DESCRIPTION
## Summary
- Adds a configurable `crossref_mailto` field across core and TUI
- When set, appends `&mailto=` to CrossRef API URLs and sets a proper `User-Agent` header on all CrossRef requests (title queries + retraction checks)
- TUI warns on startup if no mailto is configured, and exposes the setting in Config > API Keys

Relates to #19

## Test plan
- [x] `cargo check` passes across all crates
- [x] TUI without `crossref_mailto` set shows warning in activity pane
- [x] Config screen API Keys section shows 3 items, CrossRef Mailto is editable and displays unmasked
- [x] Ctrl+S saves the value to config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)