### PR TITLE
Exclude headers/footers from PDF text extraction

### DIFF
--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -1041,7 +1041,7 @@ fn dry_run_pdf(
     use owo_colors::OwoColorize;
 
     use hallucinator_core::PdfBackend as _;
-    let text = hallucinator_pdf_mupdf::MupdfBackend
+    let text = hallucinator_pdf_mupdf::MupdfBackend::default()
         .extract_text(file_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let ref_section = hallucinator_parsing::section::find_references_section(&text)

--- a/hallucinator-rs/crates/hallucinator-ingest/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-ingest/src/lib.rs
@@ -42,7 +42,7 @@ pub fn extract_references(path: &Path) -> Result<ExtractionResult, IngestError> 
 
 #[cfg(feature = "pdf")]
 fn extract_pdf(path: &Path) -> Result<ExtractionResult, IngestError> {
-    let backend = hallucinator_pdf_mupdf::MupdfBackend;
+    let backend = hallucinator_pdf_mupdf::MupdfBackend::default();
     hallucinator_parsing::extract_references(path, &backend).map_err(IngestError::Pdf)
 }
 

--- a/hallucinator-rs/crates/hallucinator-pdf-mupdf/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf-mupdf/src/lib.rs
@@ -188,18 +188,16 @@ impl PdfBackend for MupdfBackend {
                 }
 
                 // Skip blocks entirely within the fixed-ratio header region.
-                if let Some(threshold) = header_threshold {
-                    if block.y1 <= threshold {
+                if let Some(threshold) = header_threshold
+                    && block.y1 <= threshold {
                         continue;
                     }
-                }
 
                 // Skip blocks whose top edge is in the fixed-ratio footer region.
-                if let Some(threshold) = footer_threshold {
-                    if block.y0 >= threshold {
+                if let Some(threshold) = footer_threshold
+                    && block.y0 >= threshold {
                         continue;
                     }
-                }
 
                 for line in &block.lines {
                     page_text.push_str(line);

--- a/hallucinator-rs/crates/hallucinator-pdf-mupdf/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf-mupdf/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use mupdf::{Document, TextPageFlags};
@@ -10,10 +11,19 @@ use hallucinator_core::{BackendError, PdfBackend};
 /// (which is AGPL-3.0) so that non-PDF code paths do not transitively
 /// depend on it.
 ///
-/// By default, text in the bottom 5% of each page (footers) and top 4%
-/// (headers) is excluded to prevent conference proceedings footer lines
-/// like "USENIX Association  34th USENIX Security Symposium  5281" from
-/// being embedded mid-citation when references span page breaks.
+/// Header/footer removal uses two complementary strategies:
+///
+/// 1. **Repeating-element detection** (primary): text blocks whose vertical
+///    mid-point falls at the same position (within 2 pt) on ≥ 50% of pages
+///    are treated as running headers or footers and excluded.  This correctly
+///    handles journals like PoPETs whose running header sits at ~8% from the
+///    top — well beyond a naïve fixed-ratio threshold.
+///
+/// 2. **Fixed-ratio exclusion** (fallback/safety-net): blocks in the top 4%
+///    or bottom 5% of a page are always excluded.  This catches headers/footers
+///    in very short documents (< 4 pages) where the repeating-element signal is
+///    too weak, and handles conference proceedings where the strip sits at the
+///    extreme page edge (e.g. USENIX footer lines).
 pub struct MupdfBackend {
     /// Fraction of page height from bottom to exclude as footer (0.0–1.0).
     /// Default 0.05. `None` disables footer exclusion.
@@ -50,6 +60,21 @@ impl MupdfBackend {
     }
 }
 
+/// Collected data for one text block, sufficient for both repeating-element
+/// detection and text assembly.
+struct BlockData {
+    /// Quantized vertical mid-point: `(y_mid / 2.0).round() as i32`.
+    /// Two pt resolution — tight enough to group a running header that
+    /// lands at the same absolute position on every page.
+    y_bucket: i32,
+    /// Top edge of the block in page coordinates (y increases downward).
+    y0: f32,
+    /// Bottom edge of the block in page coordinates.
+    y1: f32,
+    /// Pre-extracted text lines (not yet joined).
+    lines: Vec<String>,
+}
+
 impl PdfBackend for MupdfBackend {
     fn extract_text(&self, path: &Path) -> Result<String, BackendError> {
         let path_str = path
@@ -59,58 +84,129 @@ impl PdfBackend for MupdfBackend {
         let document =
             Document::open(path_str).map_err(|e| BackendError::OpenError(e.to_string()))?;
 
-        let mut pages_text = Vec::new();
+        // ----------------------------------------------------------------
+        // Single MuPDF pass: collect block geometry and text for every page.
+        // ----------------------------------------------------------------
+        //
+        // Alongside the block data we build `bucket_page_count`: for each
+        // quantized y-bucket, how many distinct pages contain a block there.
+        // Pages that share the same y-bucket are likely running header/footer
+        // pages; we'll filter them out below.
+
+        let mut all_pages: Vec<(Vec<BlockData>, f32, f32)> = Vec::new(); // (blocks, page_y0, page_y1)
+        let mut bucket_page_count: HashMap<i32, usize> = HashMap::new();
 
         for page_result in document
             .pages()
             .map_err(|e| BackendError::ExtractionError(e.to_string()))?
         {
             let page = page_result.map_err(|e| BackendError::ExtractionError(e.to_string()))?;
+
+            let page_bounds = page
+                .bounds()
+                .map_err(|e| BackendError::ExtractionError(e.to_string()))?;
+
             let text_page = page
                 .to_text_page(TextPageFlags::empty())
                 .map_err(|e| BackendError::ExtractionError(e.to_string()))?;
 
-            // Get page bounds for header/footer exclusion
-            let page_bounds = page
-                .bounds()
-                .map_err(|e| BackendError::ExtractionError(e.to_string()))?;
-            let page_height = page_bounds.y1 - page_bounds.y0;
+            let mut page_blocks: Vec<BlockData> = Vec::new();
+            let mut seen_buckets: HashSet<i32> = HashSet::new();
+
+            for block in text_page.blocks() {
+                let bb = block.bounds();
+                let y_mid = (bb.y0 + bb.y1) / 2.0;
+                let y_bucket = (y_mid / 2.0).round() as i32;
+
+                // Count each bucket once per page (not once per block).
+                if seen_buckets.insert(y_bucket) {
+                    *bucket_page_count.entry(y_bucket).or_insert(0) += 1;
+                }
+
+                let lines: Vec<String> = block
+                    .lines()
+                    .map(|line| {
+                        line.chars()
+                            .map(|c| c.char().unwrap_or('\u{FFFD}'))
+                            .collect()
+                    })
+                    .collect();
+
+                page_blocks.push(BlockData {
+                    y_bucket,
+                    y0: bb.y0,
+                    y1: bb.y1,
+                    lines,
+                });
+            }
+
+            all_pages.push((page_blocks, page_bounds.y0, page_bounds.y1));
+        }
+
+        // ----------------------------------------------------------------
+        // Identify repeating-element y-buckets.
+        //
+        // A bucket is "repeating" if it appears on at least half the pages
+        // (minimum 2).  For a 16-page paper this is 8 pages; running headers
+        // appear on 15/16 while coincidental repeated section positions appear
+        // on ≤ 5.  For short documents the fixed-ratio fallback below takes
+        // over instead.
+        // ----------------------------------------------------------------
+
+        let total_pages = all_pages.len();
+        let repeat_threshold = (total_pages / 2).max(2);
+
+        let repeating_buckets: HashSet<i32> = bucket_page_count
+            .into_iter()
+            .filter(|(_, count)| *count >= repeat_threshold)
+            .map(|(bucket, _)| bucket)
+            .collect();
+
+        // ----------------------------------------------------------------
+        // Assemble output text, skipping repeating-element blocks and
+        // fixed-ratio header/footer regions.
+        // ----------------------------------------------------------------
+
+        let mut pages_text = Vec::with_capacity(total_pages);
+
+        for (blocks, page_y0, page_y1) in &all_pages {
+            let page_height = page_y1 - page_y0;
 
             let header_threshold = self
                 .header_exclusion_ratio
-                .map(|r| page_bounds.y0 + page_height * r);
+                .map(|r| page_y0 + page_height * r);
             let footer_threshold = self
                 .footer_exclusion_ratio
-                .map(|r| page_bounds.y1 - page_height * r);
+                .map(|r| page_y1 - page_height * r);
 
-            // Use block/line iteration to match PyMuPDF's get_text() behavior
             let mut page_text = String::new();
-            for block in text_page.blocks() {
-                let block_bounds = block.bounds();
 
-                // Skip blocks entirely within the header region
+            for block in blocks {
+                // Skip blocks whose y-position repeats across many pages.
+                if repeating_buckets.contains(&block.y_bucket) {
+                    continue;
+                }
+
+                // Skip blocks entirely within the fixed-ratio header region.
                 if let Some(threshold) = header_threshold {
-                    if block_bounds.y1 <= threshold {
+                    if block.y1 <= threshold {
                         continue;
                     }
                 }
 
-                // Skip blocks whose top edge is in the footer region
+                // Skip blocks whose top edge is in the fixed-ratio footer region.
                 if let Some(threshold) = footer_threshold {
-                    if block_bounds.y0 >= threshold {
+                    if block.y0 >= threshold {
                         continue;
                     }
                 }
 
-                for line in block.lines() {
-                    let line_text: String = line
-                        .chars()
-                        .map(|c| c.char().unwrap_or('\u{FFFD}'))
-                        .collect();
-                    page_text.push_str(&line_text);
+                for line in &block.lines {
+                    page_text.push_str(line);
                     page_text.push('\n');
                 }
             }
+
             pages_text.push(page_text);
         }
 

--- a/hallucinator-rs/crates/hallucinator-pdf-mupdf/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-pdf-mupdf/src/lib.rs
@@ -9,7 +9,46 @@ use hallucinator_core::{BackendError, PdfBackend};
 /// This crate is the sole AGPL island — it isolates the mupdf dependency
 /// (which is AGPL-3.0) so that non-PDF code paths do not transitively
 /// depend on it.
-pub struct MupdfBackend;
+///
+/// By default, text in the bottom 5% of each page (footers) and top 4%
+/// (headers) is excluded to prevent conference proceedings footer lines
+/// like "USENIX Association  34th USENIX Security Symposium  5281" from
+/// being embedded mid-citation when references span page breaks.
+pub struct MupdfBackend {
+    /// Fraction of page height from bottom to exclude as footer (0.0–1.0).
+    /// Default 0.05. `None` disables footer exclusion.
+    footer_exclusion_ratio: Option<f32>,
+    /// Fraction of page height from top to exclude as header (0.0–1.0).
+    /// Default 0.04. `None` disables header exclusion.
+    header_exclusion_ratio: Option<f32>,
+}
+
+impl Default for MupdfBackend {
+    fn default() -> Self {
+        Self {
+            footer_exclusion_ratio: Some(0.05),
+            header_exclusion_ratio: Some(0.04),
+        }
+    }
+}
+
+impl MupdfBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the footer exclusion ratio. Pass `0.0` to disable.
+    pub fn with_footer_exclusion(mut self, ratio: f32) -> Self {
+        self.footer_exclusion_ratio = if ratio > 0.0 { Some(ratio) } else { None };
+        self
+    }
+
+    /// Set the header exclusion ratio. Pass `0.0` to disable.
+    pub fn with_header_exclusion(mut self, ratio: f32) -> Self {
+        self.header_exclusion_ratio = if ratio > 0.0 { Some(ratio) } else { None };
+        self
+    }
+}
 
 impl PdfBackend for MupdfBackend {
     fn extract_text(&self, path: &Path) -> Result<String, BackendError> {
@@ -31,9 +70,38 @@ impl PdfBackend for MupdfBackend {
                 .to_text_page(TextPageFlags::empty())
                 .map_err(|e| BackendError::ExtractionError(e.to_string()))?;
 
+            // Get page bounds for header/footer exclusion
+            let page_bounds = page
+                .bounds()
+                .map_err(|e| BackendError::ExtractionError(e.to_string()))?;
+            let page_height = page_bounds.y1 - page_bounds.y0;
+
+            let header_threshold = self
+                .header_exclusion_ratio
+                .map(|r| page_bounds.y0 + page_height * r);
+            let footer_threshold = self
+                .footer_exclusion_ratio
+                .map(|r| page_bounds.y1 - page_height * r);
+
             // Use block/line iteration to match PyMuPDF's get_text() behavior
             let mut page_text = String::new();
             for block in text_page.blocks() {
+                let block_bounds = block.bounds();
+
+                // Skip blocks entirely within the header region
+                if let Some(threshold) = header_threshold {
+                    if block_bounds.y1 <= threshold {
+                        continue;
+                    }
+                }
+
+                // Skip blocks whose top edge is in the footer region
+                if let Some(threshold) = footer_threshold {
+                    if block_bounds.y0 >= threshold {
+                        continue;
+                    }
+                }
+
                 for line in block.lines() {
                     let line_text: String = line
                         .chars()

--- a/legacy/check_hallucinated_references.py
+++ b/legacy/check_hallucinated_references.py
@@ -1066,49 +1066,11 @@ def expand_ligatures(text):
     return text
 
 
-def extract_text_from_pdf(pdf_path, footer_margin_ratio=0.05, header_margin_ratio=0.04):
-    """Extract text from PDF using PyMuPDF with footer/header exclusion.
-
-    Args:
-        pdf_path: Path to the PDF file.
-        footer_margin_ratio: Fraction of page height from the bottom to exclude (0.0-1.0).
-            Default 0.05 (bottom 5%) removes footers like "USENIX Association 34th USENIX
-            Security Symposium 5281" that otherwise get embedded in cross-page citations.
-        header_margin_ratio: Fraction of page height from the top to exclude (0.0-1.0).
-            Default 0.04 (top 4%) removes running headers at page tops.
-    """
+def extract_text_from_pdf(pdf_path):
+    """Extract text from PDF using PyMuPDF."""
     import fitz
     doc = fitz.open(pdf_path)
-
-    if footer_margin_ratio > 0 or header_margin_ratio > 0:
-        pages_text = []
-        for page in doc:
-            page_rect = page.rect
-            page_height = page_rect.height
-
-            header_threshold = page_rect.y0 + (page_height * header_margin_ratio) if header_margin_ratio > 0 else page_rect.y0
-            footer_threshold = page_rect.y1 - (page_height * footer_margin_ratio) if footer_margin_ratio > 0 else page_rect.y1
-
-            blocks = page.get_text("blocks")
-            page_text_parts = []
-            for block in blocks:
-                # block = (x0, y0, x1, y1, text, block_no, block_type)
-                if block[6] != 0:  # skip non-text blocks (images)
-                    continue
-                block_top_y = block[1]
-                block_bottom_y = block[3]
-                # Skip blocks entirely within the header region
-                if header_margin_ratio > 0 and block_bottom_y <= header_threshold:
-                    continue
-                # Skip blocks whose top edge is in the footer region
-                if footer_margin_ratio > 0 and block_top_y >= footer_threshold:
-                    continue
-                page_text_parts.append(block[4])
-            pages_text.append("".join(page_text_parts))
-        text = "\n".join(pages_text)
-    else:
-        text = "\n".join(page.get_text() for page in doc)
-
+    text = "\n".join(page.get_text() for page in doc)
     doc.close()
     # Expand typographic ligatures (ﬁ → fi, ﬂ → fl, etc.)
     text = expand_ligatures(text)
@@ -1192,18 +1154,6 @@ def strip_running_headers(text):
     # e.g., "HODGE THEORY OF SECANT VARIETIES"
     math_title_header_pattern = r'^[A-Z][A-Z\s\-]+$'
 
-    # Pattern for conference proceedings footer/header lines
-    # e.g., "USENIX Association 34th USENIX Security Symposium 5281"
-    # Matches: Organization + optional ordinal conference name + optional page number
-    proceedings_footer_pattern = r'^(?:USENIX Association|©?\s*\d{4}\s+(?:ACM|IEEE))\s+.*$'
-
-    # Pattern for "USENIX Association" alone on a line (partial footer)
-    usenix_alone_pattern = r'^USENIX\s+Association\s*$'
-
-    # Pattern for ordinal conference names with trailing page number (footer artifact)
-    # e.g., "34th USENIX Security Symposium 5281"
-    ordinal_conf_pattern = r'^\d+(?:st|nd|rd|th)\s+[\w\s]+(?:Symposium|Conference|Workshop|Congress)\s+\d{1,5}\s*$'
-
     # Pattern for standalone page numbers (math papers often have these)
     # e.g., "99" or "123"
     page_number_pattern = r'^\d{1,4}$'
@@ -1239,23 +1189,6 @@ def strip_running_headers(text):
         # Check for math paper ALL CAPS title headers (at least 3 words, all caps)
         if re.match(math_title_header_pattern, line) and len(line.split()) >= 3 and len(line) > 15:
             # This is likely a math paper title running header, skip it
-            i += 1
-            continue
-
-        # Check for conference proceedings footer/header lines
-        # e.g., "USENIX Association 34th USENIX Security Symposium 5281"
-        if re.match(proceedings_footer_pattern, line):
-            i += 1
-            continue
-
-        # Check for "USENIX Association" alone on a line
-        if re.match(usenix_alone_pattern, line):
-            i += 1
-            continue
-
-        # Check for ordinal conference name with trailing page number
-        # e.g., "34th USENIX Security Symposium 5281"
-        if re.match(ordinal_conf_pattern, line):
             i += 1
             continue
 


### PR DESCRIPTION
Remove pdf footers before extracting text. Fixes #114.

In manual testing, I am noticing fewer issues related to footer parsing compared to when I originally made this PR, so I am not sure if there was another fix that improved the false positives. Regardless, this PR would theoretically help in edge cases.