### PR TITLE
TUI quick wins: screen names, spinner fix, quit confirmation

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
@@ -23,7 +23,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect, footer_area: Rect) {
 
     // Header with section tabs
     let mut header_spans = vec![
-        Span::styled(" HALLUCINATOR ", theme.header_style()),
+        Span::styled(" Config ", theme.header_style()),
         Span::styled(
             " > Config  ",
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
@@ -35,7 +35,7 @@ pub fn render_in(
     // --- Breadcrumb ---
     let title_short = truncate(&rs.title, 40);
     let breadcrumb = Line::from(vec![
-        Span::styled(" HALLUCINATOR ", theme.header_style()),
+        Span::styled(" Reference ", theme.header_style()),
         Span::styled(" > ", Style::default().fg(theme.dim)),
         Span::styled(
             &paper.filename,

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
@@ -40,7 +40,7 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
             " > Select PDFs / .bbl / .bib / Archives / Results (.json)".to_string()
         };
     let header = Line::from(vec![
-        Span::styled(" HALLUCINATOR ", theme.header_style()),
+        Span::styled(" Files ", theme.header_style()),
         Span::styled(
             header_text,
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/mod.rs
@@ -7,6 +7,7 @@ pub mod file_picker;
 pub mod help;
 pub mod paper;
 pub mod queue;
+pub mod quit_confirm;
 
 /// Spinner frames for animated progress indication.
 const SPINNER_FRAMES: &[char] = &[

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
@@ -57,7 +57,7 @@ pub fn render_in(f: &mut Frame, app: &mut App, paper_index: usize, area: Rect, f
 
 fn render_breadcrumb(f: &mut Frame, area: Rect, filename: &str, theme: &Theme) {
     let breadcrumb = Line::from(vec![
-        Span::styled(" HALLUCINATOR ", theme.header_style()),
+        Span::styled(" Paper ", theme.header_style()),
         Span::styled(" > ", Style::default().fg(theme.dim)),
         Span::styled(
             filename,
@@ -82,7 +82,11 @@ fn render_progress(
         0.0
     };
 
-    let label = format!("{} {} / {} refs", spinner_char(tick), done, total);
+    let label = if done >= total && total > 0 {
+        format!("\u{2713} {} / {} refs", done, total)
+    } else {
+        format!("{} {} / {} refs", spinner_char(tick), done, total)
+    };
 
     let gauge = Gauge::default()
         .block(

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
@@ -48,7 +48,7 @@ pub fn render_in(f: &mut Frame, app: &mut App, area: Rect, footer_area: Rect) {
 
 fn render_header(f: &mut Frame, area: Rect, app: &App, theme: &Theme) {
     let mut spans = vec![
-        Span::styled(" HALLUCINATOR ", theme.header_style()),
+        Span::styled(" Queue ", theme.header_style()),
         Span::styled(
             " Queue",
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/quit_confirm.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/quit_confirm.rs
@@ -1,0 +1,57 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use crate::theme::Theme;
+
+/// Render the quit confirmation dialog as a centered popup.
+pub fn render(f: &mut Frame, theme: &Theme) {
+    let area = f.area();
+    let popup = centered_rect(40, 5, area);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Quit hallucinator?",
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled(
+                "  q",
+                Style::default()
+                    .fg(theme.not_found)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(": quit   ", Style::default().fg(theme.dim)),
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(theme.active)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(": cancel", Style::default().fg(theme.dim)),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme.not_found))
+            .title(" Confirm Quit "),
+    );
+
+    f.render_widget(Clear, popup);
+    f.render_widget(paragraph, popup);
+}
+
+/// Create a centered rectangle of the given width (columns) and height (rows).
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .split(area);
+    Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .split(vertical[0])[0]
+}


### PR DESCRIPTION
## Summary
- **#134**: Replace redundant "HALLUCINATOR" header span with contextual screen names (Queue, Paper, Reference, Config, Files)
- **#133**: Show checkmark instead of animated spinner in paper progress bar when analysis is complete
- **#132**: Add quit confirmation modal popup — `q` to confirm, `Esc` to cancel. Banner screen and config unsaved-changes prompt bypass it for immediate exit.

## Test plan
- [ ] Verify each screen shows its name (not "HALLUCINATOR") in the green header span
- [ ] Open a fully-analyzed paper and confirm the progress bar shows a checkmark, not a spinner
- [ ] Press `q` on Queue/Paper/Reference/Config/Files — modal popup appears, `Esc` dismisses, second `q` quits
- [ ] Press `q` on the splash/banner screen — exits immediately (no confirmation)
- [ ] Config with unsaved changes → Esc → "save before leaving?" prompt → `q` exits immediately (no double confirmation)

Closes #134, closes #133, closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)