### PR TITLE
TUI: Preserve queue cursor when returning from paper view

### DIFF
--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -452,14 +452,19 @@ fn dry_run_pdf(
 
         let word_count = cleaned_title.split_whitespace().count();
         if cleaned_title.is_empty() || word_count < 4 {
-            if use_color {
-                writeln!(
-                    writer,
-                    "  {}",
-                    format!("SKIPPED (title too short: {} words)", word_count).red()
-                )?;
-            } else {
-                writeln!(writer, "  SKIPPED (title too short: {} words)", word_count)?;
+            // Check for strong signals that override the short-title skip
+            let has_signal =
+                !cleaned_title.is_empty() && (doi.is_some() || arxiv_id.is_some() || from_quotes);
+            if !has_signal {
+                if use_color {
+                    writeln!(
+                        writer,
+                        "  {}",
+                        format!("SKIPPED (title too short: {} words)", word_count).red()
+                    )?;
+                } else {
+                    writeln!(writer, "  SKIPPED (title too short: {} words)", word_count)?;
+                }
             }
         }
 

--- a/hallucinator-rs/crates/hallucinator-pdf/src/extractor.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf/src/extractor.rs
@@ -166,9 +166,19 @@ fn parse_single_reference(
     if (URL_RE.is_match(&ref_text) || BROKEN_URL_RE.is_match(&ref_text))
         && !ACADEMIC_URL_RE.is_match(&ref_text)
     {
+        // Still extract a title for display purposes even though we're skipping
+        let (extracted_title, from_quotes) =
+            title::extract_title_from_reference_with_config(&ref_text, config);
+        let cleaned_title = title::clean_title_with_config(&extracted_title, from_quotes, config);
+        let title = if cleaned_title.is_empty() {
+            None
+        } else {
+            Some(cleaned_title)
+        };
+
         static WS_SKIP_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
         let raw = WS_SKIP_RE.replace_all(&ref_text, " ").trim().to_string();
-        return ParsedRef::Skip(SkipReason::UrlOnly, raw, None);
+        return ParsedRef::Skip(SkipReason::UrlOnly, raw, title);
     }
 
     // Extract title
@@ -178,15 +188,24 @@ fn parse_single_reference(
 
     if cleaned_title.is_empty() || cleaned_title.split_whitespace().count() < config.min_title_words
     {
-        // Clean up raw citation for the skipped ref
-        static WS_SKIP_RE2: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
-        let raw = WS_SKIP_RE2.replace_all(&ref_text, " ").trim().to_string();
-        let title = if cleaned_title.is_empty() {
-            None
-        } else {
-            Some(cleaned_title)
-        };
-        return ParsedRef::Skip(SkipReason::ShortTitle, raw, title);
+        // Short titles can still be real citations if we have strong signals:
+        // DOI, arXiv ID, quoted title, or venue/year markers in the raw text.
+        let has_strong_signal = !cleaned_title.is_empty()
+            && (doi.is_some()
+                || arxiv_id.is_some()
+                || from_quotes
+                || looks_like_citation(&ref_text));
+
+        if !has_strong_signal {
+            static WS_SKIP_RE2: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
+            let raw = WS_SKIP_RE2.replace_all(&ref_text, " ").trim().to_string();
+            let title = if cleaned_title.is_empty() {
+                None
+            } else {
+                Some(cleaned_title)
+            };
+            return ParsedRef::Skip(SkipReason::ShortTitle, raw, title);
+        }
     }
 
     // Extract authors
@@ -218,6 +237,27 @@ fn parse_single_reference(
         original_number: 0, // placeholder; overwritten by caller
         skip_reason: None,
     })
+}
+
+/// Check whether raw citation text has structural signals of a real reference
+/// (venue markers, author-year patterns, journal metadata) even when the
+/// extracted title is very short.
+fn looks_like_citation(ref_text: &str) -> bool {
+    static VENUE_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\b(?:In\s+Proceedings|Proc\.|Conference|Workshop|Symposium|IEEE|ACM|USENIX|AAAI|ICML|NeurIPS|ICLR|arXiv\s+preprint|Journal\s+of|Transactions\s+on)\b").unwrap()
+    });
+    static YEAR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:19|20)\d{2}").unwrap());
+    static AUTHOR_YEAR_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"[A-Z][a-z]+.*(?:19|20)\d{2}").unwrap());
+    static VOL_ISSUE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\d+\s*\(\d+\)").unwrap());
+
+    let has_venue = VENUE_RE.is_match(ref_text);
+    let has_year = YEAR_RE.is_match(ref_text);
+    let has_author_year = AUTHOR_YEAR_RE.is_match(ref_text);
+    let has_vol_issue = VOL_ISSUE_RE.is_match(ref_text);
+
+    // Need at least two signals: venue+year, author+year+volume, etc.
+    (has_venue && has_year) || (has_author_year && has_vol_issue)
 }
 
 #[cfg(test)]
