### PR TITLE
Derive Python wheel version from git tag

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 0.1.1). Required for manual triggers."
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
@@ -38,6 +43,21 @@ jobs:
         if: runner.os != 'Linux'
         with:
           python-version: "3.12"
+
+      - name: Set version from tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          elif [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            echo "Using version from pyproject.toml"
+            exit 0
+          fi
+          sed "s/^version = .*/version = \"${VERSION}\"/" hallucinator-rs/pyproject.toml > hallucinator-rs/pyproject.toml.tmp
+          mv hallucinator-rs/pyproject.toml.tmp hallucinator-rs/pyproject.toml
+          echo "Version set to ${VERSION}"
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
@@ -105,6 +125,21 @@ jobs:
           submodules: recursive
           fetch-depth: 500
 
+      - name: Set version from tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          elif [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            echo "Using version from pyproject.toml"
+            exit 0
+          fi
+          sed "s/^version = .*/version = \"${VERSION}\"/" hallucinator-rs/pyproject.toml > hallucinator-rs/pyproject.toml.tmp
+          mv hallucinator-rs/pyproject.toml.tmp hallucinator-rs/pyproject.toml
+          echo "Version set to ${VERSION}"
+
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
@@ -122,7 +157,7 @@ jobs:
     name: Publish to PyPI
     needs: [build, test, sdist]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.version != ''
     environment: pypi
     permissions:
       id-token: write

--- a/hallucinator-rs/pyproject.toml
+++ b/hallucinator-rs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hallucinator"
-version = "0.1.1a5"
+version = "0.0.0.dev0"
 description = "Detect hallucinated references in academic papers"
 requires-python = ">=3.9"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- Python Wheels CI now patches `pyproject.toml` version from the git tag (stripping the `v` prefix) before building, so the wheel version always matches the release tag
- Added `workflow_dispatch` version input so builds can be manually triggered with a specific version (e.g., to retry the failed `v0.1.1` publish without retagging)
- Set `pyproject.toml` version to `0.0.0.dev0` as a dev placeholder since CI always overrides it

Fixes the `v0.1.1` Python Wheels failure where wheels were built as `0.1.1a5` because `pyproject.toml` wasn't bumped.

## Test plan
- [ ] Merge to main, then manually trigger Python Wheels workflow with `version=0.1.1`
- [ ] Verify wheels are built as `hallucinator-0.1.1-*` and published to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)