### PR TITLE
Fix citation counts not adding up (#163)

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app.rs
@@ -2499,7 +2499,7 @@ impl App {
         let theme = &self.theme;
         let total = self.papers.len();
         let done = self.papers.iter().filter(|p| p.phase.is_terminal()).count();
-        let total_refs: usize = self.papers.iter().map(|p| p.total_refs).sum();
+        let total_refs: usize = self.papers.iter().map(|p| p.stats.total).sum();
         let total_verified: usize = self.papers.iter().map(|p| p.stats.verified).sum();
         let total_not_found: usize = self.papers.iter().map(|p| p.stats.not_found).sum();
         let total_mismatch: usize = self.papers.iter().map(|p| p.stats.author_mismatch).sum();

--- a/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
@@ -189,12 +189,9 @@ async fn process_single_paper(
     let skip_stats = extraction.skip_stats.clone();
     let all_refs = extraction.references;
 
-    // Count only non-skipped refs for the ref_count (used for stats/progress)
-    let checkable_count = all_refs.iter().filter(|r| r.skip_reason.is_none()).count();
-
     let _ = tx.send(BackendEvent::ExtractionComplete {
         paper_index,
-        ref_count: checkable_count,
+        ref_count: all_refs.len(),
         references: all_refs.clone(),
         skip_stats,
     });

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
@@ -129,13 +129,14 @@ impl PaperState {
 
     /// Percentage of references that are problematic (0.0 - 100.0).
     ///
-    /// Uses `total_refs` as the denominator (checkable refs only — skipped refs
-    /// are excluded at extraction time and never enter the validation pipeline).
+    /// Uses checkable refs (total minus skipped) as the denominator so the
+    /// percentage reflects only refs that actually entered the validation pipeline.
     pub fn problematic_pct(&self) -> f64 {
-        if self.total_refs == 0 {
+        let checkable = self.total_refs.saturating_sub(self.stats.skipped);
+        if checkable == 0 {
             0.0
         } else {
-            (self.problems() as f64 / self.total_refs as f64) * 100.0
+            (self.problems() as f64 / checkable as f64) * 100.0
         }
     }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
@@ -75,17 +75,17 @@ fn render_progress(
     theme: &Theme,
 ) {
     let done = paper.completed_count();
-    let total = paper.total_refs;
-    let ratio = if total > 0 {
-        done as f64 / total as f64
+    let checkable = paper.total_refs.saturating_sub(paper.stats.skipped);
+    let ratio = if checkable > 0 {
+        done as f64 / checkable as f64
     } else {
         0.0
     };
 
-    let label = if done >= total && total > 0 {
-        format!("\u{2713} {} / {} refs", done, total)
+    let label = if done >= checkable && checkable > 0 {
+        format!("\u{2713} {} / {} refs", done, checkable)
     } else {
-        format!("{} {} / {} refs", spinner_char(tick), done, total)
+        format!("{} {} / {} refs", spinner_char(tick), done, checkable)
     };
 
     let gauge = Gauge::default()

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
@@ -76,22 +76,21 @@ fn render_progress_bar(f: &mut Frame, area: Rect, app: &App, theme: &Theme) {
         0.0
     };
 
-    // Build a text progress bar: ██████░░░░ 12/50
-    let bar_width = (area.width as usize).saturating_sub(12);
+    // Build a text progress bar: ██████░░░░ 12/50 0:30
+    let elapsed = app.elapsed();
+    let elapsed_str = format!("{}:{:02}", elapsed.as_secs() / 60, elapsed.as_secs() % 60);
+    let count_str = format!(" {}/{} ", done, total);
+    let non_bar = 1 + count_str.len() + elapsed_str.len(); // leading space + count + timer
+    let bar_width = (area.width as usize).saturating_sub(non_bar);
     let filled = (ratio * bar_width as f64) as usize;
     let empty = bar_width.saturating_sub(filled);
 
     let bar: String = "\u{2588}".repeat(filled) + &"\u{2591}".repeat(empty);
-    let elapsed = app.elapsed();
-    let elapsed_str = format!("{}:{:02}", elapsed.as_secs() / 60, elapsed.as_secs() % 60);
 
     let mut spans = vec![
         Span::styled(" ", Style::default()),
         Span::styled(&bar, Style::default().fg(theme.active)),
-        Span::styled(
-            format!(" {}/{} ", done, total),
-            Style::default().fg(theme.text),
-        ),
+        Span::styled(count_str, Style::default().fg(theme.text)),
         Span::styled(elapsed_str, Style::default().fg(theme.dim)),
     ];
 


### PR DESCRIPTION
## Summary
- Send total ref count (including skipped) as `ref_count` so `Refs = V + M + NF + Skip + Ret` adds up in the queue and stats bar
- Adjust `problematic_pct()` denominator and paper progress bar to exclude skipped refs, keeping percentages and completion tracking meaningful
- Fix queue progress bar width calculation to dynamically size based on actual content length, preventing the timer from being truncated with large paper counts

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all` clean
- [ ] Run TUI with a batch of papers containing skipped refs — verify `Refs` count in the stats bar equals `V + M + NF + Skip + Ret`
- [ ] Verify progress bar on paper detail view fills to 100% and shows correct `done/total` (excluding skipped)
- [ ] Verify queue progress bar timer is fully visible with large paper counts (100+)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)