### PR TITLE
Port remaining regex improvements to Rust engine

### DIFF
--- a/hallucinator-rs/crates/hallucinator-dblp/src/query.rs
+++ b/hallucinator-rs/crates/hallucinator-dblp/src/query.rs
@@ -20,8 +20,15 @@ fn normalize_title(title: &str) -> String {
 }
 
 /// Extract meaningful query words for FTS5 MATCH (4+ chars, no stop words).
+///
+/// Handles digits (`L2`, `3D`), hyphens (`Machine-Learning`), and apostrophes (`What's`).
+/// Also strips BibTeX braces (`{BERT}` → `BERT`).
 fn get_query_words(title: &str) -> Vec<String> {
-    static WORD_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"[a-zA-Z]+").unwrap());
+    // Strip BibTeX capitalization braces
+    let title = title.replace(['{', '}'], "");
+
+    static WORD_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"[a-zA-Z0-9]+(?:['\u{2019}\u{2018}\-][a-zA-Z0-9]+)*").unwrap());
     static STOP_WORDS: Lazy<std::collections::HashSet<&'static str>> = Lazy::new(|| {
         [
             "the", "and", "for", "with", "from", "that", "this", "have", "are", "was", "were",
@@ -36,7 +43,7 @@ fn get_query_words(title: &str) -> Vec<String> {
     });
 
     WORD_RE
-        .find_iter(title)
+        .find_iter(&title)
         .map(|m| m.as_str().to_lowercase())
         .filter(|w| w.len() >= 4 && !STOP_WORDS.contains(w.as_str()))
         .collect()
@@ -168,6 +175,27 @@ mod tests {
         assert!(words.contains(&"need".to_string()));
         // "is", "all", "you" are too short or stop words
         assert!(!words.contains(&"is".to_string()));
+    }
+
+    #[test]
+    fn test_get_query_words_bibtex_braces() {
+        let words = get_query_words("{BERT}: Pre-training of Deep Bidirectional Transformers");
+        assert!(words.contains(&"bert".to_string()));
+        assert!(words.contains(&"pre-training".to_string()));
+    }
+
+    #[test]
+    fn test_get_query_words_hyphenated() {
+        let words = get_query_words("Machine-Learning Approaches for Natural Language");
+        assert!(words.contains(&"machine-learning".to_string()));
+    }
+
+    #[test]
+    fn test_get_query_words_digits() {
+        let words = get_query_words("L2 Regularization for 3D Point Cloud Models");
+        // "l2" and "3d" are too short, but "point", "cloud", "models" should be present
+        assert!(words.contains(&"point".to_string()));
+        assert!(words.contains(&"regularization".to_string()));
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-pdf/src/title.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf/src/title.rs
@@ -1084,6 +1084,8 @@ fn split_sentences_skip_initials(text: &str) -> Vec<String> {
             Regex::new(&format!(r"(?i)^([A-Z]{}+)\s+and\s+[A-Z]", sc)).unwrap(),
             // Multi-part surname: "Van Goethem,"
             Regex::new(&format!(r"^([A-Z]{}+)\s+([A-Z]{}+)\s*,", sc, sc)).unwrap(),
+            // Middle initial without period: "D Kaplan,"
+            Regex::new(&format!(r"^[A-Z]\s+({}+)\s*,", sc)).unwrap(),
         ]
     });
 
@@ -1281,6 +1283,35 @@ mod tests {
         assert_eq!(parts.len(), 3);
         assert!(parts[0].contains("Smith"));
         assert!(parts[1].contains("Novel Detection"));
+    }
+
+    #[test]
+    fn test_split_sentences_middle_initial_no_period() {
+        // "D Kaplan" has a middle initial without its period — should stay in author section
+        let text = "J. D Kaplan, P. Dhariwal. Title here.";
+        let parts = split_sentences_skip_initials(text);
+        assert!(
+            parts[0].contains("Kaplan"),
+            "Kaplan should be in author segment: {:?}",
+            parts
+        );
+        assert!(
+            parts[0].contains("Dhariwal"),
+            "Dhariwal should be in author segment: {:?}",
+            parts
+        );
+    }
+
+    #[test]
+    fn test_split_sentences_middle_initial_no_period_variant() {
+        // Multiple authors with missing-period initials, separated by commas
+        let text = "A. B Smith, C. D Jones, E. Brown. Some interesting research.";
+        let parts = split_sentences_skip_initials(text);
+        assert!(
+            parts[0].contains("Jones"),
+            "Jones should be in author segment: {:?}",
+            parts
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Ports the 4 remaining regex improvements from `regexp_improvements.py` into the Rust engine (17 of 21 were already implemented)
- Adds **BibTeX brace stripping** (`{BERT}` → `BERT`) to `get_query_words()` in hallucinator-pdf, hallucinator-dblp, and hallucinator-acl
- Updates **DBLP/ACL query word regex** from `[a-zA-Z]+` to support digits (`L2`, `3D`), hyphens (`Machine-Learning`), and apostrophes (`What's`)
- Adds **middle-initial-without-period** pattern (`D Kaplan,`) to author detection in title sentence splitting
- Adds **conservative prefix matching** with subtitle awareness to `titles_match()` — prevents false matches where a short title ending in `?` incorrectly matches a longer, different paper that starts the same way

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy` — no new warnings
- [x] `cargo test -p hallucinator-pdf` — 138 passed
- [x] `cargo test -p hallucinator-core` — 83 passed
- [x] `cargo test -p hallucinator-dblp` — 32 passed
- [x] `cargo test -p hallucinator-acl` — 16 passed
- [x] 15 new unit tests added across 5 files

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)