### PR TITLE
Export improvements, CLI --json, HTML report UX

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-acl"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-bbl"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "biblatex",
  "hallucinator-core",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-cli"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1264,6 +1264,7 @@ dependencies = [
  "hallucinator-openalex",
  "hallucinator-pdf",
  "hallucinator-pdf-mupdf",
+ "hallucinator-reporting",
  "indicatif",
  "owo-colors",
  "tempfile",
@@ -1274,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-core"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -1306,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-dblp"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1325,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-ingest"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "flate2",
  "hallucinator-bbl",
@@ -1340,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-openalex"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "async-compression",
  "flate2",
@@ -1361,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-pdf"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "flate2",
  "hallucinator-bbl",
@@ -1376,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-pdf-mupdf"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "hallucinator-pdf",
  "mupdf",
@@ -1384,14 +1385,14 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-reporting"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "hallucinator-core",
 ]
 
 [[package]]
 name = "hallucinator-tui"
-version = "0.1.1-alpha.4"
+version = "0.1.1-alpha.5"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/hallucinator-rs/crates/hallucinator-cli/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-cli/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 hallucinator-core.workspace = true
 hallucinator-ingest.workspace = true
+hallucinator-reporting.workspace = true
 hallucinator-pdf.workspace = true
 hallucinator-pdf-mupdf.workspace = true
 hallucinator-bbl.workspace = true

--- a/hallucinator-rs/crates/hallucinator-core/src/checker.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/checker.rs
@@ -6,8 +6,8 @@ use crate::orchestrator::query_all_databases;
 use crate::pool::{RefJob, ValidationPool};
 use crate::retraction::check_retraction;
 use crate::{
-    ArxivInfo, Config, DbResult, DbStatus, DoiInfo, ProgressEvent, Reference, RetractionInfo,
-    Status, ValidationResult,
+    Config, DbResult, DbStatus, DoiInfo, ProgressEvent, Reference, RetractionInfo, Status,
+    ValidationResult,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -357,11 +357,7 @@ pub async fn check_single_reference(
         failed_dbs: db_result.failed_dbs,
         db_results: db_result.db_results,
         doi_info,
-        arxiv_info: reference.arxiv_id.as_ref().map(|id| ArxivInfo {
-            arxiv_id: id.clone(),
-            valid: false, // Will be validated separately if needed
-            title: None,
-        }),
+        arxiv_info: None, // TODO(#124): implement arXiv ID validation
         retraction_info,
     }
 }

--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -19,8 +19,7 @@ use crate::db::searxng::Searxng;
 use crate::orchestrator::{build_database_list, query_local_databases};
 use crate::rate_limit::{self, DbQueryError, DoiContext};
 use crate::{
-    ArxivInfo, Config, DbResult, DbStatus, DoiInfo, ProgressEvent, Reference, Status,
-    ValidationResult,
+    Config, DbResult, DbStatus, DoiInfo, ProgressEvent, Reference, Status, ValidationResult,
 };
 
 // ── Public API (unchanged) ──────────────────────────────────────────────
@@ -570,11 +569,7 @@ async fn finalize_collector(collector: &RefCollector) {
         failed_dbs: all_failed_dbs,
         db_results: all_db_results,
         doi_info,
-        arxiv_info: collector.reference.arxiv_id.as_ref().map(|id| ArxivInfo {
-            arxiv_id: id.clone(),
-            valid: false,
-            title: None,
-        }),
+        arxiv_info: None, // TODO(#124): implement arXiv ID validation
         retraction_info,
     };
 
@@ -828,11 +823,7 @@ async fn coordinator_loop(
                             failed_dbs: local_result.failed_dbs.clone(),
                             db_results,
                             doi_info: None,
-                            arxiv_info: reference.arxiv_id.as_ref().map(|id| ArxivInfo {
-                                arxiv_id: id.clone(),
-                                valid: false,
-                                title: None,
-                            }),
+                            arxiv_info: None, // TODO(#124): implement arXiv ID validation
                             retraction_info: None,
                         }
                     } else {
@@ -948,11 +939,7 @@ async fn coordinator_loop(
                 failed_dbs: local_result.failed_dbs,
                 db_results: all_db_results,
                 doi_info,
-                arxiv_info: reference.arxiv_id.as_ref().map(|id| ArxivInfo {
-                    arxiv_id: id.clone(),
-                    valid: false,
-                    title: None,
-                }),
+                arxiv_info: None, // TODO(#124): implement arXiv ID validation
                 retraction_info,
             };
 
@@ -1004,11 +991,7 @@ async fn coordinator_loop(
                     valid: false,
                     title: None,
                 }),
