### PR TITLE
Disable NeurIPS querying

### DIFF
--- a/hallucinator-rs/crates/hallucinator-cli/src/output.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/output.rs
@@ -191,9 +191,9 @@ fn print_not_found_block(
     }
 
     let dbs = if searched_openalex {
-        "Searched: OpenAlex, CrossRef, arXiv, DBLP, Semantic Scholar, ACL, NeurIPS, Europe PMC, PubMed"
+        "Searched: OpenAlex, CrossRef, arXiv, DBLP, Semantic Scholar, ACL, Europe PMC, PubMed"
     } else {
-        "Searched: CrossRef, arXiv, DBLP, Semantic Scholar, ACL, NeurIPS, Europe PMC, PubMed"
+        "Searched: CrossRef, arXiv, DBLP, Semantic Scholar, ACL, Europe PMC, PubMed"
     };
     if color.enabled() {
         writeln!(w, "{}", dbs.dimmed())?;

--- a/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
@@ -260,9 +260,11 @@ fn build_database_list(
             databases.push(Box::new(acl::AclAnthology));
         }
     }
-    if should_include("NeurIPS") {
-        databases.push(Box::new(neurips::NeurIPS));
-    }
+    // NeurIPS disabled: papers.nips.cc returns 404 and the HTML structure has changed.
+    // DBLP already indexes NeurIPS papers, so this source is redundant for now.
+    // if should_include("NeurIPS") {
+    //     databases.push(Box::new(neurips::NeurIPS));
+    // }
     if should_include("Europe PMC") {
         databases.push(Box::new(europe_pmc::EuropePmc));
     }

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/config.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/config.rs
@@ -62,7 +62,6 @@ impl Default for ConfigState {
             ("Semantic Scholar".to_string(), true),
             ("SSRN".to_string(), true),
             ("ACL Anthology".to_string(), true),
-            ("NeurIPS".to_string(), true),
             ("Europe PMC".to_string(), true),
             ("PubMed".to_string(), true),
             ("OpenAlex".to_string(), true),

--- a/hallucinator-rs/crates/hallucinator-tui/src/tips.txt
+++ b/hallucinator-rs/crates/hallucinator-tui/src/tips.txt
@@ -21,7 +21,7 @@ Pro-tip: Press o to add more PDFs to the queue without restarting
 
 # === How It Works ===
 Pro-tip: Each reference is checked against up to 11 databases simultaneously
-Pro-tip: Databases: CrossRef, arXiv, DBLP, Semantic Scholar, ACL, NeurIPS, PubMed, and more
+Pro-tip: Databases: CrossRef, arXiv, DBLP, Semantic Scholar, ACL, PubMed, and more
 Pro-tip: Title matching uses fuzzy comparison at 95% similarity (rapidfuzz)
 Pro-tip: Author verification catches cases where a title exists but authors don't match
 Pro-tip: Retraction checking queries CrossRef for retraction notices on found papers


### PR DESCRIPTION
## Summary
- Disabled NeurIPS database querying in hallucinator-rs — `papers.nips.cc` returns 404 and the HTML structure (`li.author` selector) no longer exists
- DBLP already indexes NeurIPS papers, so this source is redundant
- Commented out rather than deleted so it can be revisited if the site comes back
- Removed NeurIPS from CLI output strings, TUI config toggles, and tips

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` passes (2 pre-existing failures in `hallucinator-acl` XML parser are unrelated)
- [ ] Verify NeurIPS papers are still found via DBLP

🤖 Generated with [Claude Code](https://claude.com/claude-code)