### PR TITLE
Add .bbl file support to archive extraction

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -635,7 +635,7 @@ impl App {
                 }
                 Ok(ArchiveItem::Done { total }) => {
                     self.activity.log(format!(
-                        "Extracted {} PDF{} from {}",
+                        "Extracted {} file{} from {}",
                         total,
                         if total == 1 { "" } else { "s" },
                         archive_name,


### PR DESCRIPTION
## Summary
- Archives (ZIP, tar.gz) now extract `.bbl` files alongside PDFs
- Previously `.bbl` files were silently skipped due to hardcoded `.pdf` extension check and `%PDF-` magic bytes validation
- Added `is_extractable()` and `passes_magic_check()` helpers — PDFs still get magic byte validation, `.bbl` files (plain text) skip it
- All six extraction paths updated (batch zip/tar.gz, streaming zip/tar.gz)
- Backend already routes `.bbl` files to the BBL parser, so this works end-to-end

## Test plan
- [ ] Create a `.zip` containing both PDFs and `.bbl` files → both types extracted and processed
- [ ] Create a `.tar.gz` with `.bbl` files → extracted and processed correctly
- [ ] Archive with only `.bbl` files → works (no "No PDF files found" error)
- [ ] Archive with only PDFs → still works as before
- [ ] `cargo clippy` — zero new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)