### PR TITLE
Fix TUI crash when offline DBLP/ACL database is missing

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
@@ -306,8 +306,7 @@ pub fn open_dblp_db(
 ) -> anyhow::Result<Arc<Mutex<hallucinator_dblp::DblpDatabase>>> {
     if !path.exists() {
         anyhow::bail!(
-            "Offline DBLP database not found at {}. Use hallucinator-cli --update-dblp={} to build it.",
-            path.display(),
+            "Offline DBLP database not found at {}. Run 'hallucinator-tui update-dblp' to build it.",
             path.display()
         );
     }


### PR DESCRIPTION
## Summary
- TUI no longer errors out when a configured offline DBLP/ACL database file is missing — gracefully falls back to web requests
- Shows a warning in the activity log so the user knows the DB couldn't be loaded
- Fixes incorrect error message that referenced `hallucinator-cli --update-dblp=` instead of `hallucinator-tui update-dblp`

Closes #84

## Test plan
- [ ] Configure a DBLP/ACL path in config, delete the DB file, launch TUI — should show warning, not crash
- [ ] Launch TUI with no DB path configured — should show existing "no offline DB" hint as before
- [ ] Launch TUI with valid DB path — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)