### PR TITLE
Add categorized false positive reasons to TUI

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -516,7 +516,8 @@ async fn main() -> anyhow::Result<()> {
                             if let Some(ref dir) = run_dir {
                                 let pi = *paper_index;
                                 if let Some(paper) = app.papers.get(pi) {
-                                    persistence::save_paper_results(dir, pi, paper);
+                                    let rs = app.ref_states.get(pi).map(|v| v.as_slice()).unwrap_or(&[]);
+                                    persistence::save_paper_results(dir, pi, paper, rs);
                                 }
                             }
                         }

--- a/hallucinator-rs/crates/hallucinator-tui/src/persistence.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/persistence.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 
+use crate::model::paper::RefState;
 use crate::model::queue::PaperState;
 
 /// Get the run directory for persisting results.
@@ -20,9 +21,15 @@ pub fn run_dir() -> Option<PathBuf> {
 ///
 /// Uses the same rich JSON format as the export module so that saved results
 /// can be loaded back via `--load` or the file picker.
-pub fn save_paper_results(run_dir: &std::path::Path, paper_index: usize, paper: &PaperState) {
+pub fn save_paper_results(
+    run_dir: &std::path::Path,
+    paper_index: usize,
+    paper: &PaperState,
+    ref_states: &[RefState],
+) {
     let out_path = run_dir.join(format!("paper_{}.json", paper_index));
-    let json = crate::export::export_json(&[paper]);
+    let rs_slice: &[RefState] = ref_states;
+    let json = crate::export::export_json(&[paper], &[rs_slice]);
 
     if let Ok(mut file) = std::fs::File::create(&out_path) {
         let _ = file.write_all(json.as_bytes());

--- a/hallucinator-rs/crates/hallucinator-tui/src/tips.txt
+++ b/hallucinator-rs/crates/hallucinator-tui/src/tips.txt
@@ -8,7 +8,7 @@ Pro-tip: Press , to open config -- set API keys, concurrency, timeouts
 Pro-tip: Set an OpenAlex key for broader coverage (--openalex-key or config)
 Pro-tip: Build an offline DBLP database for instant local lookups (hallucinator-tui update-dblp)
 Pro-tip: Increase concurrent papers in config to process batches faster
-Pro-tip: Press Space on a reference to mark false positives as safe
+Pro-tip: Press Space on a reference to cycle FP reasons (parse/GS/timeout/known)
 Pro-tip: Use s to cycle sort order, f to filter by status on queue/paper views
 Pro-tip: The Semantic Scholar API key improves rate limits (--s2-api-key)
 Pro-tip: Press e to export results as Markdown, JSON, or CSV

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
@@ -44,10 +44,10 @@ pub fn render_in(f: &mut Frame, app: &App, paper_index: usize, ref_index: usize,
     // --- Content ---
     let mut lines: Vec<Line> = Vec::new();
 
-    // Safe marker
-    if rs.marked_safe {
+    // Safe marker (FP reason)
+    if let Some(reason) = rs.fp_reason {
         lines.push(Line::from(Span::styled(
-            "  \u{2713} Marked as SAFE (false positive)",
+            format!("  \u{2713} Marked as SAFE \u{2014} {}", reason.description()),
             Style::default()
                 .fg(theme.verified)
                 .add_modifier(Modifier::BOLD),
@@ -351,7 +351,7 @@ fn url_line(lines: &mut Vec<Line<'_>>, label: &str, url: &str, theme: &Theme) {
 
 fn render_footer(f: &mut Frame, area: Rect, theme: &Theme) {
     let footer = Line::from(Span::styled(
-        " j/k:scroll  Space:toggle safe  Ctrl+r:retry  y:copy ref  Esc:back  ?:help",
+        " j/k:scroll  Space:cycle FP reason  Ctrl+r:retry  y:copy ref  Esc:back  ?:help",
         theme.footer_style(),
     ));
     f.render_widget(Paragraph::new(footer), area);

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
@@ -41,7 +41,7 @@ pub fn render(f: &mut Frame, theme: &Theme) {
         // Actions
         section_header("Actions", theme),
         key_line("r", "Start/stop processing", theme),
-        key_line("Space", "Mark paper safe/?!/ref safe", theme),
+        key_line("Space", "Paper verdict / cycle FP reason", theme),
         key_line("Ctrl+r", "Retry failed reference", theme),
         key_line("R", "Retry all failed references", theme),
         key_line("e", "Export results", theme),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
@@ -149,7 +149,7 @@ fn render_ref_table(f: &mut Frame, area: Rect, app: &App, paper_index: usize) {
             let phase_style = theme.ref_phase_style(&rs.phase);
 
             let verdict = rs.verdict_label();
-            let verdict_style = if rs.marked_safe {
+            let verdict_style = if rs.is_marked_safe() {
                 Style::default()
                     .fg(theme.verified)
                     .add_modifier(Modifier::DIM)
@@ -186,14 +186,14 @@ fn render_ref_table(f: &mut Frame, area: Rect, app: &App, paper_index: usize) {
         vec![
             Constraint::Length(4),
             Constraint::Min(20),
-            Constraint::Length(14),
+            Constraint::Length(16),
             Constraint::Length(18),
         ]
     } else {
         vec![
             Constraint::Length(4),
             Constraint::Min(15),
-            Constraint::Length(14),
+            Constraint::Length(16),
         ]
     };
 
@@ -270,7 +270,7 @@ fn render_footer(
     }
 
     spans.push(Span::styled(
-        " | j/k:nav  Space:safe  Enter:detail  Ctrl+r:retry  R:retry all  s:sort  f:filter  /:search  Esc:back",
+        " | j/k:nav  Space:FP reason  Enter:detail  Ctrl+r:retry  R:retry all  s:sort  f:filter  /:search  Esc:back",
         theme.footer_style(),
     ));
 


### PR DESCRIPTION
## Summary

- Replace `marked_safe: bool` with `FpReason` enum (`BrokenParse`, `ExistsElsewhere`, `AllTimedOut`, `KnownGood`) on `RefState`
- Space key cycles through reasons: None → BrokenParse → ExistsElsewhere → AllTimedOut → KnownGood → None
- FP reasons included in all 5 export formats (JSON, CSV, Markdown, Text, HTML) and persisted to auto-save JSON
- Backward-compatible loading: old `marked_safe: true` maps to `KnownGood`, new `fp_reason` string field preferred

Closes #60

## Test plan

- [ ] `cargo check -p hallucinator-tui` compiles cleanly
- [ ] Open a paper in TUI, press Space on a NotFound ref — verify cycling through 5 states (None → 4 reasons → None)
- [ ] Detail view banner shows reason description (e.g. "Marked as SAFE — Broken citation parse")
- [ ] Verdict column shows short label (e.g. "✓ Safe (parse)", "✓ Safe (GS)")
- [ ] Export as JSON — verify `fp_reason` field with correct string value
- [ ] Export as CSV/Markdown/HTML/Text — verify FP reason shown
- [ ] Save and re-load results — verify FP reason survives round-trip
- [ ] Load an old JSON file without `fp_reason` — verify no errors (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)