### PR TITLE
Fix problematic reference percentage denominator

### DIFF
--- a/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
+++ b/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
@@ -113,12 +113,11 @@ fn build_sorted_refs<'a>(paper: &ReportPaper<'a>, paper_refs: &[ReportRef]) -> V
 }
 
 fn problematic_pct(stats: &CheckStats) -> f64 {
-    let checked = stats.total.saturating_sub(stats.skipped);
-    if checked == 0 {
+    if stats.total == 0 {
         0.0
     } else {
         let problems = stats.not_found + stats.author_mismatch + stats.retracted;
-        (problems as f64 / checked as f64) * 100.0
+        (problems as f64 / stats.total as f64) * 100.0
     }
 }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
@@ -120,13 +120,12 @@ impl PaperState {
         self.stats.not_found + self.stats.author_mismatch + self.stats.retracted
     }
 
-    /// Percentage of checked references that are problematic (0.0 - 100.0).
+    /// Percentage of total references that are problematic (0.0 - 100.0).
     pub fn problematic_pct(&self) -> f64 {
-        let checked = self.total_refs.saturating_sub(self.stats.skipped);
-        if checked == 0 {
+        if self.total_refs == 0 {
             0.0
         } else {
-            (self.problems() as f64 / checked as f64) * 100.0
+            (self.problems() as f64 / self.total_refs as f64) * 100.0
         }
     }
 }


### PR DESCRIPTION
## Summary
- Problematic reference percentage was using `total - skipped` as the denominator, inflating the reported rate when references were skipped
- Now uses `total_refs` as the denominator in both `hallucinator-tui` and `hallucinator-reporting`

Fixes #140

## Test plan
- [x] Existing `test_problematic_pct_normal` and `test_problematic_pct_zero_checked` pass
- [ ] Visual: queue table `% flagged` column shows lower values when skipped refs are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)