@@ -371,8 +411,9 @@ mod tests {
 
     #[test]
     fn test_custom_min_title_words() {
-        // A reference whose title is exactly 3 words
-        let ref_text = r#"J. Smith, "Three Word Title," in Proc. IEEE, 2023."#;
+        // A reference with a 3-word title and no strong citation signals
+        // (no DOI, no arXiv, no quotes, no venue/year combo)
+        let ref_text = "Smith, J. Three Word Title";
 
         // Default min_title_words=4 → should be SKIPPED (3 < 4)
         let ext_default = PdfExtractor::new();
@@ -397,12 +438,13 @@ mod tests {
         }
 
         // With min_title_words = 10, a normal title should be skipped
+        // (no strong signals to override the threshold)
         let config_strict = PdfParsingConfigBuilder::new()
             .min_title_words(10)
             .build()
             .unwrap();
         let ext_strict = PdfExtractor::with_config(config_strict);
-        let long_ref = r#"J. Smith, "A Five Word Paper Title Here," in Proc. IEEE, 2023."#;
+        let long_ref = "Smith, J. A Five Word Paper Title Here";
         let parsed2 = ext_strict.parse_reference(long_ref, &[]);
         match parsed2 {
             ParsedRef::Skip(SkipReason::ShortTitle, _, _) => {} // expected
@@ -483,6 +525,146 @@ mod tests {
                 assert_eq!(r.authors, prev_authors);
             }
             ParsedRef::Skip(..) => panic!("Expected a reference"),
+        }
+    }
+
+    // ── looks_like_citation tests ──
+
+    #[test]
+    fn test_looks_like_citation_venue_and_year() {
+        // Venue + year → true
+        assert!(looks_like_citation(
+            "Smith, J. 2020. XYZ. In Proceedings of ACM CHI."
+        ));
+        assert!(looks_like_citation("Jones, K. Foo. Proc. IEEE, 2019."));
+    }
+
+    #[test]
+    fn test_looks_like_citation_author_year_vol_issue() {
+        // Author-year + volume(issue) → true
+        assert!(looks_like_citation("Smith 2020. Bar. 15(3), pp. 1-10."));
+    }
+
+    #[test]
+    fn test_looks_like_citation_not_enough_signals() {
+        // Only a year, no venue or vol/issue → false
+        assert!(!looks_like_citation("Smith 2020. Some text here."));
+        // No year at all → false
+        assert!(!looks_like_citation("Smith. Some random text."));
+    }
+
+    // ── Strong signal rescue for short titles ──
+
+    #[test]
+    fn test_short_title_rescued_by_doi() {
+        let ext = PdfExtractor::new();
+        // 3-word quoted title with DOI → should NOT be skipped despite short title
+        let ref_text = r#"Smith, J. "Word Affect Intensities." doi:10.1234/test.2020"#;
+        let parsed = ext.parse_reference(ref_text, &[]);
+        match parsed {
+            ParsedRef::Ref(r) => {
+                assert!(r.doi.is_some(), "Should have extracted DOI");
+            }
+            ParsedRef::Skip(..) => panic!("Short title with DOI should be rescued"),
+        }
+    }
+
+    #[test]
+    fn test_short_title_rescued_by_arxiv() {
+        let ext = PdfExtractor::new();
+        // 3-word title but has arXiv ID → should NOT be skipped
+        let ref_text = "Smith, J. Word Affect Intensities. arXiv:1704.08798";
+        let parsed = ext.parse_reference(ref_text, &[]);
+        match parsed {
+            ParsedRef::Ref(r) => {
+                assert!(r.arxiv_id.is_some(), "Should have extracted arXiv ID");
+            }
+            ParsedRef::Skip(..) => panic!("Short title with arXiv should be rescued"),
+        }
+    }
+
+    #[test]
+    fn test_short_title_rescued_by_venue() {
+        let ext = PdfExtractor::new();
+        // 3-word title with venue + year signals → should NOT be skipped
+        let ref_text = "Smith, J. 2020. Three Word Title. In Proceedings of ACM CHI. New York.";
+        let parsed = ext.parse_reference(ref_text, &[]);
+        match parsed {
+            ParsedRef::Ref(_) => {} // expected
+            ParsedRef::Skip(..) => {
+                panic!("Short title with venue+year signals should be rescued")
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_title_not_rescued_without_signals() {
+        let ext = PdfExtractor::new();
+        // 3-word title with no strong signals → should be skipped
+        let ref_text = "Smith, J. Three Word Title";
+        let parsed = ext.parse_reference(ref_text, &[]);
+        match parsed {
+            ParsedRef::Skip(SkipReason::ShortTitle, _, _) => {} // expected
+            _ => panic!("Short title without signals should be skipped"),
+        }
+    }
+
+    // ── URL-only skip with title extraction ──
+
+    #[test]
+    fn test_url_only_skip_preserves_title() {
+        let ext = PdfExtractor::new();
+        // A reference with a non-academic URL that also has a parseable title
+        let ref_text =
+            "Smith, J. 2023. Some Interesting Report About Software. https://example.com/report";
+        let parsed = ext.parse_reference(ref_text, &[]);
+        match parsed {
+            ParsedRef::Skip(SkipReason::UrlOnly, _, title) => {
+                assert!(
+                    title.is_some(),
+                    "URL-only skip should still extract a title"
+                );
+            }
+            ParsedRef::Ref(_) => panic!("Non-academic URL should be skipped"),
+            ParsedRef::Skip(SkipReason::ShortTitle, _, _) => {
+                panic!("Should be UrlOnly skip, not ShortTitle")
+            }
+        }
+    }
+
+    #[test]
+    fn test_two_word_title_rescued_by_venue() {
+        // "Translation-based Recommendation" is 2 words — below min_title_words=4.
+        // But it has venue ("Proceedings", "ACM", "Conference") + year → should be rescued.
+        let ext = PdfExtractor::new();
+        let ref_text = "He, R.; Kang, W.-C.; and McAuley, J. 2017. Translation-based Recommendation. Proceedings of the Eleventh ACM Conference on Recommender Systems";
+        let parsed = ext.parse_reference(ref_text, &[]);
+        match parsed {
+            ParsedRef::Ref(r) => {
+                assert_eq!(r.title.as_deref(), Some("Translation-based Recommendation"));
+            }
+            ParsedRef::Skip(..) => {
+                panic!("2-word title with venue+year signals should be rescued")
+            }
+        }
+    }
+
+    #[test]
+    fn test_disambiguated_year_suffix() {
+        // AAAI year "2022b" — letter suffix for multiple papers by same author in one year
+        let ext = PdfExtractor::new();
+        let ref_text = "Feng, S.; and Luo, M. 2022b. TwiBot-22: Towards Graph-Based Twitter Bot Detection. In Proceedings of NeurIPS, 35254-35269";
+        let parsed = ext.parse_reference(ref_text, &[]);
+        match parsed {
+            ParsedRef::Ref(r) => {
+                let title = r.title.unwrap();
+                assert!(
+                    title.contains("TwiBot-22"),
+                    "Title should be the paper title, not the year. Got: {}",
+                    title
+                );
+            }
+            ParsedRef::Skip(..) => panic!("Should not be skipped"),
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-pdf/src/title.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf/src/title.rs
@@ -479,16 +479,17 @@ fn try_springer_year(ref_text: &str) -> Option<(String, bool)> {
     static TRAIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
     let title = TRAIL.replace(title, "");
 
-    if title.split_whitespace().count() >= 3 {
-        Some((title.to_string(), false))
-    } else {
+    if title.is_empty() {
         None
+    } else {
+        Some((title.to_string(), false))
     }
 }
 
 fn try_acm_year(ref_text: &str) -> Option<(String, bool)> {
-    // ". YYYY. Title" — require \s+ after year to avoid matching DOIs
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*((?:19|20)\d{2})\.\s+").unwrap());
+    // ". YYYY[a-z]. Title" — require \s+ after year to avoid matching DOIs
+    // Optional letter suffix for disambiguated years (e.g. "2022b")
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*((?:19|20)\d{2}[a-z]?)\.\s+").unwrap());
 
     let caps = RE.captures(ref_text)?;
     let after_year = &ref_text[caps.get(0).unwrap().end()..];
@@ -535,10 +536,10 @@ fn try_acm_year(ref_text: &str) -> Option<(String, bool)> {
     static TRAIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
     let title = TRAIL.replace(title, "");
 
-    if title.split_whitespace().count() >= 3 {
-        Some((title.to_string(), false))
-    } else {
+    if title.is_empty() {
         None
+    } else {
+        Some((title.to_string(), false))
     }
 }
 
@@ -568,7 +569,7 @@ fn try_venue_marker(ref_text: &str) -> Option<(String, bool)> {
                 let title = parts[1].trim();
                 static TRAIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
                 let title = TRAIL.replace(title, "");
-                if title.split_whitespace().count() >= 3 {
+                if !title.is_empty() {
                     // Verify it doesn't look like authors
                     static AUTHOR_CHECK: Lazy<Regex> =
                         Lazy::new(|| Regex::new(r"^[A-Z][a-z]+\s+[A-Z][a-z]+,").unwrap());
@@ -599,7 +600,7 @@ fn try_venue_marker(ref_text: &str) -> Option<(String, bool)> {
                 let title = remaining.trim();
                 static TRAIL2: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
                 let title = TRAIL2.replace(title, "");
-                if title.split_whitespace().count() >= 3 {
+                if !title.is_empty() {
                     static AUTHOR_CHECK2: Lazy<Regex> =
                         Lazy::new(|| Regex::new(r"^[A-Z][a-z]+,\s+[A-Z]\.").unwrap());
                     if !AUTHOR_CHECK2.is_match(&title) {
@@ -625,7 +626,7 @@ fn try_journal(ref_text: &str) -> Option<(String, bool)> {
     let parts = split_sentences_skip_initials(before_journal);
     if parts.len() >= 2 {
         let title = parts[1].trim();
-        if title.split_whitespace().count() >= 3 {
+        if !title.is_empty() {
             return Some((title.to_string(), false));
         }
     }
@@ -644,7 +645,7 @@ fn try_elsevier_journal(ref_text: &str) -> Option<(String, bool)> {
         let title = parts.last().unwrap().trim();
         static TRAIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
         let title = TRAIL.replace(title, "");
-        if title.split_whitespace().count() >= 3 {
+        if !title.is_empty() {
             return Some((title.to_string(), false));
         }
     }
@@ -717,10 +718,10 @@ fn try_chinese_allcaps(ref_text: &str) -> Option<(String, bool)> {
     static TRAIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
     let title = TRAIL.replace(title, "");
 
-    if title.split_whitespace().count() >= 3 {
-        Some((title.to_string(), false))
-    } else {
+    if title.is_empty() {
         None
+    } else {
+        Some((title.to_string(), false))
     }
 }
 
@@ -764,7 +765,7 @@ fn try_all_caps_authors(ref_text: &str) -> Option<(String, bool)> {
         let title = title_text[..title_end].trim();
         static TRAIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
         let title = TRAIL.replace(title, "");
-        if title.split_whitespace().count() >= 3 {
+        if !title.is_empty() {
             return Some((title.to_string(), false));
         }
     }
@@ -801,7 +802,7 @@ fn try_bracket_code(ref_text: &str) -> Option<(String, bool)> {
                 let remaining: String = sentences[i + 1..].join(". ");
                 let title_end = remaining.find(". In ").unwrap_or(remaining.len());
                 let title = remaining[..title_end].trim();
-                if title.split_whitespace().count() >= 3 {
+                if !title.is_empty() {
                     return Some((title.to_string(), false));
                 }
             }
@@ -864,10 +865,10 @@ fn try_author_particles(ref_text: &str) -> Option<(String, bool)> {
     static TRAIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.\s*$").unwrap());
     let title = TRAIL.replace(title, "");
 
-    if title.split_whitespace().count() >= 3 {
-        Some((title.to_string(), false))
-    } else {
+    if title.is_empty() {
         None
+    } else {
+        Some((title.to_string(), false))
     }
 }
 
@@ -916,10 +917,10 @@ fn try_fallback_sentence(ref_text: &str) -> Option<(String, bool)> {
         return None;
     }
 
-    if potential_title.split_whitespace().count() >= 3 {
-        Some((potential_title, false))
-    } else {
+    if potential_title.is_empty() {
         None
+    } else {
+        Some((potential_title, false))
     }
 }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -322,7 +322,13 @@ impl App {
     }
 
     /// Recompute `queue_sorted` based on the current `sort_order`, filter, and search.
+    ///
+    /// Stabilises the cursor: if the paper previously under the cursor is still
+    /// present after filtering/sorting, the cursor follows it to its new row.
     pub fn recompute_sorted_indices(&mut self) {
+        // Remember which paper the cursor is currently on.
+        let prev_paper = self.queue_sorted.get(self.queue_cursor).copied();
+
         let mut indices = filtered_indices(&self.papers, self.queue_filter, &self.search_query);
         match self.sort_order {
             SortOrder::Original => {}
@@ -348,6 +354,18 @@ impl App {
             }
         }
         self.queue_sorted = indices;
+
+        // Restore cursor to the same paper if it's still in the list.
+        if let Some(paper_idx) = prev_paper {
+            if let Some(new_pos) = self.queue_sorted.iter().position(|&i| i == paper_idx) {
+                self.queue_cursor = new_pos;
+            } else {
+                // Paper was filtered out — clamp cursor.
+                self.queue_cursor = self
+                    .queue_cursor
+                    .min(self.queue_sorted.len().saturating_sub(1));
+            }
+        }
     }
 
     /// Get sorted/filtered reference indices for the paper view.
@@ -1568,7 +1586,9 @@ impl App {
             } => {
                 if let Some(paper) = self.papers.get_mut(paper_index) {
                     paper.total_refs = ref_count;
-                    paper.init_results(ref_count);
+                    // Allocate result slots for ALL refs (including skipped) so
+                    // that remapped indices from the backend fit.
+                    paper.init_results(references.len());
                     paper.phase = PaperPhase::Checking;
                 }
                 if paper_index < self.ref_states.len() {
@@ -1587,6 +1607,10 @@ impl App {
                                 phase,
                                 result: None,
                                 fp_reason: None,
+                                raw_citation: r.raw_citation.clone(),
+                                authors: r.authors.clone(),
+                                doi: r.doi.clone(),
+                                arxiv_id: r.arxiv_id.clone(),
                             }
                         })
                         .collect();

--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -158,17 +158,23 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>, Vec<Referen
                 .skip_reason
                 .clone()
                 .unwrap_or_else(|| "unknown".to_string());
+            let raw_cit = loaded_ref.raw_citation.clone().unwrap_or_default();
+            let authors = loaded_ref.ref_authors.clone().unwrap_or_default();
             ref_states.push(RefState {
                 index: orig_num.saturating_sub(1),
                 title: title.clone(),
                 phase: RefPhase::Skipped(reason.clone()),
                 result: None,
                 fp_reason,
+                raw_citation: raw_cit.clone(),
+                authors: authors.clone(),
+                doi: None,
+                arxiv_id: None,
             });
             references.push(Reference {
-                raw_citation: loaded_ref.raw_citation.clone().unwrap_or_default(),
+                raw_citation: raw_cit,
                 title: if title.is_empty() { None } else { Some(title) },
-                authors: loaded_ref.ref_authors.clone().unwrap_or_default(),
+                authors,
                 doi: None,
                 arxiv_id: None,
                 original_number: orig_num,
@@ -180,19 +186,27 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>, Vec<Referen
         let status = match parse_status(&loaded_ref.status) {
             Some(s) => s,
             None => {
+                let raw_cit = loaded_ref.raw_citation.clone().unwrap_or_default();
+                let authors = loaded_ref.ref_authors.clone().unwrap_or_default();
+                let doi = loaded_ref.doi_info.as_ref().map(|d| d.doi.clone());
+                let arxiv_id = loaded_ref.arxiv_info.as_ref().map(|a| a.arxiv_id.clone());
                 ref_states.push(RefState {
                     index: orig_num.saturating_sub(1),
                     title: title.clone(),
                     phase: RefPhase::Done,
                     result: None,
                     fp_reason,
+                    raw_citation: raw_cit.clone(),
+                    authors: authors.clone(),
+                    doi: doi.clone(),
+                    arxiv_id: arxiv_id.clone(),
                 });
                 references.push(Reference {
-                    raw_citation: loaded_ref.raw_citation.clone().unwrap_or_default(),
+                    raw_citation: raw_cit,
                     title: if title.is_empty() { None } else { Some(title) },
-                    authors: loaded_ref.ref_authors.clone().unwrap_or_default(),
-                    doi: loaded_ref.doi_info.as_ref().map(|d| d.doi.clone()),
-                    arxiv_id: loaded_ref.arxiv_info.as_ref().map(|a| a.arxiv_id.clone()),
+                    authors,
+                    doi,
+                    arxiv_id,
                     original_number: orig_num,
                     skip_reason: None,
                 });
@@ -272,20 +286,28 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>, Vec<Referen
 
         paper.record_result(loaded_ref.index, result.clone());
 
+        let raw_cit = loaded_ref.raw_citation.clone().unwrap_or_default();
+        let ref_authors = loaded_ref.ref_authors.clone().unwrap_or_default();
+        let ref_doi = doi_info.as_ref().map(|d| d.doi.clone());
+        let ref_arxiv = arxiv_info.as_ref().map(|a| a.arxiv_id.clone());
         ref_states.push(RefState {
             index: orig_num.saturating_sub(1),
             title: title.clone(),
             phase: RefPhase::Done,
             result: Some(result),
             fp_reason,
+            raw_citation: raw_cit.clone(),
+            authors: ref_authors.clone(),
+            doi: ref_doi.clone(),
+            arxiv_id: ref_arxiv.clone(),
         });
 
         references.push(Reference {
-            raw_citation: loaded_ref.raw_citation.clone().unwrap_or_default(),
+            raw_citation: raw_cit,
             title: if title.is_empty() { None } else { Some(title) },
-            authors: loaded_ref.ref_authors.clone().unwrap_or_default(),
-            doi: doi_info.map(|d| d.doi),
-            arxiv_id: arxiv_info.map(|a| a.arxiv_id),
+            authors: ref_authors,
+            doi: ref_doi,
+            arxiv_id: ref_arxiv,
             original_number: orig_num,
             skip_reason: None,
         });

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
@@ -95,6 +95,14 @@ pub struct RefState {
     pub result: Option<ValidationResult>,
     /// Why the user marked this reference as a false positive, or None if not overridden.
     pub fp_reason: Option<FpReason>,
+    /// Raw citation text from extraction (always available, even for skipped refs).
+    pub raw_citation: String,
+    /// Authors parsed during extraction.
+    pub authors: Vec<String>,
+    /// DOI extracted during parsing.
+    pub doi: Option<String>,
+    /// arXiv ID extracted during parsing.
+    pub arxiv_id: Option<String>,
 }
 
 impl RefState {


### PR DESCRIPTION
## Summary
- When navigating back from paper detail to the queue, the cursor now stays on the same paper by identity
- Previously, if sort order changed during analysis, the cursor would point at a different paper after returning
- Falls back gracefully if the paper is no longer in the filtered list

Closes #75