### PR TITLE
Add Reference constructor and fix Python bindings compilation

### DIFF
--- a/hallucinator-rs/crates/hallucinator-python/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-python/Cargo.toml
@@ -15,9 +15,12 @@ pdf = ["hallucinator-pdf/pdf"]
 
 [dependencies]
 hallucinator-pdf = { path = "../hallucinator-pdf", default-features = false }
+hallucinator-pdf-mupdf = { path = "../hallucinator-pdf-mupdf" }
+hallucinator-ingest = { path = "../hallucinator-ingest" }
 hallucinator-core = { path = "../hallucinator-core" }
 hallucinator-dblp = { path = "../hallucinator-dblp" }
 hallucinator-acl = { path = "../hallucinator-acl" }
+hallucinator-openalex = { path = "../hallucinator-openalex" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-util = "0.7"
 pyo3 = { version = "0.23", features = ["extension-module"] }

--- a/hallucinator-rs/crates/hallucinator-python/src/types.rs
+++ b/hallucinator-rs/crates/hallucinator-python/src/types.rs
@@ -23,6 +23,36 @@ impl PyReference {
 
 #[pymethods]
 impl PyReference {
+    /// Create a Reference manually (without PDF extraction).
+    ///
+    /// Args:
+    ///     title: The paper title (used for database lookups).
+    ///     authors: List of author names (used for verification). Defaults to ``[]``.
+    ///     doi: The DOI, if known (enables fast DOI-based validation).
+    ///     arxiv_id: The arXiv ID, if known.
+    ///     raw_citation: Raw citation text for display. Defaults to the title.
+    #[new]
+    #[pyo3(signature = (title, authors=vec![], doi=None, arxiv_id=None, raw_citation=None))]
+    fn new(
+        title: String,
+        authors: Vec<String>,
+        doi: Option<String>,
+        arxiv_id: Option<String>,
+        raw_citation: Option<String>,
+    ) -> Self {
+        Self {
+            inner: Reference {
+                raw_citation: raw_citation.unwrap_or_else(|| title.clone()),
+                title: Some(title),
+                authors,
+                doi,
+                arxiv_id,
+                original_number: 0,
+                skip_reason: None,
+            },
+        }
+    }
+
     /// The raw citation text (cleaned up for display).
     #[getter]
     fn raw_citation(&self) -> &str {

--- a/hallucinator-rs/python/examples/batch_validate.py
+++ b/hallucinator-rs/python/examples/batch_validate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Batch-validate references without PDF extraction.
+
+Creates Reference objects directly from structured data (e.g. a CSV or
+BibTeX parser) and validates them against academic databases.
+
+This addresses the use case from issue #178 — validating references when
+you already have titles, authors, and DOIs without needing a PDF.
+"""
+
+from hallucinator import Reference, Validator, ValidatorConfig
+
+# Build references from structured data — no PDF needed.
+refs = [
+    Reference(
+        "Attention Is All You Need",
+        authors=["Vaswani", "Shazeer", "Parmar", "Uszkoreit", "Jones"],
+    ),
+    Reference(
+        "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
+        authors=["Devlin", "Chang", "Lee", "Toutanova"],
+        doi="10.18653/v1/N19-1423",
+    ),
+    Reference(
+        "A Completely Made Up Paper Title That Does Not Exist Anywhere",
+        authors=["Fakename", "Notreal"],
+    ),
+]
+
+# Configure and validate
+config = ValidatorConfig()
+validator = Validator(config)
+
+
+def on_progress(event):
+    if event.event_type == "checking":
+        print(f"  [{event.index + 1}/{event.total}] Checking: {event.title}")
+    elif event.event_type == "result":
+        r = event.result
+        icon = {"verified": "+", "not_found": "?", "author_mismatch": "~"}[r.status]
+        src = f" ({r.source})" if r.source else ""
+        print(f"  [{icon}] {r.title}{src}")
+
+
+print(f"Validating {len(refs)} references...\n")
+results = validator.check(refs, progress=on_progress)
+
+# Summary
+stats = Validator.stats(results)
+print(f"\nVerified: {stats.verified}/{stats.total}")
+if stats.not_found:
+    print(f"Potentially hallucinated: {stats.not_found}")

--- a/hallucinator-rs/python/hallucinator/__init__.pyi
+++ b/hallucinator-rs/python/hallucinator/__init__.pyi
@@ -8,12 +8,44 @@ from hallucinator._native import DbResult as DbResult
 from hallucinator._native import DoiInfo as DoiInfo
 from hallucinator._native import ExtractionResult as ExtractionResult
 from hallucinator._native import ProgressEvent as ProgressEvent
-from hallucinator._native import Reference as Reference
 from hallucinator._native import RetractionInfo as RetractionInfo
 from hallucinator._native import SkipStats as SkipStats
 from hallucinator._native import ValidationResult as ValidationResult
 from hallucinator._native import Validator as Validator
 from hallucinator._native import ValidatorConfig as ValidatorConfig
+from hallucinator._native import ArchiveEntry as ArchiveEntry
+from hallucinator._native import ArchiveIterator as ArchiveIterator
+from hallucinator._native import is_archive_path as is_archive_path
+
+class Reference:
+    """A parsed reference with structured fields.
+
+    Can be created manually for batch validation without PDF extraction.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        authors: list[str] = ...,
+        doi: Optional[str] = None,
+        arxiv_id: Optional[str] = None,
+        raw_citation: Optional[str] = None,
+    ) -> None: ...
+
+    @property
+    def raw_citation(self) -> str: ...
+    @property
+    def title(self) -> Optional[str]: ...
+    @property
+    def authors(self) -> list[str]: ...
+    @property
+    def doi(self) -> Optional[str]: ...
+    @property
+    def arxiv_id(self) -> Optional[str]: ...
+    @property
+    def original_number(self) -> int: ...
+    @property
+    def skip_reason(self) -> Optional[str]: ...
 
 class PdfExtractor:
     """A configurable PDF reference extractor with custom strategy support.
@@ -68,3 +100,6 @@ class PdfExtractor:
     def extract_from_text(self, text: str) -> ExtractionResult: ...
     def extract(self, path: str) -> ExtractionResult: ...
     def extract_text(self, path: str) -> str: ...
+    def extract_archive(
+        self, path: str, max_size_bytes: int = 0
+    ) -> ArchiveIterator: ...


### PR DESCRIPTION
## Summary

- Fix 9 compilation errors in `hallucinator-python` from API drift (archive module moved to `hallucinator-ingest`, PDF extraction now uses `PdfBackend` trait, `DbStatus::RateLimited` variant added)
- Add `Reference` constructor enabling batch validation without PDF extraction (relates to #178)
- Expose `openalex_offline_path`, `cache_positive_ttl_secs`, `cache_negative_ttl_secs`, and `searxng_url` config fields with their existing defaults
- Fix `ProgressEvent` getters for rate-limit events (`db_name`, `ref_index`, `attempt`, `wait_ms`, `backoff_ms`)
- Update PYTHON_BINDINGS.md with constructor docs, batch usage, archive extraction, and all new config fields
- Update type stubs and add `batch_validate.py` example
- Add 21 new offline Python tests (76 total pass)

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] `maturin develop --release` builds wheel
- [x] `uv run pytest tests/ -m "not network" -v` — all 76 offline tests pass
- [ ] Verify batch validation workflow: `python -c "from hallucinator import Reference, Validator, ValidatorConfig; r = Reference('test'); print(r)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)