### PR TITLE
Fix DBLP author mismatch, runtime FPS, open PDF, sort by status

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "hallucinator-reporting",
  "indicatif",
  "mimalloc",
+ "open",
  "ratatui",
  "reqwest",
  "serde",
@@ -1817,6 +1818,25 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2238,6 +2258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2323,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pathfinder_geometry"

--- a/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
@@ -38,6 +38,7 @@ tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 dirs.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+open = "5"
 
 [features]
 default = []

--- a/hallucinator-rs/crates/hallucinator-tui/src/action.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/action.rs
@@ -27,6 +27,7 @@ pub enum Action {
     #[allow(dead_code)] // planned feature: remove paper from queue
     RemovePaper,
     CopyToClipboard,
+    OpenPdf,
     OpenConfig,
     ToggleActivityPanel,
     SaveConfig,

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
@@ -419,6 +419,15 @@ impl App {
             SortOrder::Name => {
                 indices.sort_by(|&a, &b| self.papers[a].filename.cmp(&self.papers[b].filename));
             }
+            SortOrder::Status => {
+                indices.sort_by(|&a, &b| {
+                    self.papers[a]
+                        .phase
+                        .sort_key()
+                        .cmp(&self.papers[b].phase.sort_key())
+                        .then_with(|| a.cmp(&b))
+                });
+            }
         }
         if self.sort_reversed {
             indices.reverse();

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -852,6 +852,27 @@ impl App {
                     self.activity.log("Copied to clipboard".to_string());
                 }
             }
+            Action::OpenPdf => {
+                let paper_idx = match &self.screen {
+                    Screen::Queue => self.queue_sorted.get(self.queue_cursor).copied(),
+                    Screen::Paper(i) | Screen::RefDetail(i, _) => Some(*i),
+                    _ => None,
+                };
+                if let Some(idx) = paper_idx
+                    && let Some(path) = self.file_paths.get(idx)
+                {
+                    if path.as_os_str().is_empty() {
+                        self.activity
+                            .log_warn("No source file path available for this paper".to_string());
+                    } else if !path.exists() {
+                        self.activity
+                            .log_warn(format!("File not found: {}", path.display()));
+                    } else if let Err(e) = open::that(path) {
+                        self.activity
+                            .log_warn(format!("Failed to open {}: {}", path.display(), e));
+                    }
+                }
+            }
             Action::SaveConfig => {
                 self.save_config();
                 if matches!(self.screen, Screen::Config) {

--- a/hallucinator-rs/crates/hallucinator-tui/src/input.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/input.rs
@@ -59,6 +59,7 @@ fn map_key_normal(key: &KeyEvent) -> Action {
         KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageDown,
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageUp,
         KeyCode::Char('y') => Action::CopyToClipboard,
+        KeyCode::Char('p') => Action::OpenPdf,
         KeyCode::Char(',') | KeyCode::Char('c') => Action::OpenConfig,
         KeyCode::Char(' ') => Action::ToggleSafe,
         KeyCode::Tab => Action::ToggleActivityPanel,

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
@@ -149,6 +149,7 @@ pub enum SortOrder {
     NotFound,
     ProblematicPct,
     Name,
+    Status,
 }
 
 impl SortOrder {
@@ -158,7 +159,8 @@ impl SortOrder {
             Self::Problems => Self::NotFound,
             Self::NotFound => Self::ProblematicPct,
             Self::ProblematicPct => Self::Name,
-            Self::Name => Self::Original,
+            Self::Name => Self::Status,
+            Self::Status => Self::Original,
         }
     }
 
@@ -169,6 +171,21 @@ impl SortOrder {
             Self::NotFound => "not found",
             Self::ProblematicPct => "% flagged",
             Self::Name => "name",
+            Self::Status => "status",
+        }
+    }
+}
+
+impl PaperPhase {
+    /// Sort key for status ordering: active phases first, then completed, then queued.
+    pub fn sort_key(&self) -> u8 {
+        match self {
+            Self::Checking => 0,
+            Self::Extracting => 1,
+            Self::Retrying => 2,
+            Self::Complete => 3,
+            Self::ExtractionFailed => 4,
+            Self::Queued => 5,
         }
     }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/help.rs
@@ -9,7 +9,7 @@ use crate::theme::Theme;
 /// Render the help overlay as a centered popup.
 pub fn render(f: &mut Frame, theme: &Theme) {
     let area = f.area();
-    let popup = centered_rect(72, 45, area);
+    let popup = centered_rect(72, 46, area);
 
     let lines = vec![
         Line::from(Span::styled(
@@ -46,6 +46,7 @@ pub fn render(f: &mut Frame, theme: &Theme) {
         key_line("Ctrl+r", "Retry failed reference", theme),
         key_line("R", "Retry all failed references", theme),
         key_line("e", "Export results", theme),
+        key_line("p", "Open source PDF in default viewer", theme),
         key_line("o / a", "Open file picker (add files)", theme),
         key_line("o", "Browse for database file (Config > Databases)", theme),
         key_line("y", "Copy reference to clipboard (OSC 52)", theme),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
@@ -284,7 +284,7 @@ fn render_footer(
     }
 
     spans.push(Span::styled(
-        " | Space:FP reason  Enter:detail  Ctrl+r:retry  R:retry all  s:sort  f:filter  c:config  e:export  Esc:back",
+        " | Space:FP reason  Enter:detail  p:pdf  Ctrl+r:retry  R:retry all  s:sort  f:filter  c:config  e:export  Esc:back",
         theme.footer_style(),
     ));
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
@@ -336,7 +336,7 @@ fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::styled(
-            " Space:mark  Enter:open  o:add  c:config  e:export  ?:help  q:quit",
+            " Space:mark  Enter:open  p:pdf  o:add  c:config  e:export  ?:help  q:quit",
             theme.footer_style(),
         ));
     } else if app.processing_started && !app.batch_complete {
@@ -348,7 +348,7 @@ fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::styled(
-            " Space:mark  Enter:open  s/S:sort  f:filter  c:config  e:export  ?:help",
+            " Space:mark  Enter:open  p:pdf  s/S:sort  f:filter  c:config  e:export  ?:help",
             theme.footer_style(),
         ));
     } else if app.batch_complete && !app.file_paths.is_empty() {
@@ -360,12 +360,12 @@ fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::styled(
-            " Space:mark  Enter:open  s/S:sort  f:filter  o:add  c:config  e:export  ?:help  q:quit",
+            " Space:mark  Enter:open  p:pdf  s/S:sort  f:filter  o:add  c:config  e:export  ?:help  q:quit",
             theme.footer_style(),
         ));
     } else {
         spans.push(Span::styled(
-            " Space:mark  Enter:open  s/S:sort  f:filter  o:add  c:config  e:export  ?:help  q:quit",
+            " Space:mark  Enter:open  p:pdf  s/S:sort  f:filter  o:add  c:config  e:export  ?:help  q:quit",
             theme.footer_style(),
         ));
     }


### PR DESCRIPTION
## Summary
- #160: Strip DBLP 4-digit disambiguation suffixes from author names (e.g. Nuno Santos 0001 -> Nuno Santos) to prevent false Author Mismatch results. Applied to both online API and offline DB backends, with unit tests.
- #127: Recreate the tick timer when FPS is changed in the config UI so it takes effect immediately without requiring a restart.
- #128: Add p keybinding to open the source PDF in the default system viewer. Gracefully handles missing files and loaded results without local paths. Added to help screen and footer hints.
- #213: Add status sort order to the queue view -- sorts active (Checking/Extracting/Retrying) first, then completed, then queued. Useful for watching progress.

## Test plan
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo fmt --all clean
- [x] cargo test --workspace passes (including 4 new DBLP suffix tests)
- [ ] Manual: change FPS in config, verify measured FPS updates immediately
- [ ] Manual: press p on a paper to verify PDF opens
- [ ] Manual: press p when file doesn't exist (e.g. loaded results) to verify graceful warning
- [ ] Manual: cycle sort with s to reach status, verify active papers sort first
- [ ] Manual: check help screen shows new p keybinding

Closes #160, closes #127, closes #128, closes #213.

Generated with [Claude Code](https://claude.com/claude-code)