-                arxiv_info: reference.arxiv_id.as_ref().map(|id| ArxivInfo {
-                    arxiv_id: id.clone(),
-                    valid: false,
-                    title: None,
-                }),
+                arxiv_info: None, // TODO(#124): implement arXiv ID validation
                 retraction_info: None,
             };
 
@@ -1144,11 +1127,7 @@ fn build_validation_result(
         failed_dbs: db_result.failed_dbs,
         db_results: db_result.db_results,
         doi_info: None,
-        arxiv_info: reference.arxiv_id.as_ref().map(|id| ArxivInfo {
-            arxiv_id: id.clone(),
-            valid: false,
-            title: None,
-        }),
+        arxiv_info: None, // TODO(#124): implement arXiv ID validation
         retraction_info,
     }
 }

--- a/hallucinator-rs/crates/hallucinator-pdf/src/section.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf/src/section.rs
@@ -86,9 +86,8 @@ fn strip_page_headers(text: &str) -> String {
     });
 
     // "USENIX Association" on its own line (often appears before the symposium line)
-    static USENIX_ASSOC_ONLY: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"(?m)^\s*USENIX\s+Association\s*$").unwrap()
-    });
+    static USENIX_ASSOC_ONLY: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?m)^\s*USENIX\s+Association\s*$").unwrap());
 
     // IEEE S&P, EuroS&P, etc.
     static IEEE_HEADER: Lazy<Regex> = Lazy::new(|| {
@@ -807,7 +806,14 @@ mod tests {
         );
         let section = find_references_section(text).unwrap();
         // Should contain the actual references, not the table content
-        assert!(section.contains("[1] First real reference"), "Section: {}", section);
-        assert!(!section.contains("Classification"), "Should not contain table content");
+        assert!(
+            section.contains("[1] First real reference"),
+            "Section: {}",
+            section
+        );
+        assert!(
+            !section.contains("Classification"),
+            "Should not contain table content"
+        );
     }
 }

