### PR TITLE
TUI polish: right-align columns, dismiss warnings, build path hints

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -1913,6 +1913,7 @@ impl App {
                     self.config_state.dblp_offline_path = db_path.display().to_string();
                     self.activity
                         .log(format!("DBLP database built: {}", db_path.display()));
+                    self.activity.dismiss_warnings_containing("DBLP");
                 } else {
                     let msg = error.unwrap_or_else(|| "unknown error".to_string());
                     self.config_state.dblp_build_status = Some(format!("Failed: {}", msg));
@@ -1950,6 +1951,7 @@ impl App {
                     self.config_state.acl_offline_path = db_path.display().to_string();
                     self.activity
                         .log(format!("ACL database built: {}", db_path.display()));
+                    self.activity.dismiss_warnings_containing("ACL");
                 } else {
                     let msg = error.unwrap_or_else(|| "unknown error".to_string());
                     self.config_state.acl_build_status = Some(format!("Failed: {}", msg));
@@ -2312,7 +2314,7 @@ fn osc52_copy(text: &str) {
 }
 
 /// Default path for offline databases: `~/.local/share/hallucinator/<filename>`.
-fn default_db_path(filename: &str) -> PathBuf {
+pub(crate) fn default_db_path(filename: &str) -> PathBuf {
     dirs::data_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join("hallucinator")

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/activity.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/activity.rs
@@ -124,6 +124,12 @@ impl ActivityState {
         self.throughput_buckets.push_back(count);
     }
 
+    /// Remove warning messages containing the given needle.
+    pub fn dismiss_warnings_containing(&mut self, needle: &str) {
+        self.messages
+            .retain(|(text, is_warning)| !(*is_warning && text.contains(needle)));
+    }
+
     /// Build sparkline string from throughput buckets.
     pub fn sparkline(&self) -> String {
         const CHARS: &[char] = &[

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/activity.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/activity.rs
@@ -199,7 +199,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(theme.border_style())
-                .title(" Activity (Tab to hide) "),
+                .title(" Status (Tab to hide) "),
         )
         .wrap(Wrap { trim: true });
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
@@ -212,6 +212,15 @@ fn render_databases(lines: &mut Vec<Line>, config: &ConfigState, theme: &Theme, 
     }
     lines.push(Line::from(spans));
 
+    // Show default build path hint when path is not set and cursor is on item
+    if config.item_cursor == 0 && !config.editing && config.dblp_offline_path.is_empty() {
+        let default_path = crate::app::default_db_path("dblp.db");
+        lines.push(Line::from(Span::styled(
+            format!("      b will build to: {}", default_path.display()),
+            Style::default().fg(theme.dim),
+        )));
+    }
+
     // Show DBLP build status inline
     if let Some(ref status) = config.dblp_build_status {
         let style = if config.dblp_building {
@@ -249,6 +258,15 @@ fn render_databases(lines: &mut Vec<Line>, config: &ConfigState, theme: &Theme, 
         spans.push(Span::styled("  (o:browse  b:build)", Style::default().fg(theme.dim)));
     }
     lines.push(Line::from(spans));
+
+    // Show default build path hint when path is not set and cursor is on item
+    if config.item_cursor == 1 && !config.editing && config.acl_offline_path.is_empty() {
+        let default_path = crate::app::default_db_path("acl.db");
+        lines.push(Line::from(Span::styled(
+            format!("      b will build to: {}", default_path.display()),
+            Style::default().fg(theme.dim),
+        )));
+    }
 
     // Show ACL build status inline
     if let Some(ref status) = config.acl_build_status {

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
@@ -1,5 +1,5 @@
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
@@ -142,17 +142,32 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
     let wide = area.width >= 75;
 
     // Build header row
-    let header_cells = if wide {
+    let hdr_style = Style::default().fg(theme.text).add_modifier(Modifier::BOLD);
+    let header_cells: Vec<Cell> = if wide {
         vec![
-            "#", "Paper", "Refs", "OK", "Mis", "NF", "Ret", "%", "Status",
+            ("#", Alignment::Right),
+            ("Paper", Alignment::Left),
+            ("Refs", Alignment::Right),
+            ("OK", Alignment::Right),
+            ("Mis", Alignment::Right),
+            ("NF", Alignment::Right),
+            ("Ret", Alignment::Right),
+            ("%", Alignment::Right),
+            ("Status", Alignment::Left),
         ]
     } else {
-        vec!["#", "Paper", "Refs", "Prob", "Status"]
-    };
-    let header = Row::new(header_cells.iter().map(|h| {
-        Cell::from(*h).style(Style::default().fg(theme.text).add_modifier(Modifier::BOLD))
-    }))
-    .height(1);
+        vec![
+            ("#", Alignment::Right),
+            ("Paper", Alignment::Left),
+            ("Refs", Alignment::Right),
+            ("Prob", Alignment::Right),
+            ("Status", Alignment::Left),
+        ]
+    }
+    .into_iter()
+    .map(|(h, align)| Cell::from(Line::from(h).alignment(align)).style(hdr_style))
+    .collect();
+    let header = Row::new(header_cells).height(1);
 
     // Use the pre-computed sorted/filtered indices
     let indices = &app.queue_sorted;
@@ -221,18 +236,18 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
                     Style::default().fg(theme.dim)
                 };
                 Row::new(vec![
-                    Cell::from(num),
+                    Cell::from(Line::from(num).alignment(Alignment::Right)),
                     Cell::from(name).style(name_style),
-                    Cell::from(refs),
-                    Cell::from(format!("{}", paper.stats.verified))
+                    Cell::from(Line::from(refs).alignment(Alignment::Right)),
+                    Cell::from(Line::from(format!("{}", paper.stats.verified)).alignment(Alignment::Right))
                         .style(Style::default().fg(theme.verified)),
-                    Cell::from(format!("{}", paper.stats.author_mismatch))
+                    Cell::from(Line::from(format!("{}", paper.stats.author_mismatch)).alignment(Alignment::Right))
                         .style(Style::default().fg(theme.author_mismatch)),
-                    Cell::from(format!("{}", paper.stats.not_found))
+                    Cell::from(Line::from(format!("{}", paper.stats.not_found)).alignment(Alignment::Right))
                         .style(Style::default().fg(theme.not_found)),
-                    Cell::from(format!("{}", paper.stats.retracted))
+                    Cell::from(Line::from(format!("{}", paper.stats.retracted)).alignment(Alignment::Right))
                         .style(Style::default().fg(theme.retracted)),
-                    Cell::from(pct_text).style(pct_style),
+                    Cell::from(Line::from(pct_text).alignment(Alignment::Right)).style(pct_style),
                     Cell::from(status_text).style(phase_style),
                 ])
             } else {
@@ -243,14 +258,14 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
                     Style::default().fg(theme.dim)
                 };
                 Row::new(vec![
-                    Cell::from(num),
+                    Cell::from(Line::from(num).alignment(Alignment::Right)),
                     Cell::from(name).style(name_style),
-                    Cell::from(if paper.total_refs > 0 {
+                    Cell::from(Line::from(if paper.total_refs > 0 {
                         format!("{}", paper.total_refs)
                     } else {
                         "\u{2014}".to_string()
-                    }),
-                    Cell::from(format!("{}", problems)).style(prob_style),
+                    }).alignment(Alignment::Right)),
+                    Cell::from(Line::from(format!("{}", problems)).alignment(Alignment::Right)).style(prob_style),
                     Cell::from(status_text).style(phase_style),
                 ])
             }
@@ -260,7 +275,7 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
     let widths = if wide {
         vec![
             Constraint::Length(4),
-            Constraint::Min(15),
+            Constraint::Fill(1),
             Constraint::Length(5),
             Constraint::Length(5),
             Constraint::Length(5),
@@ -272,7 +287,7 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
     } else {
         vec![
             Constraint::Length(4),
-            Constraint::Min(10),
+            Constraint::Fill(1),
             Constraint::Length(5),
             Constraint::Length(5),
             Constraint::Length(14),


### PR DESCRIPTION
## Summary
- Right-align numeric columns (Refs, OK, Mis, NF, Ret, %) in queue table and use `Fill(1)` for Paper column to prevent layout jitter
- Dismiss DBLP/ACL warning messages from status panel after successful database builds
- Show default build path hint in config when DB path is empty and cursor is on the item
- Rename Activity panel title to Status

**Depends on #100** — GitHub will auto-retarget to `main` when that merges.

## Test plan
- [ ] Verify numeric columns are right-aligned in queue table (both wide and narrow modes)
- [ ] Build a DB from config, confirm warning disappears from status panel
- [ ] With empty DB path, hover DBLP/ACL row and confirm build path hint appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)