### PR TITLE
Persist false-positive (safe) markings in offline cache

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
@@ -2,6 +2,8 @@ use std::time::Instant;
 
 use hallucinator_core::{DbStatus, ProgressEvent};
 
+use hallucinator_reporting::FpReason;
+
 use super::App;
 use crate::model::activity::ActiveQuery;
 use crate::model::paper::{RefPhase, RefState};
@@ -58,6 +60,15 @@ impl App {
                             }
                         })
                         .collect();
+
+                    // Restore persisted FP overrides from cache
+                    if let Some(cache) = &self.current_query_cache {
+                        for rs in &mut self.ref_states[paper_index] {
+                            if let Some(reason_str) = cache.get_fp_override(&rs.title) {
+                                rs.fp_reason = reason_str.parse::<FpReason>().ok();
+                            }
+                        }
+                    }
                 }
             }
             BackendEvent::ExtractionFailed { paper_index, error } => {

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -778,6 +778,12 @@ impl App {
                                 && let Some(rs) = refs.get_mut(ref_idx)
                             {
                                 rs.fp_reason = FpReason::cycle(rs.fp_reason);
+                                if let Some(cache) = &self.current_query_cache {
+                                    cache.set_fp_override(
+                                        &rs.title,
+                                        rs.fp_reason.map(|r| r.as_str()),
+                                    );
+                                }
                             }
                         }
                     }
@@ -789,6 +795,9 @@ impl App {
                             && let Some(rs) = refs.get_mut(ref_idx)
                         {
                             rs.fp_reason = FpReason::cycle(rs.fp_reason);
+                            if let Some(cache) = &self.current_query_cache {
+                                cache.set_fp_override(&rs.title, rs.fp_reason.map(|r| r.as_str()));
+                            }
                         }
                     }
                     Screen::Config => {


### PR DESCRIPTION
## Summary
- Adds `fp_overrides` SQLite table to the existing `QueryCache` database for persisting user FP markings across sessions
- When a reference is marked as safe (Space key) on the Paper or RefDetail screen, the marking is immediately written to disk
- On re-analysis, stored FP overrides are automatically restored after reference extraction
- Cache clears (`clear()`) intentionally do **not** wipe FP overrides — they are user data, not stale DB results

Closes #217

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [x] `cargo fmt --all` passes clean
- [x] `cargo test --workspace` passes (7 new FP override tests)
- [ ] Launch TUI, analyze a paper, mark a reference as safe, quit, re-analyze → FP marking restored
- [ ] Verify cache clear does not remove FP markings
- [ ] Verify in-memory-only cache (no SQLite) gracefully no-ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)