### PR TITLE
Implement manual retry in TUI (closes #53)

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "hallucinator-pdf",
  "indicatif",
  "ratatui",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/hallucinator-rs/crates/hallucinator-core/src/checker.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/checker.rs
@@ -199,7 +199,7 @@ pub async fn check_references(
 }
 
 /// Check a single reference against all databases.
-async fn check_single_reference(
+pub async fn check_single_reference(
     reference: &Reference,
     config: &Config,
     client: &reqwest::Client,
@@ -342,7 +342,7 @@ async fn check_single_reference(
 }
 
 /// Retry a reference check targeting only the previously failed databases.
-async fn check_single_reference_retry(
+pub async fn check_single_reference_retry(
     reference: &Reference,
     config: &Config,
     client: &reqwest::Client,

--- a/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
@@ -15,6 +15,7 @@ hallucinator-pdf = { workspace = true, features = ["pdf"] }
 hallucinator-bbl.workspace = true
 hallucinator-dblp.workspace = true
 hallucinator-acl.workspace = true
+reqwest.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 clap.workspace = true

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -408,6 +408,23 @@ async fn main() -> anyhow::Result<()> {
                         .await;
                     });
                 }
+                tui_event::BackendCommand::RetryReferences {
+                    paper_index,
+                    refs_to_retry,
+                    mut config,
+                } => {
+                    // Inject cached DB handles
+                    config.dblp_offline_path = cached_dblp_path.clone();
+                    config.dblp_offline_db = cached_dblp_db.clone();
+                    config.acl_offline_path = cached_acl_path.clone();
+                    config.acl_offline_db = cached_acl_db.clone();
+                    config.check_openalex_authors = check_openalex_authors;
+
+                    let tx = event_tx_for_backend.clone();
+                    tokio::spawn(async move {
+                        backend::retry_references(paper_index, refs_to_retry, *config, tx).await;
+                    });
+                }
                 tui_event::BackendCommand::CancelProcessing => {
                     batch_cancel.cancel();
                 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/tui_event.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/tui_event.rs
@@ -12,6 +12,14 @@ pub enum BackendCommand {
         max_concurrent_papers: usize,
         config: Box<hallucinator_core::Config>,
     },
+    /// Retry specific references for a paper.
+    /// Each tuple is (ref_index, Reference, failed_dbs). If failed_dbs is empty,
+    /// the reference is re-checked against all databases.
+    RetryReferences {
+        paper_index: usize,
+        refs_to_retry: Vec<(usize, Reference, Vec<String>)>,
+        config: Box<hallucinator_core::Config>,
+    },
     /// Cancel the current batch.
     CancelProcessing,
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
@@ -270,7 +270,7 @@ fn render_footer(
     }
 
     spans.push(Span::styled(
-        " | j/k:nav  Space:safe  Enter:detail  s:sort  f:filter  /:search  Esc:back",
+        " | j/k:nav  Space:safe  Enter:detail  Ctrl+r:retry  R:retry all  s:sort  f:filter  /:search  Esc:back",
         theme.footer_style(),
     ));
 


### PR DESCRIPTION
## Summary
- Wire up `Ctrl+r` (retry single ref) and `R` (retry all not-found refs) which were previously stubs in the TUI
- Retries target only previously failed databases with longer timeouts, or do a full re-check when no failed DBs are recorded
- Adds `RetryReferences` backend command, concurrent retry execution with semaphore, and progress event emission

## Changes
- **hallucinator-core/checker.rs** — Make `check_single_reference` and `check_single_reference_retry` public
- **hallucinator-tui/tui_event.rs** — Add `RetryReferences` variant to `BackendCommand`
- **hallucinator-tui/backend.rs** — Add `retry_references()` async function with concurrent execution
- **hallucinator-tui/main.rs** — Handle `RetryReferences` command with cached DB handle injection
- **hallucinator-tui/app.rs** — Implement `handle_retry_single()` and `handle_retry_all()` replacing stub
- **hallucinator-tui/view/paper.rs** — Add `Ctrl+r:retry  R:retry all` to footer hints

## Test plan
- [ ] `cargo clippy --workspace` — zero warnings
- [ ] `cargo fmt --all --check` — passes
- [ ] Run a batch, find a ref with timed-out DBs, `Ctrl+r` on it — status should update
- [ ] `R` on paper screen — all not-found refs should retry
- [ ] `Ctrl+r` on a Verified ref — should log "Already verified"

🤖 Generated with [Claude Code](https://claude.com/claude-code)