### PR TITLE
Fix title extraction for ACM year-first and arXiv preprint formats

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-ingest"
-version = "0.1.1-alpha.2"
+version = "0.1.1-alpha.3"
 dependencies = [
  "flate2",
  "hallucinator-bbl",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-pdf-mupdf"
-version = "0.1.1-alpha.2"
+version = "0.1.1-alpha.3"
 dependencies = [
  "hallucinator-pdf",
  "mupdf",


### PR DESCRIPTION
## Summary
- Handle ACM `[n. d.]` (no date) marker in `try_acm_year` regex
- Add `try_arxiv_preprint` extractor for "Authors. Title. Year. arXiv: ID" format
- Strip leading year from ACM-style titles in `clean_title` (before sentence truncation)
- Fix `is_journal_metadata` to not reject titles starting with "In " (e.g., "In numeris veritas")
- Add `et al.:` pattern support in `try_lncs`
- Reject arXiv IDs, DOI URLs, and code snippets as titles

## Test plan
- [x] All 143 lib tests pass
- [x] All 75 integration tests pass
- [x] Manual verification on ACM papers

🤖 Generated with [Claude Code](https://claude.ai/code)