### PR TITLE
Fix ref_states/paper.results misalignment after loading sorted JSON

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -313,6 +313,15 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>, Vec<Referen
         });
     }
 
+    // Sort ref_states and references by original position so they align
+    // with paper.results (which is indexed by original position).
+    // This handles JSON files where entries are sorted by severity.
+    let mut pairs: Vec<(RefState, Reference)> = ref_states.into_iter().zip(references).collect();
+    pairs.sort_by_key(|(rs, _)| rs.index);
+    let (sorted_states, sorted_refs): (Vec<_>, Vec<_>) = pairs.into_iter().unzip();
+    ref_states = sorted_states;
+    references = sorted_refs;
+
     // Set total and skipped from loaded stats if available
     if let Some(stats) = &loaded.stats {
         let total = stats.total.filter(|&t| t > 0).unwrap_or(ref_count);


### PR DESCRIPTION
## Summary
- After loading a severity-sorted JSON export, `ref_states` was in JSON (severity) order while `paper.results` was indexed by original position
- This caused `build_sorted_refs()` to produce **wrong reference numbers and FP states** in all re-exported reports (JSON, HTML, CSV, markdown, text)
- Fix: sort `ref_states` and `references` by original index after loading in `convert_loaded()` to restore alignment with `paper.results`

## Test plan
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all` clean
- [x] `cargo test --workspace` — all 328 tests pass
- [ ] Manual roundtrip: run TUI on a paper → export JSON → load JSON → re-export to HTML/JSON → verify ref numbers are stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)