### PR TITLE
Fix export stats showing 0 total refs and 0% problematic

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -1868,6 +1868,9 @@ impl App {
             } => {
                 if let Some(paper) = self.papers.get_mut(paper_index) {
                     paper.total_refs = ref_count;
+                    let skipped = references.iter().filter(|r| r.skip_reason.is_some()).count();
+                    paper.stats.total = references.len();
+                    paper.stats.skipped = skipped;
                     // Allocate result slots for ALL refs (including skipped) so
                     // that remapped indices from the backend fit.
                     paper.init_results(references.len());


### PR DESCRIPTION
## Summary
- Fixes #117 — exported reports (JSON, HTML, CSV, Markdown, text) showed 0 total references and 0% problematic for freshly-checked papers
- Root cause: `stats.total` and `stats.skipped` were never populated during live processing (only on the load-from-JSON path)
- Adds 3 lines in `ExtractionComplete` handler to set both fields from the parsed references

## Test plan
- [ ] @gianlucasb — Run TUI, process a PDF, export as HTML/JSON — verify total count and problematic % are correct
- [ ] @gianlucasb — Load a previously exported JSON, re-export — verify stats still correct (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)