### PR TITLE
Fix whitespace under TUI logo and left-align stats bar

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
@@ -570,7 +570,7 @@ impl App {
 
         let spans = vec![
             Span::styled(
-                format!(" {}/{} papers ", done, total),
+                format!("{}/{} papers ", done, total),
                 Style::default().fg(theme.text),
             ),
             Span::styled(

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/banner.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/banner.rs
@@ -880,8 +880,7 @@ pub fn render_logo_bar(
         ]));
     }
 
-    // Blank line + stats line below logo (fits within the 5-row column)
-    logo_lines.push(Line::from(""));
+    // Stats line below logo (fits within the 5-row column)
     if let Some(stats) = stats_line {
         logo_lines.push(stats);
     }


### PR DESCRIPTION
## Summary
- Remove blank line between logo art and stats bar in the TUI banner, closing the visual gap (#212)
- Left-align the stats bar by removing the leading space from the papers count

## Test plan
- [ ] Launch TUI and verify no blank row between logo and stats bar
- [ ] Verify stats bar text is flush-left under the logo
- [ ] Verify Pro-tips box size is unchanged

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)