### PR TITLE
Add NotFound sort mode and reverse sort direction

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/action.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/action.rs
@@ -11,6 +11,7 @@ pub enum Action {
     GoTop,
     GoBottom,
     CycleSort,
+    ReverseSortDirection,
     CycleFilter,
     ToggleHelp,
     StartSearch,

--- a/hallucinator-rs/crates/hallucinator-tui/src/input.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/input.rs
@@ -45,6 +45,7 @@ fn map_key_normal(key: &KeyEvent) -> Action {
         KeyCode::Char('g') => Action::GoTop,
         KeyCode::Char('G') => Action::GoBottom,
         KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::SaveConfig,
+        KeyCode::Char('S') => Action::ReverseSortDirection,
         KeyCode::Char('s') => Action::CycleSort,
         KeyCode::Char('f') => Action::CycleFilter,
         KeyCode::Char('/') => Action::StartSearch,

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
@@ -146,6 +146,7 @@ impl PaperState {
 pub enum SortOrder {
     Original,
     Problems,
+    NotFound,
     ProblematicPct,
     Name,
 }
@@ -154,7 +155,8 @@ impl SortOrder {
     pub fn next(self) -> Self {
         match self {
             Self::Original => Self::Problems,
-            Self::Problems => Self::ProblematicPct,
+            Self::Problems => Self::NotFound,
+            Self::NotFound => Self::ProblematicPct,
             Self::ProblematicPct => Self::Name,
             Self::Name => Self::Original,
         }
@@ -164,6 +166,7 @@ impl SortOrder {
         match self {
             Self::Original => "order",
             Self::Problems => "problems",
+            Self::NotFound => "not found",
             Self::ProblematicPct => "% flagged",
             Self::Name => "name",
         }

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
@@ -9,7 +9,7 @@ use crate::theme::Theme;
 /// Render the help overlay as a centered popup.
 pub fn render(f: &mut Frame, theme: &Theme) {
     let area = f.area();
-    let popup = centered_rect(72, 44, area);
+    let popup = centered_rect(72, 45, area);
 
     let lines = vec![
         Line::from(Span::styled(
@@ -34,6 +34,7 @@ pub fn render(f: &mut Frame, theme: &Theme) {
         // Sorting & Filtering
         section_header("Sorting & Filtering", theme),
         key_line("s", "Cycle sort order", theme),
+        key_line("S", "Reverse sort direction", theme),
         key_line("f", "Cycle filter", theme),
         key_line("/", "Start search", theme),
         key_line("n / N", "Next / previous match", theme),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
@@ -287,7 +287,15 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(theme.border_style())
-                .title(format!(" Sort: {} (s) ", app.sort_order.label())),
+                .title(
+                    if app.sort_order == crate::model::queue::SortOrder::Original {
+                        format!(" Sort: {} (s) ", app.sort_order.label())
+                    } else if app.sort_reversed {
+                        format!(" Sort: {} \u{2191} (s) ", app.sort_order.label())
+                    } else {
+                        format!(" Sort: {} \u{2193} (s) ", app.sort_order.label())
+                    },
+                ),
         )
         .row_highlight_style(theme.highlight_style());
 
@@ -323,12 +331,12 @@ fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::styled(
-            " Space:mark  Enter:open  s:sort  f:filter  c:config  e:export  ?:help",
+            " Space:mark  Enter:open  s/S:sort  f:filter  c:config  e:export  ?:help",
             theme.footer_style(),
         ));
     } else {
         spans.push(Span::styled(
-            " Space:mark  Enter:open  s:sort  f:filter  o:add  c:config  e:export  ?:help  q:quit",
+            " Space:mark  Enter:open  s/S:sort  f:filter  o:add  c:config  e:export  ?:help  q:quit",
             theme.footer_style(),
         ));
     }


### PR DESCRIPTION
## Summary
- Add **"not found"** sort mode to the queue table, sorting by `stats.not_found` count descending (cycle: order → problems → **not found** → % flagged → name)
- Add **Shift+S** keybinding to reverse sort direction, with `↓`/`↑` arrow indicators in the table title
- Cycling sort mode with `s` resets direction to default (descending)

Closes #197

## Test plan
- [ ] TUI: press `s` repeatedly — verify cycle includes new "not found" mode between "problems" and "% flagged"
- [ ] TUI: press `S` — verify sort direction reverses and arrow indicator toggles (`↓` ↔ `↑`)
- [ ] TUI: press `s` after reversing — verify direction resets to default (`↓`)
- [ ] TUI: verify "Original" sort shows no arrow indicator
- [ ] Verify footer shows `s/S:sort` hint
- [ ] Verify help overlay (`?`) shows `S` → "Reverse sort direction"

🤖 Generated with [Claude Code](https://claude.com/claude-code)