--- a/hallucinator-rs/crates/hallucinator-pdf/src/title.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf/src/title.rs
@@ -951,16 +951,16 @@ fn try_acm_year(ref_text: &str) -> Option<(String, bool)> {
 fn try_arxiv_preprint(ref_text: &str) -> Option<(String, bool)> {
     // Try Format 2 first: ". arXiv:ID, Year" (more common in recent papers)
     // Pattern: Title ends at ". arXiv:" and the arXiv ID is followed by ", Year"
-    static RE2: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"\.\s*arXiv\s*:\s*\d+\.\d+(?:v\d+)?\s*,\s*(?:19|20)\d{2}").unwrap());
+    static RE2: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\.\s*arXiv\s*:\s*\d+\.\d+(?:v\d+)?\s*,\s*(?:19|20)\d{2}").unwrap()
+    });
 
     if let Some(m) = RE2.find(ref_text) {
         let before_arxiv = &ref_text[..m.start()];
 
         // Find the title: look for the last ". X" pattern (sentence boundary)
-        static TITLE_START: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r#"\.\s+([A-Z0-9"\u{201c}])"#).unwrap()
-        });
+        static TITLE_START: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r#"\.\s+([A-Z0-9"\u{201c}])"#).unwrap());
 
         let mut title_start_pos = None;
         for caps in TITLE_START.captures_iter(before_arxiv) {
@@ -988,9 +988,8 @@ fn try_arxiv_preprint(ref_text: &str) -> Option<(String, bool)> {
         let before_comma = &ref_text[..m.start()];
 
         // Find the title: look for the last ". X" pattern (sentence boundary)
-        static TITLE_START: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r#"\.\s+([A-Z0-9"\u{201c}])"#).unwrap()
-        });
+        static TITLE_START: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r#"\.\s+([A-Z0-9"\u{201c}])"#).unwrap());
 
         let mut title_start_pos = None;
         for caps in TITLE_START.captures_iter(before_comma) {
@@ -1017,9 +1016,8 @@ fn try_arxiv_preprint(ref_text: &str) -> Option<(String, bool)> {
     let before_year = &ref_text[..m.start()];
 
     // Find the title: look for the last ". X" pattern (sentence boundary) before the year
-    static TITLE_START: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r#"\.\s+([A-Z0-9"\u{201c}])"#).unwrap()
-    });
+    static TITLE_START: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r#"\.\s+([A-Z0-9"\u{201c}])"#).unwrap());
 
     let mut title_start_pos = None;
     for caps in TITLE_START.captures_iter(before_year) {
@@ -1074,7 +1072,8 @@ fn try_venue_marker(ref_text: &str) -> Option<(String, bool)> {
         if let Some(venue_match) = vp.find(ref_text) {
             // Check if this match is actually an editor list, not a venue
             // Use floor_char_boundary to avoid slicing in the middle of a UTF-8 character
-            let editor_check_end = ref_text.floor_char_boundary(venue_match.start().saturating_add(200));
+            let editor_check_end =
+                ref_text.floor_char_boundary(venue_match.start().saturating_add(200));
             if EDITOR_PATTERN.is_match(&ref_text[venue_match.start()..editor_check_end]) {
                 // This is an editor list, not a regular venue.
                 // Extract the title from BEFORE the ". In editors" marker
@@ -1438,8 +1437,7 @@ fn try_book_citation(ref_text: &str) -> Option<(String, bool)> {
 
     // Skip if the "title" starts with words indicating this is an editor list, not a book title
     // e.g., "and A. Oh, editors, Advances..." should not match
-    static EDITOR_START: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?i)^editors?,").unwrap());
+    static EDITOR_START: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)^editors?,").unwrap());
     if EDITOR_START.is_match(title_text) {
         return None;
     }
@@ -1519,7 +1517,8 @@ fn try_direct_in_venue(ref_text: &str) -> Option<(String, bool)> {
 fn try_accessed_date(ref_text: &str) -> Option<(String, bool)> {
     // Match: "Title. (Accessed MM-DD-YYYY)" or "(Ac- cessed ...)" with hyphenation
     static RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"^([A-Z][^.]+)\.\s*\((?:Ac-?\s*cessed|Accessed|Retrieved|Last accessed)\s+").unwrap()
+        Regex::new(r"^([A-Z][^.]+)\.\s*\((?:Ac-?\s*cessed|Accessed|Retrieved|Last accessed)\s+")
+            .unwrap()
     });
 
     let caps = RE.captures(ref_text)?;
@@ -1538,7 +1537,8 @@ fn try_accessed_date(ref_text: &str) -> Option<(String, bool)> {
 fn try_standard_document(ref_text: &str) -> Option<(String, bool)> {
     // Match: "Title. IEEE No XXX, Year" or "Title. ISO XXXX, Year" etc.
     static RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"^([A-Z][^.]+)\.\s*(?:IEEE|ISO|NIST|RFC|FIPS|ITU)\s+(?:No\.?\s*)?[\d\-]+").unwrap()
+        Regex::new(r"^([A-Z][^.]+)\.\s*(?:IEEE|ISO|NIST|RFC|FIPS|ITU)\s+(?:No\.?\s*)?[\d\-]+")
+            .unwrap()
     });
 
     let caps = RE.captures(ref_text)?;
@@ -1701,7 +1701,12 @@ fn split_sentences_skip_initials(text: &str) -> Vec<String> {
             if word_before.to_lowercase() == "al" {
                 let after_period = &text[m.end()..];
                 let is_author = AUTHOR_AFTER.iter().any(|re| re.is_match(after_period));
-                if !is_author && after_period.chars().next().is_some_and(|c| c.is_uppercase()) {
+                if !is_author
+                    && after_period
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c.is_uppercase())
+                {
                     // This "al." is followed by what looks like a title - treat it as a boundary
                     // (don't continue, fall through to sentence boundary handling)
                 } else {
@@ -3134,7 +3139,9 @@ fn test_usenix_workshop_participants_title() {
     let (title, _) = extract_title_from_reference(ref_text);
     println!("Workshop title extracted: {}", title);
     assert!(
-        title.to_lowercase().contains("identifying research challenges"),
+        title
+            .to_lowercase()
+            .contains("identifying research challenges"),
         "Should extract title from workshop report format: {}",
         title,
     );
@@ -3161,7 +3168,9 @@ fn test_usenix_url_accessed_date() {
     let (title, _) = extract_title_from_reference(ref_text);
     println!("URL accessed title: {}", title);
     assert!(
-        title.to_lowercase().contains("defcon 30 hacking conference"),
+        title
+            .to_lowercase()
+            .contains("defcon 30 hacking conference"),
         "Should extract title from URL reference: {}",
         title,
     );
@@ -3171,7 +3180,8 @@ fn test_usenix_url_accessed_date() {
 fn test_usenix_ieee_standard() {
     // Paper 194 ref 1: IEEE standard document
     // Should extract: "IEEE recommended practice for speech quality measurements"
-    let ref_text = "IEEE recommended practice for speech quality mea- surements. IEEE No 297-1969, 1969.";
+    let ref_text =
+        "IEEE recommended practice for speech quality mea- surements. IEEE No 297-1969, 1969.";
     let (title, _) = extract_title_from_reference(ref_text);
     println!("IEEE standard title: {}", title);
     assert!(
@@ -3289,7 +3299,8 @@ fn test_et_al_extraction() {
     );
 
     // Test full extraction
-    let ref_text = "A. Smith et al. Machine learning for security analysis. In Proceedings of IEEE, 2023.";
+    let ref_text =
+        "A. Smith et al. Machine learning for security analysis. In Proceedings of IEEE, 2023.";
     let (title, _) = extract_title_from_reference(ref_text);
     assert!(
         title.contains("Machine learning"),

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
@@ -506,7 +506,10 @@ impl App {
                 .current_paper_index()
                 .map(|i| self.paper_export_stem(i))
                 .unwrap_or_else(|| "hallucinator-results".to_string()),
-            crate::view::export::ExportScope::AllPapers => "hallucinator-results".to_string(),
+            crate::view::export::ExportScope::AllPapers
+            | crate::view::export::ExportScope::ProblematicPapers => {
+                "hallucinator-results".to_string()
+            }
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/persistence.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/persistence.rs
@@ -51,7 +51,7 @@ pub fn save_paper_results(
             fp_reason: rs.fp_reason,
         })
         .collect();
-    let json = hallucinator_reporting::export_json(&[report_paper], &[&report_refs]);
+    let json = hallucinator_reporting::export_json(&[report_paper], &[&report_refs], false);
 
     if let Ok(mut file) = std::fs::File::create(&out_path) {
         let _ = file.write_all(json.as_bytes());


### PR DESCRIPTION
## Summary

- **Problematic-only export filter** (#195): New "Filter" toggle in TUI export modal excludes verified, FP-overridden, and skipped references across all 5 export formats (JSON, CSV, Markdown, Text, HTML). The "Hide Verified" button is conditionally hidden in HTML when this filter is active.
- **Problematic papers scope**: New export scope that only includes papers with at least one problematic reference (not found, mismatch, or retracted).
- **CLI `--json` flag**: `hallucinator-cli check <pdf> --json <path>` exports results in JSON format compatible with `hallucinator-tui --load`, for both single-file and archive modes.
- **Fix false arXiv "invalid" reports** (partially addresses #124): `ArxivInfo` was always constructed with `valid: false` without any actual validation, causing every reference with an arXiv ID to be falsely flagged as "invalid" in all report formats. Now `arxiv_info` is set to `None` until real arXiv validation is implemented.
- **HTML report UX** (#209): Papers start collapsed; stats (total, verified, not found, mismatch, retracted, skipped, % problematic) are shown in the summary bar so they're visible without expanding.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test --workspace` (41 reporting tests including new HTML/arXiv problematic_only tests)
- [ ] Manual: TUI export with "Problematic only" filter → verify no verified/FP/skipped refs in output
- [ ] Manual: `hallucinator-cli check <pdf> --json out.json` → verify valid JSON, loadable via `hallucinator-tui --load out.json`
- [ ] Manual: HTML report → papers start collapsed, stats visible in summary bar

Closes #195, closes #209. Partially addresses #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)