### PR TITLE
Configurable cache TTLs, persistence fix, and TUI diagnostics

### DIFF
--- a/hallucinator-rs/crates/hallucinator-python/src/config.rs
+++ b/hallucinator-rs/crates/hallucinator-python/src/config.rs
@@ -79,8 +79,13 @@ impl PyValidatorConfig {
             max_rate_limit_retries: self.max_rate_limit_retries,
             rate_limiters,
             cache_path: self.cache_path.as_ref().map(PathBuf::from),
+            cache_positive_ttl_secs: hallucinator_core::DEFAULT_POSITIVE_TTL.as_secs(),
+            cache_negative_ttl_secs: hallucinator_core::DEFAULT_NEGATIVE_TTL.as_secs(),
+            searxng_url: None,
             query_cache: Some(hallucinator_core::build_query_cache(
                 self.cache_path.as_ref().map(std::path::Path::new),
+                hallucinator_core::DEFAULT_POSITIVE_TTL.as_secs(),
+                hallucinator_core::DEFAULT_NEGATIVE_TTL.as_secs(),
             )),
         })
     }

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/activity.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/activity.rs
@@ -105,7 +105,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
         } else {
             String::new()
         };
-        let bar_color = if health.in_flight > max_in_flight / 2 {
+        let bar_color = if health.in_flight > max_in_flight.max(8) / 2 {
             Color::Yellow
         } else {
             theme.active
@@ -293,6 +293,38 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
         ),
         Style::default().fg(theme.text),
     )));
+    // Cache detail
+    if let Some(cache) = &app.current_query_cache {
+        let (l1_found, l1_nf) = cache.l1_counts();
+        let (l2_found, l2_nf) = cache.l2_counts();
+        let total = cache.disk_len();
+        lines.push(Line::from(Span::styled(
+            format!(" Cache  {} entries", total),
+            Style::default().fg(theme.dim),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled("   mem:  ", Style::default().fg(theme.dim)),
+            Span::styled(format!("{}", l1_found), Style::default().fg(theme.verified)),
+            Span::styled(" found  ", Style::default().fg(theme.dim)),
+            Span::styled(format!("{}", l1_nf), Style::default().fg(theme.not_found)),
+            Span::styled(" not-found", Style::default().fg(theme.dim)),
+        ]));
+        if cache.has_persistence() {
+            lines.push(Line::from(vec![
+                Span::styled("   disk: ", Style::default().fg(theme.dim)),
+                Span::styled(
+                    format!("{}", l2_found),
+                    Style::default().fg(theme.verified),
+                ),
+                Span::styled(" found  ", Style::default().fg(theme.dim)),
+                Span::styled(
+                    format!("{}", l2_nf),
+                    Style::default().fg(theme.not_found),
+                ),
+                Span::styled(" not-found", Style::default().fg(theme.dim)),
+            ]));
+        }
+    }
     let rss_mb = app.measured_rss_bytes as f64 / (1024.0 * 1024.0);
     lines.push(Line::from(Span::styled(
         format!(" FPS: {:.0}  RSS: {:.1} MB", app.measured_fps, rss_mb),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/config.rs
@@ -313,9 +313,23 @@ fn render_databases(lines: &mut Vec<Line>, config: &ConfigState, theme: &Theme, 
         btn_style,
     )));
 
-    // Item 4: SearxNG URL (editable)
+    // Item 4: Clear Not-Found button
     let cursor = if config.item_cursor == 4 { "> " } else { "  " };
-    let display_val = if config.editing && config.item_cursor == 4 {
+    let btn_style = if config.item_cursor == 4 {
+        Style::default()
+            .fg(theme.author_mismatch)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.dim)
+    };
+    lines.push(Line::from(Span::styled(
+        format!("  {}[Clear Not-Found]", cursor),
+        btn_style,
+    )));
+
+    // Item 5: SearxNG URL (editable)
+    let cursor = if config.item_cursor == 5 { "> " } else { "  " };
+    let display_val = if config.editing && config.item_cursor == 5 {
         format!("{}\u{2588}", config.edit_buffer)
     } else {
         match &config.searxng_url {
@@ -323,7 +337,7 @@ fn render_databases(lines: &mut Vec<Line>, config: &ConfigState, theme: &Theme, 
             None => "(disabled)".to_string(),
         }
     };
-    let val_style = if config.editing && config.item_cursor == 4 {
+    let val_style = if config.editing && config.item_cursor == 5 {
         Style::default().fg(theme.active)
     } else if config.searxng_url.is_some() {
         Style::default().fg(theme.verified)
@@ -342,7 +356,7 @@ fn render_databases(lines: &mut Vec<Line>, config: &ConfigState, theme: &Theme, 
 
     // Items 5..N: DB toggles
     for (i, (name, enabled)) in config.disabled_dbs.iter().enumerate() {
-        let item_idx = i + 5; // offset by 5 for DBLP + ACL + cache_path + clear_cache + searxng_url
+        let item_idx = i + 6; // offset by 6 for DBLP + ACL + cache_path + clear_cache + clear_not_found + searxng_url
         let cursor = if config.item_cursor == item_idx {
             "> "
         } else {


### PR DESCRIPTION
## Summary
- **Fix cache persistence bug**: both found and not-found results now persist to SQLite L2 (was only persisting found entries, breaking cross-session cache hits)
- **Configurable TTLs**: positive (found) and negative (not-found) TTLs exposed via Config (default 7 days / 24 hours)
- **Zero negative TTL** disables caching of not-found entries entirely
- **`clear_not_found()`**: selectively purge negative cache entries without nuking everything
- **Clear Not-Found button** in TUI config panel
- **Atomic counters** replace per-frame SQLite COUNT queries for `l1_counts`/`l2_counts`/`disk_len` (initialized once on open, updated on insert/clear)
- **Cache stats** in TUI activity summary: total persistent entries, mem/disk found/not-found breakdown
- **Cache open log message** in activity messages panel (similar to DBLP/ACL DB load messages)

## Test plan
- [x] `cargo check` full workspace — clean, no warnings
- [x] `cargo test -p hallucinator-core --lib cache` — all 35 tests pass
- [ ] Manual TUI testing: verify cache stats update in real-time during a batch run
- [ ] Verify cache DB grows between runs (the original bug)
- [ ] Test Clear Not-Found from config panel, verify only not-found entries removed

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)