### PR TITLE
Add .bib file support with resilient parsing

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -192,6 +192,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "biblatex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d0c374feba1b9a59042a7c1cf00ce7c34b977b9134fe7c42b08e5183729f66"
+dependencies = [
+ "paste",
+ "roman-numerals-rs",
+ "strum 0.27.2",
+ "unicode-normalization",
+ "unscanny",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1103,7 @@ dependencies = [
 name = "hallucinator-bbl"
 version = "0.1.0"
 dependencies = [
+ "biblatex",
  "hallucinator-pdf",
  "once_cell",
  "regex",
@@ -2240,7 +2254,7 @@ dependencies = [
  "itertools",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -2360,6 +2374,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "rusqlite"
@@ -2769,7 +2789,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2782,6 +2811,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3191,6 +3232,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"

--- a/hallucinator-rs/Cargo.toml
+++ b/hallucinator-rs/Cargo.toml
@@ -86,6 +86,9 @@ ratatui = "0.29"
 # Encoding
 base64 = "0.22"
 
+# BibTeX parsing
+biblatex = "0.11"
+
 # Error handling
 thiserror = "2"
 anyhow = "1"

--- a/hallucinator-rs/crates/hallucinator-bbl/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-bbl/Cargo.toml
@@ -7,6 +7,7 @@ description = "BibTeX .bbl file parser for hallucinated reference detection"
 
 [dependencies]
 hallucinator-pdf.workspace = true
+biblatex.workspace = true
 regex.workspace = true
 once_cell.workspace = true
 thiserror.workspace = true

--- a/hallucinator-rs/crates/hallucinator-pdf/src/archive.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf/src/archive.rs
@@ -35,19 +35,19 @@ pub fn is_archive_path(path: &Path) -> bool {
     name.ends_with(".zip") || name.ends_with(".tar.gz") || name.ends_with(".tgz")
 }
 
-/// Returns true if the filename is a supported extractable type (PDF or BBL).
+/// Returns true if the filename is a supported extractable type (PDF, BBL, or BIB).
 fn is_extractable(name: &str) -> bool {
     let lower = name.to_lowercase();
-    lower.ends_with(".pdf") || lower.ends_with(".bbl")
+    lower.ends_with(".pdf") || lower.ends_with(".bbl") || lower.ends_with(".bib")
 }
 
 /// Returns true if the file content looks valid for its extension.
-/// PDFs must start with `%PDF-`; BBL files are plain text and skip the check.
+/// PDFs must start with `%PDF-`; BBL and BIB files are plain text and skip the check.
 fn passes_magic_check(name: &str, data: &[u8]) -> bool {
     if name.to_lowercase().ends_with(".pdf") {
         data.starts_with(b"%PDF-")
     } else {
-        true // .bbl files are plain text, no magic bytes to check
+        true // .bbl/.bib files are plain text, no magic bytes to check
     }
 }
 
@@ -124,7 +124,7 @@ pub fn extract_from_zip(
             continue;
         }
 
-        // Only process PDFs and BBL files
+        // Only process PDFs, BBL, and BIB files
         if !is_extractable(&name_str) {
             continue;
         }
@@ -170,7 +170,7 @@ pub fn extract_from_zip(
     }
 
     if pdfs.is_empty() {
-        return Err("No PDF or BBL files found in archive".to_string());
+        return Err("No PDF, BBL, or BIB files found in archive".to_string());
     }
 
     Ok(ExtractionResult { pdfs, warnings })
@@ -221,7 +221,7 @@ pub fn extract_from_tar_gz(
             continue;
         }
 
-        // Only process PDFs and BBL files
+        // Only process PDFs, BBL, and BIB files
         if !is_extractable(&name_str) {
             continue;
         }
@@ -268,13 +268,13 @@ pub fn extract_from_tar_gz(
     }
 
     if pdfs.is_empty() {
-        return Err("No PDF or BBL files found in archive".to_string());
+        return Err("No PDF, BBL, or BIB files found in archive".to_string());
     }
 
     Ok(ExtractionResult { pdfs, warnings })
 }
 
-/// Stream-extract PDFs and BBL files from an archive, sending each one through `tx` as it's extracted.
+/// Stream-extract PDFs, BBL, and BIB files from an archive, sending each one through `tx` as it's extracted.
 ///
 /// This is the streaming counterpart of [`extract_archive`]. Instead of collecting all
 /// PDFs into a Vec, each extracted PDF is sent immediately via the channel so the caller
@@ -392,7 +392,7 @@ fn extract_from_zip_streaming(
     }
 
     if total == 0 {
-        return Err("No PDF or BBL files found in archive".to_string());
+        return Err("No PDF, BBL, or BIB files found in archive".to_string());
     }
 
     let _ = tx.send(ArchiveItem::Done { total });
@@ -489,7 +489,7 @@ fn extract_from_tar_gz_streaming(
     }
 
     if total == 0 {
-        return Err("No PDF or BBL files found in archive".to_string());
+        return Err("No PDF, BBL, or BIB files found in archive".to_string());
     }
 
     let _ = tx.send(ArchiveItem::Done { total });

--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -62,6 +62,7 @@ pub struct FileEntry {
     pub is_dir: bool,
     pub is_pdf: bool,
     pub is_bbl: bool,
+    pub is_bib: bool,
     pub is_archive: bool,
     pub is_json: bool,
 }
@@ -92,6 +93,7 @@ impl FilePickerState {
                 is_dir: true,
                 is_pdf: false,
                 is_bbl: false,
+                is_bib: false,
                 is_archive: false,
                 is_json: false,
             });
@@ -117,6 +119,7 @@ impl FilePickerState {
                         is_dir: true,
                         is_pdf: false,
                         is_bbl: false,
+                        is_bib: false,
                         is_archive: false,
                         is_json: false,
                     });
@@ -124,6 +127,7 @@ impl FilePickerState {
                     let ext = path.extension().and_then(|e| e.to_str());
                     let is_pdf = ext.map(|e| e.eq_ignore_ascii_case("pdf")).unwrap_or(false);
                     let is_bbl = ext.map(|e| e.eq_ignore_ascii_case("bbl")).unwrap_or(false);
+                    let is_bib = ext.map(|e| e.eq_ignore_ascii_case("bib")).unwrap_or(false);
                     let is_archive = hallucinator_pdf::archive::is_archive_path(&path);
                     let is_json = ext.map(|e| e.eq_ignore_ascii_case("json")).unwrap_or(false);
                     files.push(FileEntry {
@@ -132,6 +136,7 @@ impl FilePickerState {
                         is_dir: false,
                         is_pdf,
                         is_bbl,
+                        is_bib,
                         is_archive,
                         is_json,
                     });
@@ -150,10 +155,10 @@ impl FilePickerState {
         self.scroll_offset = 0;
     }
 
-    /// Toggle selection of the current entry (PDFs, .bbl files, archives, and .json results).
+    /// Toggle selection of the current entry (PDFs, .bbl, .bib files, archives, and .json results).
     pub fn toggle_selected(&mut self) {
         if let Some(entry) = self.entries.get(self.cursor) {
-            if entry.is_pdf || entry.is_bbl || entry.is_archive || entry.is_json {
+            if entry.is_pdf || entry.is_bbl || entry.is_bib || entry.is_archive || entry.is_json {
                 if let Some(pos) = self.selected.iter().position(|p| p == &entry.path) {
                     self.selected.remove(pos);
                 } else {

--- a/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
@@ -85,11 +85,17 @@ async fn process_single_paper(
     let is_bbl = path
         .extension()
         .is_some_and(|e| e.eq_ignore_ascii_case("bbl"));
+    let is_bib = path
+        .extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("bib"));
 
     let extraction: Result<ExtractionResult, String> = tokio::task::spawn_blocking(move || {
         if is_bbl {
             hallucinator_bbl::extract_references_from_bbl(&path)
                 .map_err(|e| format!("BBL extraction failed: {}", e))
+        } else if is_bib {
+            hallucinator_bbl::extract_references_from_bib(&path)
+                .map_err(|e| format!("BIB extraction failed: {}", e))
         } else {
             hallucinator_pdf::extract_references(&path)
                 .map_err(|e| format!("PDF extraction failed: {}", e))

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -37,7 +37,7 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 
-    /// PDF or .bbl files to check
+    /// PDF, .bbl, or .bib files to check
     file_paths: Vec<PathBuf>,
 
     /// OpenAlex API key

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
@@ -31,7 +31,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
     let header = Line::from(vec![
         Span::styled(" HALLUCINATOR ", theme.header_style()),
         Span::styled(
-            " > Select PDFs / .bbl / Archives / Results (.json)",
+            " > Select PDFs / .bbl / .bib / Archives / Results (.json)",
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
         ),
     ]);
@@ -61,7 +61,12 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
         .map(|entry| {
             let (icon, style) = if entry.is_dir {
                 ("\u{1F4C1} ", Style::default().fg(theme.active))
-            } else if entry.is_pdf || entry.is_bbl || entry.is_archive || entry.is_json {
+            } else if entry.is_pdf
+                || entry.is_bbl
+                || entry.is_bib
+                || entry.is_archive
+                || entry.is_json
+            {
                 let selected = picker.is_selected(&entry.path);
                 if selected {
                     (
@@ -111,7 +116,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(theme.dim),
             )),
             Line::from(Span::styled(
-                "  Navigate to PDFs, .bbl, archives, or .json results and press Space to select",
+                "  Navigate to PDFs, .bbl, .bib, archives, or .json results and press Space to select",
                 Style::default().fg(theme.dim),
             )),
         ]


### PR DESCRIPTION
## Summary
- Adds full `.bib` bibliography file support across CLI, TUI, and archive extraction using the `biblatex` crate (v0.11, by Typst team)
- Implements resilient fallback parser: when `Bibliography::parse()` fails on the whole file (extra braces, missing `@` prefix, non-standard entry types, raw text), falls back to splitting by `@` boundaries and parsing each entry individually — one bad entry no longer kills the entire file
- Normalizes URL-form DOIs (`https://doi.org/10.xxx` → `10.xxx`) and guards against false arXiv ID extraction from URL-style `eprint` fields

## Changes
- `hallucinator-bbl`: New `extract_references_from_bib`/`bib_str` functions with `biblatex` crate integration, fallback entry-by-entry parser, DOI normalization, URL eprint guard
- `hallucinator-pdf/archive.rs`: `.bib` files recognized in archive extraction
- `hallucinator-cli`: `.bib` dispatch in `check()` and `dry_run_check()`
- `hallucinator-tui`: `.bib` dispatch in backend, file picker model and UI updated
- 19 tests passing including integration tests against 8 real-world `.bib` files from arXiv source bundles

## Test plan
- [x] `cargo test -p hallucinator-bbl` — 19 tests pass
- [x] `cargo check` — clean build (only pre-existing warning)
- [x] Integration tests cover files with extra braces, missing `@`, non-standard entry types (`@softmisc`, `@online`, `@software`), raw text separators, URL-style DOIs, URL-style eprint fields
- [ ] Manual test: run TUI on directory with `.bib` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)