### PR TITLE
Move FPS/RSS to footer bar, bound extraction concurrency

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/view/activity.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/activity.rs
@@ -319,12 +319,6 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
             ]));
         }
     }
-    let rss_mb = app.measured_rss_bytes as f64 / (1024.0 * 1024.0);
-    lines.push(Line::from(Span::styled(
-        format!(" FPS: {:.0}  RSS: {:.1} MB", app.measured_fps, rss_mb),
-        Style::default().fg(theme.dim),
-    )));
-
     // Log messages (archive extraction, errors)
     if !activity.messages.is_empty() {
         lines.push(Line::from(""));

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/banner.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/banner.rs
@@ -860,8 +860,8 @@ pub fn render_logo_bar(
         return chunks[1];
     }
 
-    // 5-line bar: logo+icon left, tip pane right
     let rows = Layout::vertical([Constraint::Length(5), Constraint::Min(0)]).split(area);
+
     let cols = Layout::horizontal([Constraint::Length(logo_glass_width), Constraint::Min(15)])
         .split(rows[0]);
 
@@ -879,9 +879,10 @@ pub fn render_logo_bar(
             Span::styled(icon_line.to_string(), Style::default().fg(theme.text)),
         ]));
     }
-    // Row 3: blank separator, Row 4: stats
+
+    // Blank line + stats line below logo (fits within the 5-row column)
+    logo_lines.push(Line::from(""));
     if let Some(stats) = stats_line {
-        logo_lines.push(Line::raw(""));
         logo_lines.push(stats);
     }
 


### PR DESCRIPTION
## Summary
- Move FPS/RSS counters from the activity panel and banner stats line into the right-aligned footer bar, fixing clipping when the stats string exceeded the 59-char logo column
- Revert banner to original 5-row layout (remaining stats fit within logo column)
- Bound PDF extraction concurrency to `available_parallelism()` workers via a channel-based pool, preventing resource exhaustion when processing large archives

## Files changed
- `hallucinator-tui/src/app.rs` — remove FPS/RSS from `build_stats_line()`, add `build_footer_right()` helper, render it after each screen's footer
- `hallucinator-tui/src/view/banner.rs` — revert to 5-row layout, render stats inside logo paragraph
- `hallucinator-tui/src/view/activity.rs` — remove FPS/RSS from activity panel summary
- `hallucinator-tui/src/backend.rs` — add bounded extraction worker pool

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all` passes
- [ ] Visually confirm: stats line fits in logo column, FPS/RSS visible right-aligned in footer
- [ ] Test with large archive to verify extraction doesn't exhaust resources

Closes #177
Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)