### PR TITLE
Add --load flag and .json file picker for loading saved results in TUI

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/export.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/export.rs
@@ -91,7 +91,7 @@ fn json_str_array(v: &[String]) -> String {
     format!("[{}]", items.join(", "))
 }
 
-fn export_json(papers: &[&PaperState]) -> String {
+pub fn export_json(papers: &[&PaperState]) -> String {
     let mut out = String::from("[\n");
     for (pi, paper) in papers.iter().enumerate() {
         let s = &paper.stats;

--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -1,0 +1,288 @@
+use std::path::Path;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use hallucinator_core::{
+    ArxivInfo, DbResult, DbStatus, DoiInfo, Reference, RetractionInfo, Status, ValidationResult,
+};
+
+use crate::model::paper::{RefPhase, RefState};
+use crate::model::queue::{PaperPhase, PaperState, PaperVerdict};
+
+// ---------------------------------------------------------------------------
+// Deserialization structs — mirrors export.rs JSON schema.
+// All non-essential fields are Option so we gracefully handle both the rich
+// export format and the simplified persistence format.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct LoadedFile {
+    filename: String,
+    verdict: Option<String>,
+    stats: Option<LoadedStats>,
+    references: Vec<LoadedRef>,
+}
+
+#[derive(Deserialize)]
+struct LoadedStats {
+    total: Option<usize>,
+    skipped: Option<usize>,
+    // remaining fields are recomputed from results
+}
+
+#[derive(Deserialize)]
+struct LoadedRef {
+    index: usize,
+    title: Option<String>,
+    raw_citation: Option<String>,
+    status: String,
+    source: Option<String>,
+    ref_authors: Option<Vec<String>>,
+    found_authors: Option<Vec<String>>,
+    paper_url: Option<String>,
+    failed_dbs: Option<Vec<String>>,
+    /// Simplified persistence format field (rich format uses retraction_info).
+    retracted: Option<bool>,
+    doi_info: Option<LoadedDoiInfo>,
+    arxiv_info: Option<LoadedArxivInfo>,
+    retraction_info: Option<LoadedRetractionInfo>,
+    db_results: Option<Vec<LoadedDbResult>>,
+}
+
+#[derive(Deserialize)]
+struct LoadedDoiInfo {
+    doi: String,
+    valid: bool,
+    title: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LoadedArxivInfo {
+    arxiv_id: String,
+    valid: bool,
+    title: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LoadedRetractionInfo {
+    is_retracted: bool,
+    retraction_doi: Option<String>,
+    retraction_source: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LoadedDbResult {
+    db: String,
+    status: String,
+    elapsed_ms: Option<u64>,
+    authors: Option<Vec<String>>,
+    url: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+fn parse_status(s: &str) -> Option<Status> {
+    match s {
+        "verified" => Some(Status::Verified),
+        "not_found" => Some(Status::NotFound),
+        "author_mismatch" => Some(Status::AuthorMismatch),
+        _ => None, // "pending" or unknown
+    }
+}
+
+fn parse_verdict(s: &str) -> Option<PaperVerdict> {
+    match s {
+        "safe" | "SAFE" => Some(PaperVerdict::Safe),
+        "questionable" | "?!" => Some(PaperVerdict::Questionable),
+        _ => None,
+    }
+}
+
+fn convert_db_status(s: &str) -> DbStatus {
+    match s {
+        "match" => DbStatus::Match,
+        "no_match" => DbStatus::NoMatch,
+        "author_mismatch" => DbStatus::AuthorMismatch,
+        "timeout" => DbStatus::Timeout,
+        "error" => DbStatus::Error,
+        "skipped" => DbStatus::Skipped,
+        _ => DbStatus::Error,
+    }
+}
+
+fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>, Vec<Reference>) {
+    let ref_count = loaded.references.len();
+    let mut paper = PaperState::new(loaded.filename);
+    paper.phase = PaperPhase::Complete;
+    paper.total_refs = ref_count;
+    paper.init_results(ref_count);
+    paper.verdict = loaded.verdict.as_deref().and_then(parse_verdict);
+
+    let mut ref_states = Vec::with_capacity(ref_count);
+    let mut references = Vec::with_capacity(ref_count);
+
+    for loaded_ref in &loaded.references {
+        let title = loaded_ref.title.clone().unwrap_or_default();
+
+        // Parse status — skip pending/unknown entries (no result to reconstruct)
+        let status = match parse_status(&loaded_ref.status) {
+            Some(s) => s,
+            None => {
+                ref_states.push(RefState {
+                    index: loaded_ref.index,
+                    title: title.clone(),
+                    phase: RefPhase::Done,
+                    result: None,
+                    marked_safe: false,
+                });
+                references.push(Reference {
+                    raw_citation: loaded_ref.raw_citation.clone().unwrap_or_default(),
+                    title: if title.is_empty() { None } else { Some(title) },
+                    authors: loaded_ref.ref_authors.clone().unwrap_or_default(),
+                    doi: loaded_ref.doi_info.as_ref().map(|d| d.doi.clone()),
+                    arxiv_id: loaded_ref.arxiv_info.as_ref().map(|a| a.arxiv_id.clone()),
+                });
+                continue;
+            }
+        };
+
+        // Build DOI info
+        let doi_info = loaded_ref.doi_info.as_ref().map(|d| DoiInfo {
+            doi: d.doi.clone(),
+            valid: d.valid,
+            title: d.title.clone(),
+        });
+
+        // Build arXiv info
+        let arxiv_info = loaded_ref.arxiv_info.as_ref().map(|a| ArxivInfo {
+            arxiv_id: a.arxiv_id.clone(),
+            valid: a.valid,
+            title: a.title.clone(),
+        });
+
+        // Build retraction info — prefer rich retraction_info, fall back to bool flag
+        let retraction_info = if let Some(ret) = &loaded_ref.retraction_info {
+            Some(RetractionInfo {
+                is_retracted: ret.is_retracted,
+                retraction_doi: ret.retraction_doi.clone(),
+                retraction_source: ret.retraction_source.clone(),
+            })
+        } else if loaded_ref.retracted == Some(true) {
+            Some(RetractionInfo {
+                is_retracted: true,
+                retraction_doi: None,
+                retraction_source: None,
+            })
+        } else {
+            None
+        };
+
+        // Build per-DB results
+        let db_results = loaded_ref
+            .db_results
+            .as_ref()
+            .map(|dbs| {
+                dbs.iter()
+                    .map(|db| DbResult {
+                        db_name: db.db.clone(),
+                        status: convert_db_status(&db.status),
+                        elapsed: db.elapsed_ms.map(Duration::from_millis),
+                        found_authors: db.authors.clone().unwrap_or_default(),
+                        paper_url: db.url.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Normalize source: empty string → None
+        let source = loaded_ref
+            .source
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned();
+
+        let result = ValidationResult {
+            title: title.clone(),
+            raw_citation: loaded_ref.raw_citation.clone().unwrap_or_default(),
+            ref_authors: loaded_ref.ref_authors.clone().unwrap_or_default(),
+            status,
+            source,
+            found_authors: loaded_ref.found_authors.clone().unwrap_or_default(),
+            paper_url: loaded_ref.paper_url.clone(),
+            failed_dbs: loaded_ref.failed_dbs.clone().unwrap_or_default(),
+            db_results,
+            doi_info: doi_info.clone(),
+            arxiv_info: arxiv_info.clone(),
+            retraction_info,
+        };
+
+        paper.record_result(loaded_ref.index, result.clone());
+
+        ref_states.push(RefState {
+            index: loaded_ref.index,
+            title: title.clone(),
+            phase: RefPhase::Done,
+            result: Some(result),
+            marked_safe: false,
+        });
+
+        references.push(Reference {
+            raw_citation: loaded_ref.raw_citation.clone().unwrap_or_default(),
+            title: if title.is_empty() { None } else { Some(title) },
+            authors: loaded_ref.ref_authors.clone().unwrap_or_default(),
+            doi: doi_info.map(|d| d.doi),
+            arxiv_id: arxiv_info.map(|a| a.arxiv_id),
+        });
+    }
+
+    // Set total and skipped from loaded stats if available
+    if let Some(stats) = &loaded.stats {
+        let total = stats.total.filter(|&t| t > 0).unwrap_or(ref_count);
+        paper.stats.total = total;
+        paper.total_refs = total;
+        paper.stats.skipped = stats.skipped.unwrap_or(0);
+    } else {
+        paper.stats.total = ref_count;
+        paper.total_refs = ref_count;
+    }
+
+    (paper, ref_states, references)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Load previously saved results from a JSON file.
+///
+/// Handles both formats:
+/// - **Export format**: JSON array of paper objects (from TUI export or `--load`)
+/// - **Persistence format**: Single JSON object (from auto-save in `~/.cache/hallucinator/runs/`)
+#[allow(clippy::type_complexity)]
+pub fn load_results_file(
+    path: &Path,
+) -> Result<Vec<(PaperState, Vec<RefState>, Vec<Reference>)>, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+
+    let loaded_files: Vec<LoadedFile> =
+        if let Ok(arr) = serde_json::from_str::<Vec<LoadedFile>>(&content) {
+            arr
+        } else if let Ok(single) = serde_json::from_str::<LoadedFile>(&content) {
+            vec![single]
+        } else {
+            return Err(
+                "Invalid JSON: expected export format (array) or persistence format (object)"
+                    .to_string(),
+            );
+        };
+
+    if loaded_files.is_empty() {
+        return Err("JSON file contains no papers".to_string());
+    }
+
+    Ok(loaded_files.into_iter().map(convert_loaded).collect())
+}

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
@@ -31,7 +31,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
     let header = Line::from(vec![
         Span::styled(" HALLUCINATOR ", theme.header_style()),
         Span::styled(
-            " > Select PDFs / .bbl / Archives",
+            " > Select PDFs / .bbl / Archives / Results (.json)",
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
         ),
     ]);
@@ -61,7 +61,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
         .map(|entry| {
             let (icon, style) = if entry.is_dir {
                 ("\u{1F4C1} ", Style::default().fg(theme.active))
-            } else if entry.is_pdf || entry.is_bbl || entry.is_archive {
+            } else if entry.is_pdf || entry.is_bbl || entry.is_archive || entry.is_json {
                 let selected = picker.is_selected(&entry.path);
                 if selected {
                     (
@@ -70,6 +70,8 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
                             .fg(theme.verified)
                             .add_modifier(Modifier::BOLD),
                     )
+                } else if entry.is_json {
+                    ("\u{1F4CA} ", Style::default().fg(theme.active))
                 } else if entry.is_archive {
                     ("\u{1F4E6} ", Style::default().fg(theme.active))
                 } else {
@@ -109,7 +111,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(theme.dim),
             )),
             Line::from(Span::styled(
-                "  Navigate to PDFs, .bbl files, or archives and press Space to select",
+                "  Navigate to PDFs, .bbl, archives, or .json results and press Space to select",
                 Style::default().fg(theme.dim),
             )),
         ]

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
@@ -9,7 +9,7 @@ use crate::theme::Theme;
 /// Render the help overlay as a centered popup.
 pub fn render(f: &mut Frame, theme: &Theme) {
     let area = f.area();
-    let popup = centered_rect(72, 39, area);
+    let popup = centered_rect(72, 43, area);
 
     let lines = vec![
         Line::from(Span::styled(
@@ -58,6 +58,10 @@ pub fn render(f: &mut Frame, theme: &Theme) {
         Line::from(""),
         section_header("Mouse", theme),
         key_line("Shift+click", "Select text / click links (terminal)", theme),
+        Line::from(""),
+        section_header("Loading Results", theme),
+        key_line("--load FILE", "Load saved results JSON at startup", theme),
+        key_line("File picker", "Select .json to load saved results", theme),
     ];
 
     let paragraph = Paragraph::new(lines)


### PR DESCRIPTION
## Summary
- Adds `--load <path>` CLI flag to load previously saved results JSON at startup, allowing review without re-running validation (closes #44)
- File picker now recognizes `.json` files (with chart icon) — selecting one loads its papers as already-complete entries
- Persistence upgraded from simplified format to rich export JSON, making auto-saved results in `~/.cache/hallucinator/runs/` loadable too
- New `load.rs` module handles both export format (array) and persistence format (single object) via `Option`-based graceful degradation
- Loaded papers fully support retry (`Reference` reconstructed from title, authors, DOI, arXiv fields)

## Test plan
- [ ] Export results JSON from TUI → `hallucinator-tui --load results.json` → papers show as Complete with all detail
- [ ] In file picker, select a `.json` file → papers load into queue as complete
- [ ] Load results, navigate to ref detail → db_results, doi_info, retraction_info all display correctly
- [ ] Load results, `Ctrl+r` on a not-found ref → retry works (full re-check)
- [ ] Auto-saved results in `~/.cache/hallucinator/runs/` are now in rich format and loadable
- [ ] `cargo clippy --workspace` — zero new warnings
- [ ] `cargo fmt --all --check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)