### PR TITLE
Fix splash screen dismissing instantly on startup

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -992,6 +992,7 @@ impl App {
                 Action::Resize(_w, h) => {
                     self.visible_rows = (h as usize).saturating_sub(11);
                 }
+                Action::None => {}
                 _ => {
                     self.dismiss_banner();
                 }


### PR DESCRIPTION
## Summary
- `Action::None` (from focus events, key releases, mouse moves) was falling through to the catch-all `dismiss_banner()` handler in the banner screen match
- Added an explicit `Action::None => {}` arm so only actual user input dismisses the splash

## Test plan
- [x] `cargo check -p hallucinator-tui` — compiles clean
- [x] `cargo clippy` / `cargo fmt` — clean
- [ ] Launch TUI, verify splash stays visible for ~2 seconds before auto-dismissing

🤖 Generated with [Claude Code](https://claude.com/claude-code)