### PR TITLE
Add .bbl file input support

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1087,6 +1087,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hallucinator-bbl"
+version = "0.1.0"
+dependencies = [
+ "hallucinator-pdf",
+ "once_cell",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "hallucinator-cli"
 version = "0.1.0"
 dependencies = [
@@ -1094,6 +1104,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "hallucinator-acl",
+ "hallucinator-bbl",
  "hallucinator-core",
  "hallucinator-dblp",
  "hallucinator-pdf",
@@ -1167,6 +1178,7 @@ dependencies = [
  "dirs",
  "dotenvy",
  "hallucinator-acl",
+ "hallucinator-bbl",
  "hallucinator-core",
  "hallucinator-dblp",
  "hallucinator-pdf",

--- a/hallucinator-rs/Cargo.toml
+++ b/hallucinator-rs/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/hallucinator-pdf",
+    "crates/hallucinator-bbl",
     "crates/hallucinator-core",
     "crates/hallucinator-dblp",
     "crates/hallucinator-acl",
@@ -17,7 +18,8 @@ license = "AGPL-3.0-or-later"
 
 [workspace.dependencies]
 # Internal crates
-hallucinator-pdf = { path = "crates/hallucinator-pdf" }
+hallucinator-pdf = { path = "crates/hallucinator-pdf", default-features = false }
+hallucinator-bbl = { path = "crates/hallucinator-bbl" }
 hallucinator-core = { path = "crates/hallucinator-core" }
 hallucinator-dblp = { path = "crates/hallucinator-dblp" }
 hallucinator-acl = { path = "crates/hallucinator-acl" }

--- a/hallucinator-rs/crates/hallucinator-bbl/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-bbl/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hallucinator-bbl"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "BibTeX .bbl file parser for hallucinated reference detection"
+
+[dependencies]
+hallucinator-pdf.workspace = true
+regex.workspace = true
+once_cell.workspace = true
+thiserror.workspace = true

--- a/hallucinator-rs/crates/hallucinator-bbl/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-bbl/src/lib.rs
@@ -1,0 +1,572 @@
+use std::path::Path;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use thiserror::Error;
+
+use hallucinator_pdf::{ExtractionResult, Reference, SkipStats};
+
+#[derive(Error, Debug)]
+pub enum BblError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("no \\bibitem entries found")]
+    NoBibItems,
+}
+
+/// Extract references from a .bbl file (BibTeX-generated bibliography).
+///
+/// Parses `\bibitem` entries and extracts structured fields from
+/// `\bibinfo{field}{value}` markup (ACM-Reference-Format style).
+pub fn extract_references_from_bbl(path: &Path) -> Result<ExtractionResult, BblError> {
+    let content = std::fs::read_to_string(path)?;
+    extract_references_from_bbl_str(&content)
+}
+
+/// Parse .bbl content from a string (useful for testing).
+pub fn extract_references_from_bbl_str(content: &str) -> Result<ExtractionResult, BblError> {
+    let entries = segment_bibitem_entries(content);
+
+    if entries.is_empty() {
+        return Err(BblError::NoBibItems);
+    }
+
+    let mut stats = SkipStats {
+        total_raw: entries.len(),
+        ..Default::default()
+    };
+
+    let mut references = Vec::new();
+
+    for entry in &entries {
+        // Extract title
+        let title = extract_title(entry).map(|t| strip_latex(&t));
+
+        // Skip entries without a title or with very short titles
+        let title = match title {
+            Some(t) if !t.is_empty() && t.split_whitespace().count() >= 4 => t,
+            Some(t) if t.is_empty() => {
+                stats.no_title += 1;
+                continue;
+            }
+            Some(_) => {
+                stats.short_title += 1;
+                continue;
+            }
+            None => {
+                stats.no_title += 1;
+                continue;
+            }
+        };
+
+        // Extract authors
+        let authors: Vec<String> = extract_authors(entry)
+            .into_iter()
+            .map(|a| strip_latex(&a))
+            .collect();
+
+        if authors.is_empty() {
+            stats.no_authors += 1;
+            // Still include (tracked only)
+        }
+
+        // Skip URL-only entries (non-academic URLs without a real title)
+        if is_url_only_entry(entry) {
+            stats.url_only += 1;
+            continue;
+        }
+
+        // Extract identifiers
+        let doi = extract_doi_from_bbl(entry);
+        let arxiv_id = hallucinator_pdf::identifiers::extract_arxiv_id(entry);
+
+        // Build raw citation for display (collapse whitespace)
+        static WS_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
+        let raw_citation = WS_RE.replace_all(entry.trim(), " ").to_string();
+
+        references.push(Reference {
+            raw_citation,
+            title: Some(title),
+            authors,
+            doi,
+            arxiv_id,
+        });
+    }
+
+    Ok(ExtractionResult {
+        references,
+        skip_stats: stats,
+    })
+}
+
+/// Segment .bbl content into individual `\bibitem` entries.
+fn segment_bibitem_entries(content: &str) -> Vec<String> {
+    static BIBITEM_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?m)^\\bibitem").unwrap());
+
+    let matches: Vec<_> = BIBITEM_RE.find_iter(content).collect();
+
+    if matches.is_empty() {
+        return vec![];
+    }
+
+    let mut entries = Vec::with_capacity(matches.len());
+    for i in 0..matches.len() {
+        let start = matches[i].start();
+        let end = if i + 1 < matches.len() {
+            matches[i + 1].start()
+        } else {
+            // Find \end{thebibliography} or use end of content
+            content[start..]
+                .find("\\end{thebibliography}")
+                .map(|pos| start + pos)
+                .unwrap_or(content.len())
+        };
+        let entry = content[start..end].trim().to_string();
+        if !entry.is_empty() {
+            entries.push(entry);
+        }
+    }
+
+    entries
+}
+
+/// Extract title from a bibitem entry.
+///
+/// Tries in order:
+/// 1. `\showarticletitle{...}` — article titles
+/// 2. `\bibinfo{title}{...}` — misc/informal titles
+/// 3. `\bibinfo{booktitle}{...}` — book titles
+fn extract_title(entry: &str) -> Option<String> {
+    // 1. \showarticletitle{...}
+    if let Some(t) = extract_braced_arg(entry, "\\showarticletitle") {
+        if !t.is_empty() {
+            return Some(t);
+        }
+    }
+
+    // 2. \bibinfo{title}{...}
+    if let Some(t) = extract_bibinfo(entry, "title") {
+        if !t.is_empty() {
+            return Some(t);
+        }
+    }
+
+    // 3. \bibinfo{booktitle}{...}
+    if let Some(t) = extract_bibinfo(entry, "booktitle") {
+        if !t.is_empty() {
+            return Some(t);
+        }
+    }
+
+    None
+}
+
+/// Extract authors from `\bibinfo{person}{Name}` patterns.
+fn extract_authors(entry: &str) -> Vec<String> {
+    static PERSON_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\\bibinfo\s*\{person\}\s*\{").unwrap());
+
+    let mut authors = Vec::new();
+
+    for m in PERSON_RE.find_iter(entry) {
+        let after = &entry[m.end()..];
+        if let Some(name) = extract_balanced_braces(after) {
+            let name = name.trim().to_string();
+            if !name.is_empty() {
+                authors.push(name);
+            }
+        }
+    }
+
+    authors
+}
+
+/// Extract DOI from `\showDOI{...}` or raw DOI patterns.
+fn extract_doi_from_bbl(entry: &str) -> Option<String> {
+    // Try \showDOI{...} first
+    if let Some(doi_text) = extract_braced_arg(entry, "\\showDOI") {
+        // The content might be a URL like https://doi.org/10.xxx or just the DOI
+        return hallucinator_pdf::identifiers::extract_doi(&doi_text);
+    }
+
+    // Fall back to raw DOI pattern in the text
+    hallucinator_pdf::identifiers::extract_doi(entry)
+}
+
+/// Check if an entry is URL-only (has a URL but the "title" is just a URL or news headline).
+fn is_url_only_entry(entry: &str) -> bool {
+    static URL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\\url\s*\{").unwrap());
+    static HOWPUB_URL_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\\bibinfo\s*\{howpublished\}\s*\{\\url").unwrap());
+
+    // If the entry's main content is just a howpublished URL with no article title, skip
+    let has_article_title = entry.contains("\\showarticletitle");
+    let has_bibinfo_title = {
+        static TITLE_RE: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"\\bibinfo\s*\{title\}").unwrap());
+        TITLE_RE.is_match(entry)
+    };
+    let has_url = URL_RE.is_match(entry);
+    let is_howpub_url = HOWPUB_URL_RE.is_match(entry);
+
+    // URL-only: has a URL, no article title, and either the "title" is just in howpublished or absent
+    if has_url && !has_article_title && !has_bibinfo_title {
+        return true;
+    }
+
+    // Entries where the howpublished is just a URL and there's no real title
+    if is_howpub_url && !has_article_title && !has_bibinfo_title {
+        return true;
+    }
+
+    false
+}
+
+/// Extract the argument of a LaTeX command like `\command{argument}`,
+/// handling nested braces.
+fn extract_braced_arg(text: &str, command: &str) -> Option<String> {
+    let pos = text.find(command)?;
+    let after_cmd = &text[pos + command.len()..];
+
+    // Skip whitespace to find opening brace
+    let after_cmd = after_cmd.trim_start();
+    if !after_cmd.starts_with('{') {
+        return None;
+    }
+
+    extract_balanced_braces(&after_cmd[1..])
+}
+
+/// Extract text up to the matching closing brace, handling nesting.
+/// Input should start AFTER the opening `{`.
+fn extract_balanced_braces(text: &str) -> Option<String> {
+    let mut depth = 1;
+    let mut end = 0;
+
+    for (i, ch) in text.char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = i;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if depth == 0 {
+        Some(text[..end].to_string())
+    } else {
+        None
+    }
+}
+
+/// Extract `\bibinfo{field}{value}` where field matches the given name.
+fn extract_bibinfo(entry: &str, field: &str) -> Option<String> {
+    let pattern = format!("\\bibinfo{{{}}}", field);
+    let pos = entry.find(&pattern)?;
+    let after = &entry[pos + pattern.len()..];
+    let after = after.trim_start();
+
+    if !after.starts_with('{') {
+        return None;
+    }
+
+    extract_balanced_braces(&after[1..])
+}
+
+/// Strip common LaTeX markup from extracted text.
+fn strip_latex(text: &str) -> String {
+    let mut result = text.to_string();
+
+    // \emph{X} → X
+    static EMPH_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\\emph\s*\{([^}]*)\}").unwrap());
+    result = EMPH_RE.replace_all(&result, "$1").to_string();
+
+    // \textbf{X} → X
+    static TEXTBF_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\\textbf\s*\{([^}]*)\}").unwrap());
+    result = TEXTBF_RE.replace_all(&result, "$1").to_string();
+
+    // \textit{X} → X
+    static TEXTIT_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\\textit\s*\{([^}]*)\}").unwrap());
+    result = TEXTIT_RE.replace_all(&result, "$1").to_string();
+
+    // \url{X} → X
+    static URL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\\url\s*\{([^}]*)\}").unwrap());
+    result = URL_RE.replace_all(&result, "$1").to_string();
+
+    // Common LaTeX accents: {\'e} → é, etc.
+    result = expand_latex_accents(&result);
+
+    // \& → &
+    result = result.replace("\\&", "&");
+
+    // \_ → _
+    result = result.replace("\\_", "_");
+
+    // \# → #
+    result = result.replace("\\#", "#");
+
+    // \~ → ~ (non-breaking space, but in text just use space)
+    static TILDE_SPACE: Lazy<Regex> = Lazy::new(|| Regex::new(r"~").unwrap());
+    result = TILDE_SPACE.replace_all(&result, " ").to_string();
+
+    // Remove remaining stray braces
+    result = result.replace('{', "").replace('}', "");
+
+    // Collapse whitespace
+    static WS_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
+    result = WS_RE.replace_all(&result, " ").to_string();
+
+    result.trim().to_string()
+}
+
+/// Expand common LaTeX accent commands to Unicode characters.
+fn expand_latex_accents(text: &str) -> String {
+    let mut result = text.to_string();
+
+    // Braced forms: {\'e}, {\`a}, {\"o}, {\^i}, {\~n}, {\c{c}}, etc.
+    static ACCENT_BRACED: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r#"\{\\(['"`^~])\{?([a-zA-Z])\}?\}"#).unwrap());
+    result = ACCENT_BRACED
+        .replace_all(&result, |caps: &regex::Captures| {
+            let accent = &caps[1];
+            let letter = &caps[2];
+            apply_accent(accent, letter)
+        })
+        .to_string();
+
+    // Unbraced forms: \'e, \"o, etc.
+    static ACCENT_UNBRACED: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r#"\\(['"`^~])([a-zA-Z])"#).unwrap());
+    result = ACCENT_UNBRACED
+        .replace_all(&result, |caps: &regex::Captures| {
+            let accent = &caps[1];
+            let letter = &caps[2];
+            apply_accent(accent, letter)
+        })
+        .to_string();
+
+    result
+}
+
+fn apply_accent(accent: &str, letter: &str) -> String {
+    match (accent, letter) {
+        ("'", "e") => "é".to_string(),
+        ("'", "E") => "É".to_string(),
+        ("'", "a") => "á".to_string(),
+        ("'", "A") => "Á".to_string(),
+        ("'", "i") => "í".to_string(),
+        ("'", "I") => "Í".to_string(),
+        ("'", "o") => "ó".to_string(),
+        ("'", "O") => "Ó".to_string(),
+        ("'", "u") => "ú".to_string(),
+        ("'", "U") => "Ú".to_string(),
+        ("`", "e") => "è".to_string(),
+        ("`", "E") => "È".to_string(),
+        ("`", "a") => "à".to_string(),
+        ("`", "A") => "À".to_string(),
+        ("`", "i") => "ì".to_string(),
+        ("`", "o") => "ò".to_string(),
+        ("`", "u") => "ù".to_string(),
+        ("\"", "o") => "ö".to_string(),
+        ("\"", "O") => "Ö".to_string(),
+        ("\"", "u") => "ü".to_string(),
+        ("\"", "U") => "Ü".to_string(),
+        ("\"", "a") => "ä".to_string(),
+        ("\"", "A") => "Ä".to_string(),
+        ("^", "e") => "ê".to_string(),
+        ("^", "E") => "Ê".to_string(),
+        ("^", "a") => "â".to_string(),
+        ("^", "o") => "ô".to_string(),
+        ("^", "i") => "î".to_string(),
+        ("~", "n") => "ñ".to_string(),
+        ("~", "N") => "Ñ".to_string(),
+        ("~", "a") => "ã".to_string(),
+        ("~", "o") => "õ".to_string(),
+        _ => format!("{}", letter), // Unknown accent, just return the letter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_segment_bibitem_entries() {
+        let content = r#"
+\begin{thebibliography}{10}
+
+\bibitem[Author1(2020)]{key1}
+First entry content.
+
+\bibitem[Author2(2021)]{key2}
+Second entry content.
+
+\end{thebibliography}
+"#;
+        let entries = segment_bibitem_entries(content);
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].contains("First entry"));
+        assert!(entries[1].contains("Second entry"));
+    }
+
+    #[test]
+    fn test_extract_authors() {
+        let entry = r#"\bibfield{author}{\bibinfo{person}{Pantelis Agathangelou},
+  \bibinfo{person}{Ioannis Katakis}, {and} \bibinfo{person}{Barry Richards}.}"#;
+        let authors = extract_authors(entry);
+        assert_eq!(authors.len(), 3);
+        assert_eq!(authors[0], "Pantelis Agathangelou");
+        assert_eq!(authors[1], "Ioannis Katakis");
+        assert_eq!(authors[2], "Barry Richards");
+    }
+
+    #[test]
+    fn test_extract_title_showarticletitle() {
+        let entry = r#"\newblock \showarticletitle{Understanding online political networks: The case
+  of the far-right and far-left in Greece}."#;
+        let title = extract_title(entry).unwrap();
+        assert!(title.contains("Understanding online political networks"));
+    }
+
+    #[test]
+    fn test_extract_title_bibinfo_title() {
+        let entry = r#"\newblock \bibinfo{title}{Spacy}.
+\newblock \bibinfo{howpublished}{\url{https://spacy.io/}}."#;
+        let title = extract_title(entry).unwrap();
+        assert_eq!(title, "Spacy");
+    }
+
+    #[test]
+    fn test_extract_title_bibinfo_booktitle() {
+        let entry = r#"\newblock \bibinfo{booktitle}{\emph{The Khrushchev Era: De-Stalinization and
+  the Limits of Reform in the USSR 1953-64}}."#;
+        let title = extract_title(entry).unwrap();
+        assert!(title.contains("Khrushchev Era"));
+    }
+
+    #[test]
+    fn test_strip_latex_emph() {
+        assert_eq!(strip_latex("\\emph{Journal Name}"), "Journal Name");
+    }
+
+    #[test]
+    fn test_strip_latex_accents() {
+        assert_eq!(strip_latex("Ren{\\'e}e DiResta"), "Renée DiResta");
+        assert_eq!(strip_latex("Fiskesj{\\\"o}"), "Fiskesjö");
+    }
+
+    #[test]
+    fn test_strip_latex_ampersand() {
+        assert_eq!(strip_latex("IEEE Security \\& Privacy"), "IEEE Security & Privacy");
+    }
+
+    #[test]
+    fn test_strip_latex_braces() {
+        assert_eq!(strip_latex("{Perspective API}"), "Perspective API");
+    }
+
+    #[test]
+    fn test_extract_balanced_braces() {
+        assert_eq!(
+            extract_balanced_braces("hello {world}}"),
+            Some("hello {world}".to_string())
+        );
+        assert_eq!(
+            extract_balanced_braces("simple}"),
+            Some("simple".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_doi_show_doi() {
+        let entry = r#"\showDOI{https://doi.org/10.1145/3442381.3450048}"#;
+        let doi = extract_doi_from_bbl(entry);
+        assert_eq!(doi, Some("10.1145/3442381.3450048".to_string()));
+    }
+
+    #[test]
+    fn test_integration_sample_file() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("test-data")
+            .join("no_comments.bbl");
+
+        if !path.exists() {
+            // Skip if test file not available
+            return;
+        }
+
+        let result = extract_references_from_bbl(&path).unwrap();
+
+        // The file has 122 bibitem entries; some will be skipped (URL-only, short titles)
+        assert!(
+            result.skip_stats.total_raw >= 100,
+            "Expected 100+ raw entries, got {}",
+            result.skip_stats.total_raw
+        );
+        assert!(
+            !result.references.is_empty(),
+            "Should have extracted some references"
+        );
+
+        // Spot-check: "Beyond Fish and Bicycles" entry
+        let fish = result
+            .references
+            .iter()
+            .find(|r| {
+                r.title
+                    .as_ref()
+                    .map(|t| t.contains("Beyond Fish and Bicycles"))
+                    .unwrap_or(false)
+            })
+            .expect("Should find 'Beyond Fish and Bicycles' entry");
+
+        assert!(
+            fish.title
+                .as_ref()
+                .unwrap()
+                .contains("Exploring the Varieties of Online Women"),
+            "Title should contain full text: {:?}",
+            fish.title
+        );
+
+        // Check authors
+        assert!(
+            fish.authors.iter().any(|a| a.contains("Balci")),
+            "Should have Balci as author: {:?}",
+            fish.authors
+        );
+        assert!(
+            fish.authors.iter().any(|a| a.contains("Blackburn")),
+            "Should have Blackburn as author: {:?}",
+            fish.authors
+        );
+
+        // Spot-check: entry with LaTeX accents
+        let mamie = result
+            .references
+            .iter()
+            .find(|r| {
+                r.authors
+                    .iter()
+                    .any(|a| a.contains("Mamié") || a.contains("Mamie"))
+            });
+        if let Some(mamie_ref) = mamie {
+            assert!(
+                mamie_ref.title.as_ref().unwrap().contains("Anti-Feminist"),
+                "Mamié entry should have correct title"
+            );
+        }
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-cli/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-cli/Cargo.toml
@@ -7,7 +7,8 @@ description = "CLI binary for hallucinated reference detection"
 
 [dependencies]
 hallucinator-core.workspace = true
-hallucinator-pdf.workspace = true
+hallucinator-pdf = { workspace = true, features = ["pdf"] }
+hallucinator-bbl.workspace = true
 hallucinator-dblp.workspace = true
 hallucinator-acl.workspace = true
 tokio.workspace = true

--- a/hallucinator-rs/crates/hallucinator-core/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-core/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "Validation engine and database query backends for hallucinated reference detection"
 
 [dependencies]
-hallucinator-pdf.workspace = true
+hallucinator-pdf = { workspace = true, features = ["pdf"] }
 hallucinator-dblp.workspace = true
 hallucinator-acl.workspace = true
 tokio.workspace = true

--- a/hallucinator-rs/crates/hallucinator-pdf/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-pdf/Cargo.toml
@@ -5,11 +5,15 @@ edition.workspace = true
 license.workspace = true
 description = "PDF extraction and reference parsing for hallucinated reference detection"
 
+[features]
+default = ["pdf"]
+pdf = ["dep:mupdf", "dep:zip", "dep:tar", "dep:flate2"]
+
 [dependencies]
-mupdf.workspace = true
+mupdf = { workspace = true, optional = true }
 regex.workspace = true
 once_cell.workspace = true
 thiserror.workspace = true
-zip.workspace = true
-tar.workspace = true
-flate2.workspace = true
+zip = { workspace = true, optional = true }
+tar = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }

--- a/hallucinator-rs/crates/hallucinator-pdf/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf/src/lib.rs
@@ -1,11 +1,16 @@
+#[cfg(feature = "pdf")]
 use std::path::Path;
 
+#[cfg(feature = "pdf")]
 use once_cell::sync::Lazy;
+#[cfg(feature = "pdf")]
 use regex::Regex;
 use thiserror::Error;
 
+#[cfg(feature = "pdf")]
 pub mod archive;
 pub mod authors;
+#[cfg(feature = "pdf")]
 pub mod extract;
 pub mod identifiers;
 pub mod section;
@@ -60,6 +65,7 @@ pub struct ExtractionResult {
 /// 4. For each reference, extract DOI, arXiv ID, title, and authors
 /// 5. Handle em-dash "same authors" convention
 /// 6. Skip non-academic URL-only refs and short/missing titles
+#[cfg(feature = "pdf")]
 pub fn extract_references(pdf_path: &Path) -> Result<ExtractionResult, PdfError> {
     let text = extract::extract_text_from_pdf(pdf_path)?;
 

--- a/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
@@ -11,7 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 hallucinator-core.workspace = true
-hallucinator-pdf.workspace = true
+hallucinator-pdf = { workspace = true, features = ["pdf"] }
+hallucinator-bbl.workspace = true
 hallucinator-dblp.workspace = true
 hallucinator-acl.workspace = true
 tokio.workspace = true

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -36,8 +36,8 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 
-    /// PDF files to check
-    pdf_paths: Vec<PathBuf>,
+    /// PDF or .bbl files to check
+    file_paths: Vec<PathBuf>,
 
     /// OpenAlex API key
     #[arg(long)]
@@ -111,10 +111,10 @@ async fn main() -> anyhow::Result<()> {
 
     // --- TUI mode (default, no subcommand) ---
 
-    // Validate any PDF paths provided on the command line
-    for path in &cli.pdf_paths {
+    // Validate any file paths provided on the command line
+    for path in &cli.file_paths {
         if !path.exists() {
-            anyhow::bail!("PDF file not found: {}", path.display());
+            anyhow::bail!("File not found: {}", path.display());
         }
     }
 
@@ -252,7 +252,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Build filenames for display
     let filenames: Vec<String> = cli
-        .pdf_paths
+        .file_paths
         .iter()
         .map(|p| {
             p.file_name()
@@ -293,8 +293,8 @@ async fn main() -> anyhow::Result<()> {
 
     let mut app = App::new(filenames, theme);
 
-    // Store PDF paths for deferred processing
-    app.pdf_paths = cli.pdf_paths.clone();
+    // Store file paths for deferred processing
+    app.file_paths = cli.file_paths.clone();
 
     // Apply the fully-resolved config state
     app.config_state = config_state;
@@ -334,7 +334,7 @@ async fn main() -> anyhow::Result<()> {
     let run_dir = persistence::run_dir();
 
     // Single-paper mode: if exactly one PDF, skip the queue and go directly to paper view
-    if cli.pdf_paths.len() == 1 {
+    if cli.file_paths.len() == 1 {
         app.screen = Screen::Paper(0);
         app.single_paper_mode = true;
     }

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
@@ -31,7 +31,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
     let header = Line::from(vec![
         Span::styled(" HALLUCINATOR ", theme.header_style()),
         Span::styled(
-            " > Select PDFs / Archives",
+            " > Select PDFs / .bbl / Archives",
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
         ),
     ]);
@@ -61,7 +61,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
         .map(|entry| {
             let (icon, style) = if entry.is_dir {
                 ("\u{1F4C1} ", Style::default().fg(theme.active))
-            } else if entry.is_pdf || entry.is_archive {
+            } else if entry.is_pdf || entry.is_bbl || entry.is_archive {
                 let selected = picker.is_selected(&entry.path);
                 if selected {
                     (
@@ -109,7 +109,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(theme.dim),
             )),
             Line::from(Span::styled(
-                "  Navigate to PDFs or archives and press Space to select",
+                "  Navigate to PDFs, .bbl files, or archives and press Space to select",
                 Style::default().fg(theme.dim),
             )),
         ]

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
@@ -319,7 +319,7 @@ fn render_footer(f: &mut Frame, area: Rect, app: &App) {
     ];
 
     // Show [Space] Start/Stop indicator
-    if !app.processing_started && !app.pdf_paths.is_empty() {
+    if !app.processing_started && !app.file_paths.is_empty() {
         spans.push(Span::styled(
             " [Space] Start ",
             Style::default()

--- a/hallucinator-rs/crates/hallucinator-web/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-web/Cargo.toml
@@ -7,7 +7,7 @@ description = "Axum web server with SSE streaming for hallucinated reference det
 
 [dependencies]
 hallucinator-core.workspace = true
-hallucinator-pdf.workspace = true
+hallucinator-pdf = { workspace = true, features = ["pdf"] }
 hallucinator-dblp.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true


### PR DESCRIPTION
## Summary

Closes #43.

- **New `hallucinator-bbl` crate** — parses `.bbl` files (BibTeX-generated bibliographies) into the same `Reference`/`ExtractionResult` types used by the PDF pipeline. Extracts authors, titles, DOIs, and arXiv IDs from `\bibinfo` markup, strips LaTeX commands and accents, and applies the same skip logic (short titles, URL-only entries). Depends on `hallucinator-pdf` with `default-features = false` so it doesn't pull in mupdf.
- **Feature-gated mupdf in `hallucinator-pdf`** — `mupdf`, `zip`, `tar`, `flate2` are now optional behind a `pdf` feature (default on), allowing `hallucinator-bbl` to reuse shared types without the heavy native dependency.
- **CLI** — `hallucinator-cli check` and `check --dry-run` now accept `.bbl` files, dispatching on file extension.
- **TUI** — file picker shows `.bbl` files as selectable, backend dispatches on extension for extraction. Renamed `pdf_paths` → `file_paths` throughout.

## Test plan

- [x] `cargo test --package hallucinator-bbl` — 12 tests pass (segmentation, author/title extraction, LaTeX stripping, integration test on `test-data/no_comments.bbl`)
- [x] `cargo test --package hallucinator-pdf` — 47 existing tests still pass
- [x] `cargo test --package hallucinator-core` — 17 existing tests still pass
- [x] `cargo check` — full workspace compiles cleanly
- [x] `hallucinator-cli check --dry-run test-data/no_comments.bbl` — 122 entries parsed, 115 kept after filtering, correct titles/authors/arXiv IDs
- [x] `hallucinator-cli check --dry-run test-data/acm_example.pdf` — PDF dry-run still works unchanged
- [ ] Spot-check: "Beyond Fish and Bicycles" entry has full title + authors (Balci, Ling, De Cristofaro, Squire, Stringhini, Blackburn)
- [ ] TUI: select a `.bbl` file in the file picker and run validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)