### PR TITLE
Add Standards document verifier backend

### DIFF
--- a/hallucinator-rs/crates/hallucinator-cli/src/output.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/output.rs
@@ -306,32 +306,32 @@ fn print_mismatch_block(
     }
 
     // Show DOI mismatch details if applicable
-    if kind.contains(MismatchKind::DOI) {
-        if let Some(doi_info) = &result.doi_info {
-            if color.enabled() {
-                writeln!(w, "{} {} (invalid)", "DOI:".bold(), doi_info.doi)?;
-            } else {
-                writeln!(w, "DOI: {} (invalid)", doi_info.doi)?;
-            }
-            writeln!(w)?;
+    if kind.contains(MismatchKind::DOI)
+        && let Some(doi_info) = &result.doi_info
+    {
+        if color.enabled() {
+            writeln!(w, "{} {} (invalid)", "DOI:".bold(), doi_info.doi)?;
+        } else {
+            writeln!(w, "DOI: {} (invalid)", doi_info.doi)?;
         }
+        writeln!(w)?;
     }
 
     // Show arXiv ID mismatch details if applicable
-    if kind.contains(MismatchKind::ARXIV_ID) {
-        if let Some(arxiv_info) = &result.arxiv_info {
-            if color.enabled() {
-                writeln!(
-                    w,
-                    "{} {} (invalid)",
-                    "arXiv ID:".bold(),
-                    arxiv_info.arxiv_id
-                )?;
-            } else {
-                writeln!(w, "arXiv ID: {} (invalid)", arxiv_info.arxiv_id)?;
-            }
-            writeln!(w)?;
+    if kind.contains(MismatchKind::ARXIV_ID)
+        && let Some(arxiv_info) = &result.arxiv_info
+    {
+        if color.enabled() {
+            writeln!(
+                w,
+                "{} {} (invalid)",
+                "arXiv ID:".bold(),
+                arxiv_info.arxiv_id
+            )?;
+        } else {
+            writeln!(w, "arXiv ID: {} (invalid)", arxiv_info.arxiv_id)?;
         }
+        writeln!(w)?;
     }
 
     let dash_sep = "-".repeat(60);

--- a/hallucinator-rs/crates/hallucinator-core/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/authors.rs
@@ -21,16 +21,46 @@ static NAME_SUFFIXES: Lazy<HashSet<&'static str>> =
 /// of doing normal name matching.
 static ORG_AUTHOR_NAMES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     [
-        "openai", "meta", "google", "deepmind", "anthropic", "microsoft",
-        "deepseek", "deepseekai", "alibaba", "baidu", "tencent", "nvidia", "apple",
-        "darpa", "ftc", "nasa", "nist", "ieee", "acm",
-        "who", "oecd", "unesco", "european commission",
-        "mistralai", "mistral",
+        "openai",
+        "meta",
+        "google",
+        "deepmind",
+        "anthropic",
+        "microsoft",
+        "deepseek",
+        "deepseekai",
+        "alibaba",
+        "baidu",
+        "tencent",
+        "nvidia",
+        "apple",
+        "darpa",
+        "ftc",
+        "nasa",
+        "nist",
+        "ieee",
+        "acm",
+        "who",
+        "oecd",
+        "unesco",
+        "european commission",
+        "mistralai",
+        "mistral",
         // Government departments/agencies (returned by GovInfo)
-        "commerce department", "department of commerce",
-        "department of defense", "department of energy",
-        "department of homeland security", "department of justice",
-        "congress", "senate", "gao", "cisa", "fda", "epa", "fcc", "sec",
+        "commerce department",
+        "department of commerce",
+        "department of defense",
+        "department of energy",
+        "department of homeland security",
+        "department of justice",
+        "congress",
+        "senate",
+        "gao",
+        "cisa",
+        "fda",
+        "epa",
+        "fcc",
+        "sec",
     ]
     .into_iter()
     .collect()
@@ -156,10 +186,12 @@ pub fn validate_authors(ref_authors: &[String], found_authors: &[String]) -> boo
         // the DB returns all 5 authors including Gentry.
         // Threshold is 5 because ACM format typically shows up to 5 authors
         // before "et al.", and USENIX/IEEE show up to 3.
-        if ref_authors.len() < found_authors.len() && ref_authors.len() <= 5 {
-            if !ref_surnames.is_empty() && ref_surnames.is_subset(&found_surnames) {
-                return true;
-            }
+        if ref_authors.len() < found_authors.len()
+            && ref_authors.len() <= 5
+            && !ref_surnames.is_empty()
+            && ref_surnames.is_subset(&found_surnames)
+        {
+            return true;
         }
 
         false
@@ -207,10 +239,8 @@ fn strip_diacritics(s: &str) -> String {
     // Normalize curly quotes/apostrophes to ASCII before NFKD
     // (NFKD doesn't decompose U+2019 RIGHT SINGLE QUOTATION MARK)
     let s = s
-        .replace('\u{2019}', "'") // right single quote → apostrophe
-        .replace('\u{2018}', "'") // left single quote → apostrophe
-        .replace('\u{201C}', "\"") // left double quote
-        .replace('\u{201D}', "\""); // right double quote
+        .replace(['\u{2019}', '\u{2018}'], "'") // curly single quotes → apostrophe
+        .replace(['\u{201C}', '\u{201D}'], "\""); // curly double quotes → straight
     s.nfkd().filter(|c| c.is_ascii()).collect()
 }
 
@@ -430,10 +460,7 @@ mod tests {
     #[test]
     fn test_org_author_deepseek() {
         // "DeepSeek-AI" with hyphen should also match
-        assert!(validate_authors(
-            &s(&["DeepSeek-AI"]),
-            &s(&["Some Author"]),
-        ));
+        assert!(validate_authors(&s(&["DeepSeek-AI"]), &s(&["Some Author"]),));
     }
 
     #[test]
@@ -532,7 +559,9 @@ mod tests {
         // so completely different authors should NOT match
         assert!(!validate_authors(
             &s(&["X. Alpha", "Y. Beta", "Z. Gamma", "W. Delta"]),
-            &s(&["A. One", "B. Two", "C. Three", "D. Four", "E. Five", "F. Six"]),
+            &s(&[
+                "A. One", "B. Two", "C. Three", "D. Four", "E. Five", "F. Six"
+            ]),
         ));
     }
 }

--- a/hallucinator-rs/crates/hallucinator-core/src/cache.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/cache.rs
@@ -772,6 +772,7 @@ fn cached_to_query_result(cached: &CachedResult) -> DbQueryResult {
             authors: authors.clone(),
             paper_url: url.clone(),
             retraction: retraction.clone(),
+            source_label: None,
         },
         CachedResult::NotFound => DbQueryResult::not_found(),
     }

--- a/hallucinator-rs/crates/hallucinator-core/src/db/crossref.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/crossref.rs
@@ -148,6 +148,7 @@ impl DatabaseBackend for CrossRef {
                         authors,
                         paper_url,
                         retraction: Some(retraction),
+                        source_label: None,
                     });
                 }
             }

--- a/hallucinator-rs/crates/hallucinator-core/src/db/govinfo.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/govinfo.rs
@@ -55,8 +55,10 @@ enum GovDocType {
 /// structured information for targeted querying.
 fn detect_gov_doc(title: &str) -> Option<GovDocType> {
     // NIST Special Publication: "NIST SP 800-82", "SP 800-53 Rev. 5"
-    static NIST_SP: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?i)(?:NIST\s+)?SP\s+(\d{3,4}[-‐]\d+[A-Za-z]?(?:\s*[Rr]ev\.?\s*\d*)?)").unwrap());
+    static NIST_SP: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)(?:NIST\s+)?SP\s+(\d{3,4}[-‐]\d+[A-Za-z]?(?:\s*[Rr]ev\.?\s*\d*)?)")
+            .unwrap()
+    });
     if let Some(m) = NIST_SP.captures(title) {
         return Some(GovDocType::NistSp(m[1].to_string()));
     }
@@ -69,8 +71,9 @@ fn detect_gov_doc(title: &str) -> Option<GovDocType> {
     }
 
     // NIST Internal/Interagency Report: "NIST IR 8214C", "NISTIR 8413"
-    static NIST_IR: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?i)NIST\s*(?:IR|Interagency)\s+(?:Report\s+)?(\d{4}[A-Za-z]?)").unwrap());
+    static NIST_IR: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)NIST\s*(?:IR|Interagency)\s+(?:Report\s+)?(\d{4}[A-Za-z]?)").unwrap()
+    });
     if let Some(m) = NIST_IR.captures(title) {
         return Some(GovDocType::NistIr(m[1].to_string()));
     }
@@ -113,7 +116,8 @@ fn detect_gov_doc(title: &str) -> Option<GovDocType> {
 
     // Common US law acronyms as standalone titles
     static LAW_ACRONYM: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"(?i)\b(?:HIPAA|COPPA|CCPA|FERPA|ECPA|CFAA|DMCA|GLBA|FISMA|SOX|CIPA)\b").unwrap()
+        Regex::new(r"(?i)\b(?:HIPAA|COPPA|CCPA|FERPA|ECPA|CFAA|DMCA|GLBA|FISMA|SOX|CIPA)\b")
+            .unwrap()
     });
     if LAW_ACRONYM.is_match(title) {
         return Some(GovDocType::Generic(title.to_string()));
@@ -126,11 +130,39 @@ fn detect_gov_doc(title: &str) -> Option<GovDocType> {
 fn title_keywords(title: &str, max: usize) -> String {
     static STOP_WORDS: Lazy<std::collections::HashSet<&str>> = Lazy::new(|| {
         [
-            "the", "and", "for", "with", "from", "that", "this", "are", "was",
-            "not", "but", "its", "our", "into", "over", "about", "rev", "vol",
-            "report", "standard", "special", "publication", "internal", "interagency",
-            "department", "commerce", "institute", "national", "technology", "standards",
-            "online", "available", "accessed",
+            "the",
+            "and",
+            "for",
+            "with",
+            "from",
+            "that",
+            "this",
+            "are",
+            "was",
+            "not",
+            "but",
+            "its",
+            "our",
+            "into",
+            "over",
+            "about",
+            "rev",
+            "vol",
+            "report",
+            "standard",
+            "special",
+            "publication",
+            "internal",
+            "interagency",
+            "department",
+            "commerce",
+            "institute",
+            "national",
+            "technology",
+            "standards",
+            "online",
+            "available",
+            "accessed",
         ]
         .into_iter()
         .collect()
@@ -225,8 +257,7 @@ fn gov_title_matches(
             // For NIST documents: accept if the result is from GOVPUB and authored by NIST.
             // The API search already filtered by document number, so the first NIST result
             // from a "SP 800-82" query is very likely the right document.
-            (collection == "GOVPUB" || collection == "NIST")
-                && gov_authors.contains("nist")
+            (collection == "GOVPUB" || collection == "NIST") && gov_authors.contains("nist")
         }
         GovDocType::Cfr(_) => collection == "CFR" || collection == "ECFR",
         GovDocType::Usc(_) => collection == "USCODE",
@@ -384,8 +415,14 @@ mod tests {
 
     #[test]
     fn detect_nist_sp() {
-        assert!(matches!(detect_gov_doc("NIST SP 800-82 Rev"), Some(GovDocType::NistSp(_))));
-        assert!(matches!(detect_gov_doc("SP 800-53 Rev. 5"), Some(GovDocType::NistSp(_))));
+        assert!(matches!(
+            detect_gov_doc("NIST SP 800-82 Rev"),
+            Some(GovDocType::NistSp(_))
+        ));
+        assert!(matches!(
+            detect_gov_doc("SP 800-53 Rev. 5"),
+            Some(GovDocType::NistSp(_))
+        ));
         assert!(matches!(
             detect_gov_doc("Guide to OT Security, NIST SP 800-82"),
             Some(GovDocType::NistSp(_))
@@ -394,8 +431,14 @@ mod tests {
 
     #[test]
     fn detect_nist_fips() {
-        assert!(matches!(detect_gov_doc("FIPS 198-1"), Some(GovDocType::NistFips(_))));
-        assert!(matches!(detect_gov_doc("NIST FIPS 140-3"), Some(GovDocType::NistFips(_))));
+        assert!(matches!(
+            detect_gov_doc("FIPS 198-1"),
+            Some(GovDocType::NistFips(_))
+        ));
+        assert!(matches!(
+            detect_gov_doc("NIST FIPS 140-3"),
+            Some(GovDocType::NistFips(_))
+        ));
         assert!(matches!(
             detect_gov_doc("FIPS PUB 180-4"),
             Some(GovDocType::NistFips(_))
@@ -408,7 +451,10 @@ mod tests {
             detect_gov_doc("NIST Interagency Report 8214C"),
             Some(GovDocType::NistIr(_))
         ));
-        assert!(matches!(detect_gov_doc("NIST IR 8413"), Some(GovDocType::NistIr(_))));
+        assert!(matches!(
+            detect_gov_doc("NIST IR 8413"),
+            Some(GovDocType::NistIr(_))
+        ));
     }
 
     #[test]
@@ -417,13 +463,22 @@ mod tests {
             detect_gov_doc("21 CFR Part 11: Electronic Records"),
             Some(GovDocType::Cfr(_))
         ));
-        assert!(matches!(detect_gov_doc("47 C.F.R. § 1.1307"), Some(GovDocType::Cfr(_))));
+        assert!(matches!(
+            detect_gov_doc("47 C.F.R. § 1.1307"),
+            Some(GovDocType::Cfr(_))
+        ));
     }
 
     #[test]
     fn detect_usc() {
-        assert!(matches!(detect_gov_doc("47 U.S.C. § 230"), Some(GovDocType::Usc(_))));
-        assert!(matches!(detect_gov_doc("15 USC 1681"), Some(GovDocType::Usc(_))));
+        assert!(matches!(
+            detect_gov_doc("47 U.S.C. § 230"),
+            Some(GovDocType::Usc(_))
+        ));
+        assert!(matches!(
+            detect_gov_doc("15 USC 1681"),
+            Some(GovDocType::Usc(_))
+        ));
     }
 
     #[test]
@@ -432,7 +487,10 @@ mod tests {
             detect_gov_doc("Public Law 104-191"),
             Some(GovDocType::PublicLaw(_))
         ));
-        assert!(matches!(detect_gov_doc("Pub. L. 117-263"), Some(GovDocType::PublicLaw(_))));
+        assert!(matches!(
+            detect_gov_doc("Pub. L. 117-263"),
+            Some(GovDocType::PublicLaw(_))
+        ));
     }
 
     #[test]
@@ -441,7 +499,10 @@ mod tests {
             detect_gov_doc("Executive Order 14110"),
             Some(GovDocType::ExecutiveOrder(_))
         ));
-        assert!(matches!(detect_gov_doc("E.O. 13960"), Some(GovDocType::ExecutiveOrder(_))));
+        assert!(matches!(
+            detect_gov_doc("E.O. 13960"),
+            Some(GovDocType::ExecutiveOrder(_))
+        ));
     }
 
     #[test]
@@ -503,12 +564,9 @@ mod tests {
                 "packageLink": "https://api.govinfo.gov/packages/BILLS-117hr1234"
             }]
         }"#;
-        let result = parse_govinfo_response(
-            json,
-            "Test Document Title",
-            &GovDocType::Generic("".into()),
-        )
-        .unwrap();
+        let result =
+            parse_govinfo_response(json, "Test Document Title", &GovDocType::Generic("".into()))
+                .unwrap();
         assert!(result.is_found());
         assert_eq!(result.found_title.unwrap(), "Test Document Title");
     }
@@ -526,10 +584,16 @@ mod tests {
                 "resultLink": "https://api.govinfo.gov/packages/GOVPUB-C13-abc/summary"
             }]
         }"#;
-        let result =
-            parse_govinfo_response(json, "NIST SP 800-82 Rev", &GovDocType::NistSp("800-82".into()))
-                .unwrap();
-        assert!(result.is_found(), "Should match NIST SP by collection+author");
+        let result = parse_govinfo_response(
+            json,
+            "NIST SP 800-82 Rev",
+            &GovDocType::NistSp("800-82".into()),
+        )
+        .unwrap();
+        assert!(
+            result.is_found(),
+            "Should match NIST SP by collection+author"
+        );
         assert!(result.authors.iter().any(|a| a.contains("NIST")));
     }
 
@@ -597,7 +661,10 @@ mod tests {
     #[test]
     fn gov_match_nist_sp_by_collection() {
         // NIST SP from GOVPUB collection authored by NIST should match
-        let result = mock_result("GOVPUB", "National Institute of Standards and Technology (NIST)");
+        let result = mock_result(
+            "GOVPUB",
+            "National Institute of Standards and Technology (NIST)",
+        );
         assert!(gov_title_matches(
             "NIST SP 800-82 Rev",
             "Guide to Operational Technology (OT) Security",

--- a/hallucinator-rs/crates/hallucinator-core/src/db/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/mod.rs
@@ -16,6 +16,7 @@ pub mod pubmed;
 pub mod searxng;
 pub mod semantic_scholar;
 pub mod ssrn;
+pub mod standards;
 pub mod url_check;
 
 #[cfg(test)]
@@ -37,6 +38,9 @@ pub struct DbQueryResult {
     pub authors: Vec<String>,
     pub paper_url: Option<String>,
     pub retraction: Option<crate::retraction::RetractionResult>,
+    /// Optional override for the source label shown in results.
+    /// When set, the pool uses this instead of `db.name()` (e.g., "Standards (pattern)").
+    pub source_label: Option<String>,
 }
 
 impl DbQueryResult {
@@ -47,6 +51,23 @@ impl DbQueryResult {
             authors,
             paper_url: url,
             retraction: None,
+            source_label: None,
+        }
+    }
+
+    /// Construct a "found" result with a custom source label.
+    pub fn found_with_source(
+        title: impl Into<String>,
+        authors: Vec<String>,
+        url: Option<String>,
+        source_label: impl Into<String>,
+    ) -> Self {
+        Self {
+            found_title: Some(title.into()),
+            authors,
+            paper_url: url,
+            retraction: None,
+            source_label: Some(source_label.into()),
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-core/src/db/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/mod.rs
@@ -9,8 +9,8 @@ pub mod europe_pmc;
 pub mod govinfo;
 pub mod neurips;
 pub mod openalex;
-pub mod openlibrary;
 pub mod openalex_offline;
+pub mod openlibrary;
 pub mod patentsview;
 pub mod pubmed;
 pub mod searxng;
@@ -73,7 +73,13 @@ impl DbQueryResult {
 
     /// Construct a "not found" result.
     pub fn not_found() -> Self {
-        Self::default()
+        Self {
+            found_title: None,
+            authors: Vec::new(),
+            paper_url: None,
+            retraction: None,
+            source_label: None,
+        }
     }
 
     /// Whether this result represents a found paper.

--- a/hallucinator-rs/crates/hallucinator-core/src/db/openlibrary.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/openlibrary.rs
@@ -121,11 +121,9 @@ mod tests {
     #[test]
     fn test_parse_matching_book() {
         let json = r#"{"numFound": 1, "docs": [{"title": "Social Engineering: The Science of Human Hacking", "author_name": ["Christopher Hadnagy"], "key": "/works/OL123W"}]}"#;
-        let result = parse_openlibrary_response(
-            json,
-            "Social Engineering: The Science of Human Hacking",
-        )
-        .unwrap();
+        let result =
+            parse_openlibrary_response(json, "Social Engineering: The Science of Human Hacking")
+                .unwrap();
         assert!(result.is_found());
         assert_eq!(result.authors, vec!["Christopher Hadnagy"]);
     }

--- a/hallucinator-rs/crates/hallucinator-core/src/db/searxng.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/searxng.rs
@@ -167,12 +167,9 @@ impl DatabaseBackend for Searxng {
             // Normalize smart quotes/apostrophes for better matching
             // Also remove colons which some search engines interpret as field specifiers
             let clean_title = title
-                .replace('\u{2019}', "'") // Right single quote
-                .replace('\u{2018}', "'") // Left single quote
-                .replace('\u{201C}', "\"") // Left double quote
-                .replace('\u{201D}', "\"") // Right double quote
-                .replace('\u{2013}', "-") // En-dash to hyphen
-                .replace('\u{2014}', "-") // Em-dash to hyphen
+                .replace(['\u{2019}', '\u{2018}'], "'") // Curly single quotes
+                .replace(['\u{201C}', '\u{201D}'], "\"") // Curly double quotes
+                .replace(['\u{2013}', '\u{2014}'], "-") // En/em-dash to hyphen
                 .replace(':', ""); // Remove colons (interpreted as field specifiers)
             let exact_query = format!("\"{}\"", clean_title);
 
@@ -191,12 +188,11 @@ impl DatabaseBackend for Searxng {
             if keywords.len() >= 3 {
                 let keyword_query = keywords.join(" ");
 
-                match self
+                if let Ok(Some(result)) = self
                     .search_and_match(&keyword_query, title, client, timeout)
                     .await
                 {
-                    Ok(Some(result)) => return Ok(result),
-                    Ok(None) | Err(_) => {}
+                    return Ok(result);
                 }
             }
 
@@ -208,12 +204,11 @@ impl DatabaseBackend for Searxng {
                 let rfc_num = caps.get(1).unwrap().as_str();
                 let rfc_query = format!("\"RFC {}\"", rfc_num);
 
-                match self
+                if let Ok(Some(result)) = self
                     .search_and_match(&rfc_query, title, client, timeout)
                     .await
                 {
-                    Ok(Some(result)) => return Ok(result),
-                    Ok(None) | Err(_) => {}
+                    return Ok(result);
                 }
             }
 

--- a/hallucinator-rs/crates/hallucinator-core/src/db/standards.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/standards.rs
@@ -1,0 +1,551 @@
+//! Standards document verifier backend.
+//!
+//! Recognizes references to technical standards (RFCs, 3GPP specs, IEEE standards,
+//! ITU-T recommendations, etc.) and verifies them via pattern matching and, where
+//! available, free public registry APIs.
+//!
+//! Two tiers of verification:
+//! - **Tier 2** (pattern + registry lookup): IETF RFCs and Internet-Drafts use
+//!   the RFC Editor / IETF Datatracker JSON APIs for strong verification.
+//! - **Tier 1** (pattern only): 3GPP, IEEE, ITU-T, ISO, ETSI, and W3C specs are
+//!   recognized by their rigid identifier format. This is weak verification
+//!   (similar to URL liveness) but has near-zero false positives.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::{DatabaseBackend, DbQueryError, DbQueryResult};
+use crate::matching::titles_match;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+/// Standards document verifier backend.
+pub struct StandardsVerifier;
+
+/// Type of standards document detected from a citation.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum StandardType {
+    /// IETF RFC (e.g., "RFC 8446", "RFC 791")
+    Rfc(u32),
+    /// IETF Internet-Draft (e.g., "draft-ietf-tls-esni-22")
+    InternetDraft(String),
+    /// 3GPP Technical Specification or Report (e.g., "TS 38.300", "TR 22.926")
+    ThreeGpp {
+        kind: String,
+        number: String,
+    },
+    /// 3GPP working group contribution (e.g., "R1-1913017")
+    ThreeGppContrib(String),
+    /// IEEE Standard (e.g., "IEEE 802.11ax-2021", "IEEE 1588")
+    Ieee(String),
+    /// ITU-T Recommendation (e.g., "ITU-T G.711", "ITU-T X.509")
+    ItuT {
+        series: String,
+        number: String,
+    },
+    /// ISO or ISO/IEC standard (e.g., "ISO 27001", "ISO/IEC 14882:2020")
+    Iso(String),
+    /// ETSI standard (e.g., "ETSI TS 103 645", "ETSI EN 300 328")
+    Etsi {
+        kind: String,
+        number: String,
+    },
+    /// W3C specification referenced by URL
+    W3c(String),
+    /// NIST Special Publication (e.g., "NIST SP 800-53")
+    NistSp(String),
+    /// NIST FIPS (e.g., "FIPS 140-3")
+    NistFips(String),
+}
+
+/// Detect whether a title or raw citation looks like a standards document.
+///
+/// Returns `Some(StandardType)` with the parsed identifier if recognized.
+pub(crate) fn detect_standard(text: &str) -> Option<StandardType> {
+    // IETF RFC: "RFC 8446", "RFC8446", "rfc 791"
+    static RFC_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)\bRFC\s*(\d{1,5})\b").unwrap());
+    if let Some(m) = RFC_RE.captures(text) {
+        if let Ok(num) = m[1].parse::<u32>() {
+            return Some(StandardType::Rfc(num));
+        }
+    }
+
+    // IETF Internet-Draft: "draft-ietf-tls-esni-22"
+    static DRAFT_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)\b(draft-[a-z0-9][-a-z0-9]+)\b").unwrap());
+    if let Some(m) = DRAFT_RE.captures(text) {
+        return Some(StandardType::InternetDraft(m[1].to_lowercase()));
+    }
+
+    // 3GPP TS/TR: "3GPP TS 38.300", "TS38.300", "TR 22.926", "3GPP. TR22.926:"
+    // Also matches "3GPP. TS36.321:" format from parsed references
+    static THREEGPP_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\b(?:3GPP\.?\s+)?(TS|TR)\s*(\d{2}\.\d{3})\b").unwrap()
+    });
+    if let Some(m) = THREEGPP_RE.captures(text) {
+        return Some(StandardType::ThreeGpp {
+            kind: m[1].to_uppercase(),
+            number: m[2].to_string(),
+        });
+    }
+
+    // 3GPP working group contributions: "R1-1913017", "S2-2100001"
+    static THREEGPP_CONTRIB_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)\b([RS]\d)-(\d{6,7})\b").unwrap());
+    if let Some(m) = THREEGPP_CONTRIB_RE.captures(text) {
+        return Some(StandardType::ThreeGppContrib(format!(
+            "{}-{}",
+            m[1].to_uppercase(),
+            &m[2]
+        )));
+    }
+
+    // IEEE Standards: "IEEE 802.11", "IEEE Std 1588-2019", "IEEE 802.11ax-2021"
+    static IEEE_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\bIEEE\s+(?:Std\.?\s+)?(\d{3,5}(?:\.\d+[a-z]*)?(?:-\d{4})?)\b")
+            .unwrap()
+    });
+    if let Some(m) = IEEE_RE.captures(text) {
+        return Some(StandardType::Ieee(m[1].to_string()));
+    }
+
+    // ITU-T Recommendations: "ITU-T G.711", "ITU-T X.509"
+    static ITU_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)\bITU-?T\s+([A-Z])\.(\d{1,4}(?:\.\d+)?)\b").unwrap());
+    if let Some(m) = ITU_RE.captures(text) {
+        return Some(StandardType::ItuT {
+            series: m[1].to_uppercase(),
+            number: m[2].to_string(),
+        });
+    }
+
+    // ISO/IEC: "ISO 27001", "ISO/IEC 14882:2020", "ISO 8601-1:2019"
+    static ISO_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\bISO(?:/IEC)?\s+(\d{4,5}(?:[-:]\d{1,4})?(?:[-:]\d{4})?)\b").unwrap()
+    });
+    if let Some(m) = ISO_RE.captures(text) {
+        return Some(StandardType::Iso(m[1].to_string()));
+    }
+
+    // ETSI: "ETSI TS 103 645", "ETSI EN 300 328", "ETSI TR 101 112"
+    static ETSI_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\bETSI\s+(TS|TR|EN|ES|EG|GS|GR)\s+(\d{3}\s*\d{3})\b").unwrap()
+    });
+    if let Some(m) = ETSI_RE.captures(text) {
+        return Some(StandardType::Etsi {
+            kind: m[1].to_uppercase(),
+            number: m[2].to_string(),
+        });
+    }
+
+    // W3C spec URL: "https://www.w3.org/TR/css-grid-1/"
+    static W3C_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)https?://www\.w3\.org/TR/([\w-]+)/?").unwrap());
+    if let Some(m) = W3C_RE.captures(text) {
+        return Some(StandardType::W3c(m[1].to_string()));
+    }
+
+    // NIST SP: "NIST SP 800-53", "SP 800-171"
+    static NIST_SP_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)(?:NIST\s+)?SP\s+(\d{3,4}[-‐]\d+[A-Za-z]?(?:\s*[Rr]ev\.?\s*\d*)?)")
+            .unwrap()
+    });
+    if let Some(m) = NIST_SP_RE.captures(text) {
+        return Some(StandardType::NistSp(m[1].to_string()));
+    }
+
+    // NIST FIPS: "FIPS 140-3", "FIPS PUB 180-4"
+    static NIST_FIPS_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)(?:NIST\s+)?FIPS\s+(?:PUB\s+)?(\d{2,4}[-‐]?\d*)").unwrap()
+    });
+    if let Some(m) = NIST_FIPS_RE.captures(text) {
+        return Some(StandardType::NistFips(m[1].to_string()));
+    }
+
+    None
+}
+
+/// Build a human-readable label for the standard type.
+fn standard_label(st: &StandardType) -> String {
+    match st {
+        StandardType::Rfc(n) => format!("RFC {}", n),
+        StandardType::InternetDraft(name) => format!("Internet-Draft {}", name),
+        StandardType::ThreeGpp { kind, number } => format!("3GPP {} {}", kind, number),
+        StandardType::ThreeGppContrib(id) => format!("3GPP {}", id),
+        StandardType::Ieee(num) => format!("IEEE {}", num),
+        StandardType::ItuT { series, number } => format!("ITU-T {}.{}", series, number),
+        StandardType::Iso(num) => format!("ISO {}", num),
+        StandardType::Etsi { kind, number } => format!("ETSI {} {}", kind, number),
+        StandardType::W3c(name) => format!("W3C {}", name),
+        StandardType::NistSp(num) => format!("NIST SP {}", num),
+        StandardType::NistFips(num) => format!("FIPS {}", num),
+    }
+}
+
+/// Query the RFC Editor JSON API for an RFC.
+async fn query_rfc(
+    number: u32,
+    title: &str,
+    client: &reqwest::Client,
+    timeout: Duration,
+) -> Result<DbQueryResult, DbQueryError> {
+    let url = format!("https://www.rfc-editor.org/rfc/rfc{}.json", number);
+
+    let resp = client
+        .get(&url)
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| DbQueryError::Other(e.to_string()))?;
+
+    let status = resp.status().as_u16();
+    if status == 404 {
+        return Ok(DbQueryResult::not_found());
+    }
+    if status == 429 || status == 503 {
+        return Err(DbQueryError::RateLimited {
+            retry_after: Some(Duration::from_secs(2)),
+        });
+    }
+    if !resp.status().is_success() {
+        return Err(DbQueryError::Other(format!("HTTP {}", status)));
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| DbQueryError::Other(e.to_string()))?;
+
+    let json: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| DbQueryError::Other(e.to_string()))?;
+
+    let rfc_title = json["title"].as_str().unwrap_or("");
+
+    // Accept if the RFC exists (we already matched by number); optionally verify title
+    if rfc_title.is_empty() {
+        return Ok(DbQueryResult::not_found());
+    }
+
+    // Extract authors
+    let authors: Vec<String> = json["authors"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["name"].as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let paper_url = format!("https://www.rfc-editor.org/rfc/rfc{}", number);
+
+    // Use relaxed title matching — RFC titles in citations are often abbreviated
+    // or reformatted. Since we already matched by number, a loose match suffices.
+    if titles_match(title, rfc_title) || title.len() < 10 {
+        Ok(DbQueryResult::found(rfc_title, authors, Some(paper_url)))
+    } else {
+        // Title didn't match, but the RFC number was valid — still return found
+        // with the registry title so the caller can compare authors
+        Ok(DbQueryResult::found(rfc_title, authors, Some(paper_url)))
+    }
+}
+
+/// Query the IETF Datatracker for an Internet-Draft.
+async fn query_internet_draft(
+    name: &str,
+    client: &reqwest::Client,
+    timeout: Duration,
+) -> Result<DbQueryResult, DbQueryError> {
+    let url = format!(
+        "https://datatracker.ietf.org/doc/{}/doc.json",
+        urlencoding::encode(name)
+    );
+
+    let resp = client
+        .get(&url)
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| DbQueryError::Other(e.to_string()))?;
+
+    let status = resp.status().as_u16();
+    if status == 404 {
+        return Ok(DbQueryResult::not_found());
+    }
+    if status == 429 || status == 503 {
+        return Err(DbQueryError::RateLimited {
+            retry_after: Some(Duration::from_secs(2)),
+        });
+    }
+    if !resp.status().is_success() {
+        return Err(DbQueryError::Other(format!("HTTP {}", status)));
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| DbQueryError::Other(e.to_string()))?;
+
+    let json: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| DbQueryError::Other(e.to_string()))?;
+
+    let draft_title = json["title"].as_str().unwrap_or("");
+    if draft_title.is_empty() {
+        return Ok(DbQueryResult::not_found());
+    }
+
+    let paper_url = format!("https://datatracker.ietf.org/doc/{}/", name);
+
+    Ok(DbQueryResult::found(
+        draft_title,
+        vec![],
+        Some(paper_url),
+    ))
+}
+
+impl DatabaseBackend for StandardsVerifier {
+    fn name(&self) -> &str {
+        "Standards"
+    }
+
+    fn query<'a>(
+        &'a self,
+        title: &'a str,
+        client: &'a reqwest::Client,
+        timeout: std::time::Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<DbQueryResult, DbQueryError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Pre-filter: only process standards-like references
+            let std_type = match detect_standard(title) {
+                Some(st) => st,
+                None => return Ok(DbQueryResult::not_found()),
+            };
+
+            // Tier 2: query public registries for strong verification
+            match &std_type {
+                StandardType::Rfc(num) => {
+                    return query_rfc(*num, title, client, timeout).await;
+                }
+                StandardType::InternetDraft(name) => {
+                    return query_internet_draft(name, client, timeout).await;
+                }
+                _ => {}
+            }
+
+            // Tier 1: pattern-based verification (no network call)
+            // The identifier format is rigid enough that a regex match is strong
+            // evidence the document is real. Return the standard label as the
+            // "found title" so the user sees what was matched.
+            let label = standard_label(&std_type);
+            Ok(DbQueryResult::found_with_source(
+                label,
+                vec![],
+                None,
+                "Standards (pattern)",
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Pattern detection tests ──
+
+    #[test]
+    fn test_detect_rfc() {
+        assert_eq!(detect_standard("RFC 8446"), Some(StandardType::Rfc(8446)));
+        assert_eq!(detect_standard("RFC8446"), Some(StandardType::Rfc(8446)));
+        assert_eq!(detect_standard("rfc 791"), Some(StandardType::Rfc(791)));
+        assert_eq!(
+            detect_standard("HTTP Semantics, RFC 9110"),
+            Some(StandardType::Rfc(9110))
+        );
+    }
+
+    #[test]
+    fn test_detect_internet_draft() {
+        match detect_standard("draft-ietf-tls-esni-22") {
+            Some(StandardType::InternetDraft(name)) => {
+                assert_eq!(name, "draft-ietf-tls-esni-22");
+            }
+            other => panic!("Expected InternetDraft, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_3gpp_ts() {
+        match detect_standard("3GPP TS 38.300") {
+            Some(StandardType::ThreeGpp { kind, number }) => {
+                assert_eq!(kind, "TS");
+                assert_eq!(number, "38.300");
+            }
+            other => panic!("Expected ThreeGpp, got {:?}", other),
+        }
+
+        // Without "3GPP" prefix — common in citations where author is "3GPP"
+        match detect_standard("TS38.300: 5G NR: Overall Description") {
+            Some(StandardType::ThreeGpp { kind, number }) => {
+                assert_eq!(kind, "TS");
+                assert_eq!(number, "38.300");
+            }
+            other => panic!("Expected ThreeGpp, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_3gpp_tr() {
+        match detect_standard("3GPP TR 22.926: Guidelines for Extraterritorial 5G") {
+            Some(StandardType::ThreeGpp { kind, number }) => {
+                assert_eq!(kind, "TR");
+                assert_eq!(number, "22.926");
+            }
+            other => panic!("Expected ThreeGpp TR, got {:?}", other),
+        }
+
+        // With dot-separated author format: "3GPP. TR22.926:"
+        match detect_standard("TR22.926: Guidelines for Extraterritorial 5G Systems") {
+            Some(StandardType::ThreeGpp { kind, number }) => {
+                assert_eq!(kind, "TR");
+                assert_eq!(number, "22.926");
+            }
+            other => panic!("Expected ThreeGpp TR, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_3gpp_contrib() {
+        match detect_standard("R1-1913017: Doppler Compensation") {
+            Some(StandardType::ThreeGppContrib(id)) => {
+                assert_eq!(id, "R1-1913017");
+            }
+            other => panic!("Expected ThreeGppContrib, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_ieee() {
+        match detect_standard("IEEE 802.11ax-2021") {
+            Some(StandardType::Ieee(num)) => assert_eq!(num, "802.11ax-2021"),
+            other => panic!("Expected Ieee, got {:?}", other),
+        }
+        match detect_standard("IEEE Std 1588-2019") {
+            Some(StandardType::Ieee(num)) => assert_eq!(num, "1588-2019"),
+            other => panic!("Expected Ieee, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_itu_t() {
+        match detect_standard("ITU-T G.711") {
+            Some(StandardType::ItuT { series, number }) => {
+                assert_eq!(series, "G");
+                assert_eq!(number, "711");
+            }
+            other => panic!("Expected ItuT, got {:?}", other),
+        }
+        match detect_standard("ITU-T X.509") {
+            Some(StandardType::ItuT { series, number }) => {
+                assert_eq!(series, "X");
+                assert_eq!(number, "509");
+            }
+            other => panic!("Expected ItuT, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_iso() {
+        match detect_standard("ISO/IEC 14882:2020") {
+            Some(StandardType::Iso(num)) => assert_eq!(num, "14882:2020"),
+            other => panic!("Expected Iso, got {:?}", other),
+        }
+        match detect_standard("ISO 27001") {
+            Some(StandardType::Iso(num)) => assert_eq!(num, "27001"),
+            other => panic!("Expected Iso, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_etsi() {
+        match detect_standard("ETSI TS 103 645") {
+            Some(StandardType::Etsi { kind, number }) => {
+                assert_eq!(kind, "TS");
+                assert_eq!(number, "103 645");
+            }
+            other => panic!("Expected Etsi, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_w3c() {
+        match detect_standard("https://www.w3.org/TR/css-grid-1/") {
+            Some(StandardType::W3c(name)) => assert_eq!(name, "css-grid-1"),
+            other => panic!("Expected W3c, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_nist() {
+        match detect_standard("NIST SP 800-53 Rev. 5") {
+            Some(StandardType::NistSp(num)) => assert!(num.starts_with("800-53")),
+            other => panic!("Expected NistSp, got {:?}", other),
+        }
+        match detect_standard("FIPS 140-3") {
+            Some(StandardType::NistFips(num)) => assert_eq!(num, "140-3"),
+            other => panic!("Expected NistFips, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_no_match() {
+        assert!(detect_standard("A Study of Network Security").is_none());
+        assert!(detect_standard("Machine Learning for Beginners").is_none());
+    }
+
+    #[test]
+    fn test_detect_3gpp_from_sigcomm_paper() {
+        // Real references from the SIGCOMM '25 thesis paper
+        let refs = [
+            "TR22.926: Guidelines for Extraterritorial 5G Systems, Dec",
+            "TR23.737: Study on Architecture Aspects for Using Satellite Access in 5G, Jun",
+            "TR38.811: Study on New Radio (NR) to Support Non-terrestrial Networks",
+            "TS38.300: 5G NR: Overall Description; Stage-2, Mar",
+            "TS36.331: E-UTRA; Radio Resource Control (RRC), Jun",
+            "TS38.331: 5G NR: Radio Resource Control (RRC), Jun",
+            "TS24.301: Non-Access-Stratum (NAS) for EPS, Apr",
+            "TS24.501: Non-Access-Stratum (NAS) for 5G, Apr",
+            "TS36.321: Evolved Universal Terrestrial Radio Access (E-UTRA); Medium Access Control (MAC) Protocol Specification, Mar",
+            "TS38.321: 5G NR; Medium Access Control (MAC) Protocol Specification, Jun",
+            "TS33.501: Security Architecture and Procedures for 5G System, Jul",
+            "TS33.401: 3GPP System Architecture Evolution (SAE); Security Architecture, Jul",
+            "TR33.809: Study on 5G Security Enhancement against False Base Stations (FBS), Jun",
+            "TS22.042: Network Identity and TimeZone (NITZ)",
+            "TR22.872: Study on Positioning Use Cases, Jun",
+        ];
+        for r in &refs {
+            assert!(
+                detect_standard(r).is_some(),
+                "Should detect standard in: {}",
+                r
+            );
+        }
+    }
+
+    #[test]
+    fn test_standard_label() {
+        assert_eq!(standard_label(&StandardType::Rfc(8446)), "RFC 8446");
+        assert_eq!(
+            standard_label(&StandardType::ThreeGpp {
+                kind: "TS".to_string(),
+                number: "38.300".to_string()
+            }),
+            "3GPP TS 38.300"
+        );
+        assert_eq!(
+            standard_label(&StandardType::Ieee("802.11".to_string())),
+            "IEEE 802.11"
+        );
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-core/src/db/standards.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/standards.rs
@@ -15,7 +15,6 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use super::{DatabaseBackend, DbQueryError, DbQueryResult};
-use crate::matching::titles_match;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
@@ -31,26 +30,17 @@ pub(crate) enum StandardType {
     /// IETF Internet-Draft (e.g., "draft-ietf-tls-esni-22")
     InternetDraft(String),
     /// 3GPP Technical Specification or Report (e.g., "TS 38.300", "TR 22.926")
-    ThreeGpp {
-        kind: String,
-        number: String,
-    },
+    ThreeGpp { kind: String, number: String },
     /// 3GPP working group contribution (e.g., "R1-1913017")
     ThreeGppContrib(String),
     /// IEEE Standard (e.g., "IEEE 802.11ax-2021", "IEEE 1588")
     Ieee(String),
     /// ITU-T Recommendation (e.g., "ITU-T G.711", "ITU-T X.509")
-    ItuT {
-        series: String,
-        number: String,
-    },
+    ItuT { series: String, number: String },
     /// ISO or ISO/IEC standard (e.g., "ISO 27001", "ISO/IEC 14882:2020")
     Iso(String),
     /// ETSI standard (e.g., "ETSI TS 103 645", "ETSI EN 300 328")
-    Etsi {
-        kind: String,
-        number: String,
-    },
+    Etsi { kind: String, number: String },
     /// W3C specification referenced by URL
     W3c(String),
     /// NIST Special Publication (e.g., "NIST SP 800-53")
@@ -64,12 +54,11 @@ pub(crate) enum StandardType {
 /// Returns `Some(StandardType)` with the parsed identifier if recognized.
 pub(crate) fn detect_standard(text: &str) -> Option<StandardType> {
     // IETF RFC: "RFC 8446", "RFC8446", "rfc 791"
-    static RFC_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?i)\bRFC\s*(\d{1,5})\b").unwrap());
-    if let Some(m) = RFC_RE.captures(text) {
-        if let Ok(num) = m[1].parse::<u32>() {
-            return Some(StandardType::Rfc(num));
-        }
+    static RFC_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)\bRFC\s*(\d{1,5})\b").unwrap());
+    if let Some(m) = RFC_RE.captures(text)
+        && let Ok(num) = m[1].parse::<u32>()
+    {
+        return Some(StandardType::Rfc(num));
     }
 
     // IETF Internet-Draft: "draft-ietf-tls-esni-22"
@@ -81,9 +70,8 @@ pub(crate) fn detect_standard(text: &str) -> Option<StandardType> {
 
     // 3GPP TS/TR: "3GPP TS 38.300", "TS38.300", "TR 22.926", "3GPP. TR22.926:"
     // Also matches "3GPP. TS36.321:" format from parsed references
-    static THREEGPP_RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"(?i)\b(?:3GPP\.?\s+)?(TS|TR)\s*(\d{2}\.\d{3})\b").unwrap()
-    });
+    static THREEGPP_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)\b(?:3GPP\.?\s+)?(TS|TR)\s*(\d{2}\.\d{3})\b").unwrap());
     if let Some(m) = THREEGPP_RE.captures(text) {
         return Some(StandardType::ThreeGpp {
             kind: m[1].to_uppercase(),
@@ -104,8 +92,7 @@ pub(crate) fn detect_standard(text: &str) -> Option<StandardType> {
 
     // IEEE Standards: "IEEE 802.11", "IEEE Std 1588-2019", "IEEE 802.11ax-2021"
     static IEEE_RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"(?i)\bIEEE\s+(?:Std\.?\s+)?(\d{3,5}(?:\.\d+[a-z]*)?(?:-\d{4})?)\b")
-            .unwrap()
+        Regex::new(r"(?i)\bIEEE\s+(?:Std\.?\s+)?(\d{3,5}(?:\.\d+[a-z]*)?(?:-\d{4})?)\b").unwrap()
     });
     if let Some(m) = IEEE_RE.captures(text) {
         return Some(StandardType::Ieee(m[1].to_string()));
@@ -157,9 +144,8 @@ pub(crate) fn detect_standard(text: &str) -> Option<StandardType> {
     }
 
     // NIST FIPS: "FIPS 140-3", "FIPS PUB 180-4"
-    static NIST_FIPS_RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"(?i)(?:NIST\s+)?FIPS\s+(?:PUB\s+)?(\d{2,4}[-‐]?\d*)").unwrap()
-    });
+    static NIST_FIPS_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)(?:NIST\s+)?FIPS\s+(?:PUB\s+)?(\d{2,4}[-‐]?\d*)").unwrap());
     if let Some(m) = NIST_FIPS_RE.captures(text) {
         return Some(StandardType::NistFips(m[1].to_string()));
     }
@@ -187,7 +173,7 @@ fn standard_label(st: &StandardType) -> String {
 /// Query the RFC Editor JSON API for an RFC.
 async fn query_rfc(
     number: u32,
-    title: &str,
+    _title: &str,
     client: &reqwest::Client,
     timeout: Duration,
 ) -> Result<DbQueryResult, DbQueryError> {
@@ -240,15 +226,11 @@ async fn query_rfc(
 
     let paper_url = format!("https://www.rfc-editor.org/rfc/rfc{}", number);
 
-    // Use relaxed title matching — RFC titles in citations are often abbreviated
-    // or reformatted. Since we already matched by number, a loose match suffices.
-    if titles_match(title, rfc_title) || title.len() < 10 {
-        Ok(DbQueryResult::found(rfc_title, authors, Some(paper_url)))
-    } else {
-        // Title didn't match, but the RFC number was valid — still return found
-        // with the registry title so the caller can compare authors
-        Ok(DbQueryResult::found(rfc_title, authors, Some(paper_url)))
-    }
+    // RFC matched by number — always accept if the registry returned a title.
+    // `source_label` intentionally omitted (uses default `None`) so this displays
+    // as plain "Standards" (registry-verified), unlike Tier 1 pattern matches
+    // which show "Standards (pattern)".
+    Ok(DbQueryResult::found(rfc_title, authors, Some(paper_url)))
 }
 
 /// Query the IETF Datatracker for an Internet-Draft.
@@ -295,13 +277,22 @@ async fn query_internet_draft(
         return Ok(DbQueryResult::not_found());
     }
 
+    // Extract authors from the Datatracker response (same structure as RFC editor API)
+    let authors: Vec<String> = json["authors"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["name"].as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
     let paper_url = format!("https://datatracker.ietf.org/doc/{}/", name);
 
-    Ok(DbQueryResult::found(
-        draft_title,
-        vec![],
-        Some(paper_url),
-    ))
+    // `source_label` intentionally omitted (uses default `None`) so this displays
+    // as plain "Standards" (registry-verified), unlike Tier 1 pattern matches
+    // which show "Standards (pattern)".
+    Ok(DbQueryResult::found(draft_title, authors, Some(paper_url)))
 }
 
 impl DatabaseBackend for StandardsVerifier {
@@ -502,6 +493,246 @@ mod tests {
     fn test_detect_no_match() {
         assert!(detect_standard("A Study of Network Security").is_none());
         assert!(detect_standard("Machine Learning for Beginners").is_none());
+    }
+
+    // ── Group 1: StandardsVerifier::query() end-to-end (Tier 1, no network) ──
+
+    #[tokio::test]
+    async fn test_query_tier1_ieee_returns_found_with_source() {
+        let verifier = StandardsVerifier;
+        let client = reqwest::Client::new();
+        let timeout = Duration::from_secs(5);
+        let result = verifier
+            .query("IEEE 802.11ax-2021", &client, timeout)
+            .await
+            .unwrap();
+        assert!(result.is_found());
+        assert_eq!(result.source_label.as_deref(), Some("Standards (pattern)"));
+        assert_eq!(result.found_title.as_deref(), Some("IEEE 802.11ax-2021"));
+        assert!(result.authors.is_empty());
+        assert!(result.paper_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_query_tier1_3gpp_returns_found_with_source() {
+        let verifier = StandardsVerifier;
+        let client = reqwest::Client::new();
+        let timeout = Duration::from_secs(5);
+        let result = verifier
+            .query("3GPP TS 38.300", &client, timeout)
+            .await
+            .unwrap();
+        assert!(result.is_found());
+        assert_eq!(result.source_label.as_deref(), Some("Standards (pattern)"));
+        assert_eq!(result.found_title.as_deref(), Some("3GPP TS 38.300"));
+        assert!(result.authors.is_empty());
+        assert!(result.paper_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_query_tier1_iso_returns_found_with_source() {
+        let verifier = StandardsVerifier;
+        let client = reqwest::Client::new();
+        let timeout = Duration::from_secs(5);
+        let result = verifier
+            .query("ISO/IEC 14882:2020", &client, timeout)
+            .await
+            .unwrap();
+        assert!(result.is_found());
+        assert_eq!(result.source_label.as_deref(), Some("Standards (pattern)"));
+        assert_eq!(result.found_title.as_deref(), Some("ISO 14882:2020"));
+        assert!(result.authors.is_empty());
+        assert!(result.paper_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_query_non_standard_returns_not_found() {
+        let verifier = StandardsVerifier;
+        let client = reqwest::Client::new();
+        let timeout = Duration::from_secs(5);
+        let result = verifier
+            .query("A Study of Network Security", &client, timeout)
+            .await
+            .unwrap();
+        assert!(!result.is_found());
+        assert!(result.source_label.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_query_empty_string_returns_not_found() {
+        let verifier = StandardsVerifier;
+        let client = reqwest::Client::new();
+        let timeout = Duration::from_secs(5);
+        let result = verifier.query("", &client, timeout).await.unwrap();
+        assert!(!result.is_found());
+    }
+
+    #[tokio::test]
+    async fn test_query_name_is_standards() {
+        let verifier = StandardsVerifier;
+        assert_eq!(verifier.name(), "Standards");
+    }
+
+    // ── Group 2: DbQueryResult constructor tests ──
+
+    #[test]
+    fn test_found_with_source_sets_all_fields() {
+        let r = DbQueryResult::found_with_source(
+            "Title",
+            vec!["Auth".into()],
+            Some("http://x".into()),
+            "Custom",
+        );
+        assert_eq!(r.found_title.as_deref(), Some("Title"));
+        assert_eq!(r.authors, vec!["Auth"]);
+        assert_eq!(r.paper_url.as_deref(), Some("http://x"));
+        assert_eq!(r.source_label.as_deref(), Some("Custom"));
+        assert!(r.retraction.is_none());
+        assert!(r.is_found());
+    }
+
+    #[test]
+    fn test_found_has_no_source_label() {
+        let r = DbQueryResult::found("T", vec![], None);
+        assert!(r.source_label.is_none());
+    }
+
+    #[test]
+    fn test_not_found_has_all_none() {
+        let r = DbQueryResult::not_found();
+        assert!(!r.is_found());
+        assert!(r.found_title.is_none());
+        assert!(r.authors.is_empty());
+        assert!(r.paper_url.is_none());
+        assert!(r.source_label.is_none());
+        assert!(r.retraction.is_none());
+    }
+
+    // ── Group 3: Pattern detection edge cases ──
+
+    #[test]
+    fn test_detect_empty_string() {
+        assert!(detect_standard("").is_none());
+    }
+
+    #[test]
+    fn test_detect_whitespace_only() {
+        assert!(detect_standard("   ").is_none());
+    }
+
+    #[test]
+    fn test_detect_rfc_in_sentence() {
+        assert_eq!(
+            detect_standard("As described in RFC 8446, the protocol..."),
+            Some(StandardType::Rfc(8446))
+        );
+    }
+
+    #[test]
+    fn test_detect_rfc_too_large() {
+        // 6 digits exceeds \d{1,5}
+        assert!(detect_standard("RFC 999999").is_none());
+    }
+
+    #[test]
+    fn test_detect_rfc_no_false_positive_on_prefix() {
+        // "RFCA" won't match \bRFC\s*\d because "A" breaks it
+        assert!(detect_standard("RFCA 8446").is_none());
+    }
+
+    #[test]
+    fn test_detect_ieee_in_sentence() {
+        match detect_standard("The IEEE 802.11 standard defines...") {
+            Some(StandardType::Ieee(num)) => assert_eq!(num, "802.11"),
+            other => panic!("Expected Ieee, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_case_insensitive_iso() {
+        assert!(detect_standard("iso 27001").is_some());
+    }
+
+    #[test]
+    fn test_detect_case_insensitive_etsi() {
+        assert!(detect_standard("etsi ts 103 645").is_some());
+    }
+
+    #[test]
+    fn test_detect_multiple_standards_returns_first() {
+        // RFC checked before IEEE, so "RFC 8446 and IEEE 802.11" returns Rfc
+        assert_eq!(
+            detect_standard("RFC 8446 and IEEE 802.11"),
+            Some(StandardType::Rfc(8446))
+        );
+    }
+
+    #[test]
+    fn test_detect_w3c_without_trailing_slash() {
+        match detect_standard("https://www.w3.org/TR/css-grid-1") {
+            Some(StandardType::W3c(name)) => assert_eq!(name, "css-grid-1"),
+            other => panic!("Expected W3c, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_fips_pub_variant() {
+        match detect_standard("FIPS PUB 180-4") {
+            Some(StandardType::NistFips(num)) => assert_eq!(num, "180-4"),
+            other => panic!("Expected NistFips, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_nist_sp_without_prefix() {
+        // NIST prefix is optional in the regex
+        assert!(detect_standard("SP 800-53").is_some());
+    }
+
+    // ── Group 4: Remaining standard_label coverage ──
+
+    #[test]
+    fn test_standard_label_all_variants() {
+        assert_eq!(
+            standard_label(&StandardType::InternetDraft(
+                "draft-ietf-tls-esni-22".into()
+            )),
+            "Internet-Draft draft-ietf-tls-esni-22"
+        );
+        assert_eq!(
+            standard_label(&StandardType::ThreeGppContrib("R1-1913017".into())),
+            "3GPP R1-1913017"
+        );
+        assert_eq!(
+            standard_label(&StandardType::ItuT {
+                series: "G".into(),
+                number: "711".into()
+            }),
+            "ITU-T G.711"
+        );
+        assert_eq!(
+            standard_label(&StandardType::Iso("27001".into())),
+            "ISO 27001"
+        );
+        assert_eq!(
+            standard_label(&StandardType::Etsi {
+                kind: "TS".into(),
+                number: "103 645".into()
+            }),
+            "ETSI TS 103 645"
+        );
+        assert_eq!(
+            standard_label(&StandardType::W3c("css-grid-1".into())),
+            "W3C css-grid-1"
+        );
+        assert_eq!(
+            standard_label(&StandardType::NistSp("800-53".into())),
+            "NIST SP 800-53"
+        );
+        assert_eq!(
+            standard_label(&StandardType::NistFips("140-3".into())),
+            "FIPS 140-3"
+        );
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
@@ -647,6 +647,12 @@ pub(crate) fn build_database_list(
     //     databases.push(Box::new(patentsview::PatentsView::new(key.clone())));
     // }
 
+    // Standards documents (RFCs, 3GPP, IEEE, ITU-T, ISO, ETSI, etc.)
+    // No API key required; pattern-based pre-filter means zero cost for non-standards refs.
+    if should_include("Standards") {
+        databases.push(Box::new(standards::StandardsVerifier));
+    }
+
     // Open Library - books and technical reports not in academic databases
     if should_include("Open Library") {
         databases.push(Box::new(openlibrary::OpenLibrary));
@@ -673,6 +679,7 @@ mod tests {
                 "OpenAlex".into(),
                 "DOI".into(),
                 "GovInfo".into(),
+                "Standards".into(),
                 "Open Library".into(),
             ],
             ..Config::default()
@@ -693,6 +700,7 @@ mod tests {
             "Europe PMC",
             "PubMed",
             "DOI",
+            "Standards",
             "Open Library",
         ] {
             assert!(names.contains(&expected), "missing {expected}");

--- a/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
@@ -445,8 +445,7 @@ fn process_query_result(
                 // For short/ambiguous titles, suppress author mismatch — a title-only
                 // match on a short title is unreliable (likely a different paper with
                 // the same common title like "Gemma", "Sentience", "Interactions").
-                let is_short_title =
-                    title.split_whitespace().count() < SHORT_TITLE_WORD_THRESHOLD;
+                let is_short_title = title.split_whitespace().count() < SHORT_TITLE_WORD_THRESHOLD;
 
                 // Also suppress mismatch when there is zero surname overlap
                 // from fuzzy-matching databases. This prevents false mismatches
@@ -903,7 +902,7 @@ mod tests {
 
         while let Some(result) = join_set.join_next().await {
             let (name, query_result, ref_authors, elapsed) = result.unwrap();
-            match process_query_result(
+            if let Some(verified) = process_query_result(
                 name,
                 query_result,
                 elapsed,
@@ -915,8 +914,7 @@ mod tests {
                 &mut failed_dbs,
                 &mut first_mismatch,
             ) {
-                Some(verified) => panic!("Should not verify: {:?}", verified.status),
-                None => {}
+                panic!("Should not verify: {:?}", verified.status);
             }
         }
 
@@ -946,8 +944,11 @@ mod tests {
         let rate_limiters = config.rate_limiters.clone();
 
         let title = "Secure multiparty quantum computation";
-        let ref_authors_owned: Vec<String> =
-            vec!["C. Crepeau".into(), "D. Gottesman".into(), "A. Smith".into()];
+        let ref_authors_owned: Vec<String> = vec![
+            "C. Crepeau".into(),
+            "D. Gottesman".into(),
+            "A. Smith".into(),
+        ];
         let db = mock;
         let rate_limiters_clone = rate_limiters.clone();
         let ref_authors_clone = ref_authors_owned.clone();
@@ -974,7 +975,7 @@ mod tests {
 
         while let Some(result) = join_set.join_next().await {
             let (name, query_result, ref_authors, elapsed) = result.unwrap();
-            match process_query_result(
+            if let Some(verified) = process_query_result(
                 name,
                 query_result,
                 elapsed,
@@ -986,8 +987,7 @@ mod tests {
                 &mut failed_dbs,
                 &mut first_mismatch,
             ) {
-                Some(verified) => panic!("Should not verify: {:?}", verified.status),
-                None => {}
+                panic!("Should not verify: {:?}", verified.status);
             }
         }
 

--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -335,7 +335,7 @@ async fn report_result(
                 });
                 if state.verified_info.is_none() {
                     state.verified_info = Some(VerifiedInfo {
-                        source: db_name.to_string(),
+                        source: qr.source_label.clone().unwrap_or_else(|| db_name.to_string()),
                         found_authors: found_authors.clone(),
                         paper_url: paper_url.clone(),
                     });
@@ -403,7 +403,7 @@ async fn report_result(
                     && !suppress_zero_overlap
                 {
                     state.first_mismatch = Some(MismatchInfo {
-                        source: db_name.to_string(),
+                        source: qr.source_label.clone().unwrap_or_else(|| db_name.to_string()),
                         found_authors: found_authors.clone(),
                         paper_url: paper_url.clone(),
                     });
@@ -806,7 +806,7 @@ fn pre_check_remote_cache(
                     });
                     if verified_info.is_none() {
                         verified_info = Some(VerifiedInfo {
-                            source: db_name.clone(),
+                            source: qr.source_label.clone().unwrap_or_else(|| db_name.clone()),
                             found_authors: qr.authors,
                             paper_url: qr.paper_url,
                         });
@@ -855,7 +855,7 @@ fn pre_check_remote_cache(
                         && !suppress
                     {
                         first_mismatch = Some(MismatchInfo {
-                            source: db_name.clone(),
+                            source: qr.source_label.clone().unwrap_or_else(|| db_name.clone()),
                             found_authors: qr.authors,
                             paper_url: qr.paper_url,
                         });

--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -335,7 +335,10 @@ async fn report_result(
                 });
                 if state.verified_info.is_none() {
                     state.verified_info = Some(VerifiedInfo {
-                        source: qr.source_label.clone().unwrap_or_else(|| db_name.to_string()),
+                        source: qr
+                            .source_label
+                            .clone()
+                            .unwrap_or_else(|| db_name.to_string()),
                         found_authors: found_authors.clone(),
                         paper_url: paper_url.clone(),
                     });
@@ -371,26 +374,25 @@ async fn report_result(
                 let is_short_title = title.split_whitespace().count() < 6;
 
                 // Suppress mismatch when zero surname overlap from fuzzy DBs
-                let zero_overlap =
-                    if !ref_authors.is_empty() && !found_authors.is_empty() {
-                        let ref_surnames: std::collections::HashSet<String> = ref_authors
-                            .iter()
-                            .filter_map(|a| {
-                                let s = crate::authors::get_last_name_public(a);
-                                if s.is_empty() { None } else { Some(s) }
-                            })
-                            .collect();
-                        let found_surnames: std::collections::HashSet<String> = found_authors
-                            .iter()
-                            .filter_map(|a| {
-                                let s = crate::authors::get_last_name_public(a);
-                                if s.is_empty() { None } else { Some(s) }
-                            })
-                            .collect();
-                        ref_surnames.is_disjoint(&found_surnames)
-                    } else {
-                        false
-                    };
+                let zero_overlap = if !ref_authors.is_empty() && !found_authors.is_empty() {
+                    let ref_surnames: std::collections::HashSet<String> = ref_authors
+                        .iter()
+                        .filter_map(|a| {
+                            let s = crate::authors::get_last_name_public(a);
+                            if s.is_empty() { None } else { Some(s) }
+                        })
+                        .collect();
+                    let found_surnames: std::collections::HashSet<String> = found_authors
+                        .iter()
+                        .filter_map(|a| {
+                            let s = crate::authors::get_last_name_public(a);
+                            if s.is_empty() { None } else { Some(s) }
+                        })
+                        .collect();
+                    ref_surnames.is_disjoint(&found_surnames)
+                } else {
+                    false
+                };
                 let is_fuzzy_db = matches!(
                     db_name,
                     "CrossRef" | "Semantic Scholar" | "Europe PMC" | "PubMed"
@@ -403,7 +405,10 @@ async fn report_result(
                     && !suppress_zero_overlap
                 {
                     state.first_mismatch = Some(MismatchInfo {
-                        source: qr.source_label.clone().unwrap_or_else(|| db_name.to_string()),
+                        source: qr
+                            .source_label
+                            .clone()
+                            .unwrap_or_else(|| db_name.to_string()),
                         found_authors: found_authors.clone(),
                         paper_url: paper_url.clone(),
                     });
@@ -658,15 +663,15 @@ async fn finalize_collector(collector: &RefCollector) {
     // Add DOI/arXiv mismatch flags if paper is verified but identifiers are invalid
     let status = if status == Status::Verified {
         let mut mismatch_kind = MismatchKind::empty();
-        if let Some(ref di) = doi_info {
-            if !di.valid {
-                mismatch_kind |= MismatchKind::DOI;
-            }
+        if let Some(ref di) = doi_info
+            && !di.valid
+        {
+            mismatch_kind |= MismatchKind::DOI;
         }
-        if let Some(ref ai) = arxiv_info {
-            if !ai.valid {
-                mismatch_kind |= MismatchKind::ARXIV_ID;
-            }
+        if let Some(ref ai) = arxiv_info
+            && !ai.valid
+        {
+            mismatch_kind |= MismatchKind::ARXIV_ID;
         }
         if mismatch_kind.is_empty() {
             Status::Verified
@@ -822,27 +827,26 @@ fn pre_check_remote_cache(
                     });
                     // Apply short-title and zero-overlap suppression
                     let is_short_title = title.split_whitespace().count() < 6;
-                    let zero_overlap_cache =
-                        if !ref_authors.is_empty() && !qr.authors.is_empty() {
-                            let ref_surnames: std::collections::HashSet<String> = ref_authors
-                                .iter()
-                                .filter_map(|a| {
-                                    let s = crate::authors::get_last_name_public(a);
-                                    if s.is_empty() { None } else { Some(s) }
-                                })
-                                .collect();
-                            let found_surnames: std::collections::HashSet<String> = qr
-                                .authors
-                                .iter()
-                                .filter_map(|a| {
-                                    let s = crate::authors::get_last_name_public(a);
-                                    if s.is_empty() { None } else { Some(s) }
-                                })
-                                .collect();
-                            ref_surnames.is_disjoint(&found_surnames)
-                        } else {
-                            false
-                        };
+                    let zero_overlap_cache = if !ref_authors.is_empty() && !qr.authors.is_empty() {
+                        let ref_surnames: std::collections::HashSet<String> = ref_authors
+                            .iter()
+                            .filter_map(|a| {
+                                let s = crate::authors::get_last_name_public(a);
+                                if s.is_empty() { None } else { Some(s) }
+                            })
+                            .collect();
+                        let found_surnames: std::collections::HashSet<String> = qr
+                            .authors
+                            .iter()
+                            .filter_map(|a| {
+                                let s = crate::authors::get_last_name_public(a);
+                                if s.is_empty() { None } else { Some(s) }
+                            })
+                            .collect();
+                        ref_surnames.is_disjoint(&found_surnames)
+                    } else {
+                        false
+                    };
                     let is_fuzzy_db_cache = matches!(
                         db_name.as_str(),
                         "CrossRef" | "Semantic Scholar" | "Europe PMC" | "PubMed"

--- a/hallucinator-rs/crates/hallucinator-core/src/rate_limit.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/rate_limit.rs
@@ -304,6 +304,7 @@ async fn execute_query(
     db.query(title, client, timeout).await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn query_with_rate_limit(
     db: &dyn DatabaseBackend,
     title: &str,

--- a/hallucinator-rs/crates/hallucinator-parsing/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/authors.rs
@@ -42,8 +42,7 @@ pub(crate) fn extract_authors_from_reference_with_config(
 
     // Fix "word{and}" patterns where a space was lost between a name and "and"
     // e.g., "E. Dasand J. W. Burdick" → "E. Das and J. W. Burdick"
-    static MERGED_AND_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"([a-z])and ([A-Z])").unwrap());
+    static MERGED_AND_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"([a-z])and ([A-Z])").unwrap());
     let ref_text = MERGED_AND_RE.replace_all(ref_text, "$1 and $2");
     let ref_text = ref_text.as_ref();
 
@@ -415,7 +414,8 @@ mod tests {
     #[test]
     fn test_merged_and_fixed() {
         // "Dasand" should be split to "Das and" when followed by uppercase
-        let ref_text = r#"E. Dasand J. W. Burdick, "Robust control barrier functions," in IEEE, 2023."#;
+        let ref_text =
+            r#"E. Dasand J. W. Burdick, "Robust control barrier functions," in IEEE, 2023."#;
         let authors = extract_authors_from_reference(ref_text);
         assert!(
             authors.iter().any(|a| a.contains("Das")),

--- a/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
@@ -65,17 +65,14 @@ pub(crate) fn find_references_section_with_config(
     //
     // If no match has bracketed markers, fall back to the last match (handles
     // the case where "References" appears in table headers before the real list).
-    static BRACKET_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"\n\s*\[\d+\]").unwrap());
+    static BRACKET_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\n\s*\[\d+\]").unwrap());
 
     let matches: Vec<_> = header_re.find_iter(text).collect();
     let best = if matches.len() > 1 {
-        matches
-            .iter()
-            .max_by_key(|m| {
-                let rest = &text[m.end()..];
-                BRACKET_RE.find_iter(rest).count()
-            })
+        matches.iter().max_by_key(|m| {
+            let rest = &text[m.end()..];
+            BRACKET_RE.find_iter(rest).count()
+        })
     } else {
         matches.last()
     };
@@ -94,32 +91,32 @@ pub(crate) fn find_references_section_with_config(
             // NOT followed by a colon (e.g., "Artifact Appendix: Title" in a reference).
             Regex::new(concat!(
                 r"(?i)\n\s*(?:",
-                    // Explicit "Appendix" header (not followed by colon to avoid matching reference titles)
-                    r"Appendix(?:\s+[A-Z0-9]|\s*\n|\s*$)|",
-                    // Common post-bibliography section headers
-                    r"Acknowledgments|Acknowledgements|Supplementary|",
-                    r"Ethics\s+Statement|Ethical\s+Considerations|Broader\s+Impact|",
-                    // Conference checklists
-                    r"(?:\w+\s+)?(?:Paper\s+)?Checklist|",
-                    // Single-letter appendix sections: "A\nTechnical Lemmas" (NeurIPS style)
-                    r"[A-Z]\n\s*(?:Appendix|Technical|Proofs?|Additional|Extended|Experimental|",
-                    r"Derivations?|Algorithms?|Detailed?|Implementation|Analysis|Benchmark|",
-                    r"Datasets?|Ablation|Hyperparameters?|Prompt|Annotation|Evaluation|",
-                    r"Training|Baseline|Reproducibility|Limitations?|Discussion|",
-                    r"Examples?|Supplementary|Survey|Questionnaire|Full|Further|",
-                    r"Post-Processing|Human|Category|Scoring|Results)|",
-                    // "A.\n\nTitle" pattern (ACM/LREC appendix with period after letter)
-                    r"[A-Z]\.\s*\n\s*(?:Prompt|Annotation|Evaluation|Training|Baseline|",
-                    r"Full|Further|Additional|Detailed?|Post-Processing|Human|Category|",
-                    r"Scoring|Results|Supplementary|Survey|Questionnaire|Examples?|",
-                    r"Reproducibility|Implementation|Limitations?|Discussion|",
-                    r"Proof|Derivation|Algorithm|Benchmark|Dataset|Ablation|",
-                    r"Hyperparameter|Extended|Experimental|Analysis|Error)|",
-                    // "A.1", "B.2" numbered appendix sub-sections on their own line
-                    r"[A-Z]\.\d+\s*\n",
+                // Explicit "Appendix" header (not followed by colon to avoid matching reference titles)
+                r"Appendix(?:\s+[A-Z0-9]|\s*\n|\s*$)|",
+                // Common post-bibliography section headers
+                r"Acknowledgments|Acknowledgements|Supplementary|",
+                r"Ethics\s+Statement|Ethical\s+Considerations|Broader\s+Impact|",
+                // Conference checklists
+                r"(?:\w+\s+)?(?:Paper\s+)?Checklist|",
+                // Single-letter appendix sections: "A\nTechnical Lemmas" (NeurIPS style)
+                r"[A-Z]\n\s*(?:Appendix|Technical|Proofs?|Additional|Extended|Experimental|",
+                r"Derivations?|Algorithms?|Detailed?|Implementation|Analysis|Benchmark|",
+                r"Datasets?|Ablation|Hyperparameters?|Prompt|Annotation|Evaluation|",
+                r"Training|Baseline|Reproducibility|Limitations?|Discussion|",
+                r"Examples?|Supplementary|Survey|Questionnaire|Full|Further|",
+                r"Post-Processing|Human|Category|Scoring|Results)|",
+                // "A.\n\nTitle" pattern (ACM/LREC appendix with period after letter)
+                r"[A-Z]\.\s*\n\s*(?:Prompt|Annotation|Evaluation|Training|Baseline|",
+                r"Full|Further|Additional|Detailed?|Post-Processing|Human|Category|",
+                r"Scoring|Results|Supplementary|Survey|Questionnaire|Examples?|",
+                r"Reproducibility|Implementation|Limitations?|Discussion|",
+                r"Proof|Derivation|Algorithm|Benchmark|Dataset|Ablation|",
+                r"Hyperparameter|Extended|Experimental|Analysis|Error)|",
+                // "A.1", "B.2" numbered appendix sub-sections on their own line
+                r"[A-Z]\.\d+\s*\n",
                 r")",
             ))
-                .unwrap()
+            .unwrap()
         });
 
         let end_re = config.section_end_re.as_ref().unwrap_or(&END_RE);

--- a/hallucinator-rs/crates/hallucinator-parsing/src/text_processing.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/text_processing.rs
@@ -219,7 +219,7 @@ fn fix_separated_diacritics_pdf(text: &str) -> String {
         Lazy::new(|| Regex::new(r"([A-Za-z])\s+([\u{a8}\u{b4}`\u{2dc}\u{2c7}\u{b8}])").unwrap());
 
     // Step 1: Remove space between letter and following diacritic
-    let text = SPACE_BEFORE_RE.replace_all(&text, "$1$2");
+    let text = SPACE_BEFORE_RE.replace_all(text, "$1$2");
 
     // Step 2: Compose diacritic + letter
     DIACRITIC_RE

--- a/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
@@ -361,9 +361,8 @@ pub(crate) fn clean_title_with_config(
     }
 
     // Strip trailing edition markers: "(1st ed.)" or "(2nd edition)"
-    static TRAILING_EDITION_RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\s*\(\d+(?:st|nd|rd|th)\s+(?:ed\.?|edition)\)\s*$").unwrap()
-    });
+    static TRAILING_EDITION_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\s*\(\d+(?:st|nd|rd|th)\s+(?:ed\.?|edition)\)\s*$").unwrap());
     if let Some(m) = TRAILING_EDITION_RE.find(&title) {
         title = title[..m.start()].to_string();
     }
@@ -1182,16 +1181,16 @@ fn try_arxiv_preprint(ref_text: &str) -> Option<(String, bool)> {
         Regex::new(r"\.\s*(?:19|20)\d{2}\.\s+([^.]+(?:\.[^.]+)*)\.\s*arXiv\s*:\s*\d+\.\d+").unwrap()
     });
 
-    if let Some(caps) = RE4.captures(ref_text) {
-        if let Some(title_match) = caps.get(1) {
-            let title = title_match.as_str().trim();
-            // Ensure it's a reasonable title (not just venue info)
-            if title.split_whitespace().count() >= 2
-                && !title.starts_with("In ")
-                && !title.starts_with("Proceedings")
-            {
-                return Some((title.to_string(), false));
-            }
+    if let Some(caps) = RE4.captures(ref_text)
+        && let Some(title_match) = caps.get(1)
+    {
+        let title = title_match.as_str().trim();
+        // Ensure it's a reasonable title (not just venue info)
+        if title.split_whitespace().count() >= 2
+            && !title.starts_with("In ")
+            && !title.starts_with("Proceedings")
+        {
+            return Some((title.to_string(), false));
         }
     }
 
@@ -3820,7 +3819,10 @@ mod tests {
     #[test]
     fn test_clean_title_strips_publisher() {
         assert_eq!(
-            clean_title("The Book of Why: The New Science of Cause and Effect. Basic Books", false),
+            clean_title(
+                "The Book of Why: The New Science of Cause and Effect. Basic Books",
+                false
+            ),
             "The Book of Why: The New Science of Cause and Effect"
         );
     }

--- a/hallucinator-rs/crates/hallucinator-parsing/tests/arxiv_ground_truth_dict.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/tests/arxiv_ground_truth_dict.rs
@@ -168,32 +168,30 @@ fn refs_to_titles(result: &ExtractionResult) -> Vec<String> {
 
 fn build_ground_truth(pair: &PaperPair) -> Option<GroundTruth> {
     // Prefer .bbl — it reflects exactly what's compiled into the PDF.
-    if let Some(bbl_path) = &pair.bbl_path {
-        if let Ok(content) = std::fs::read_to_string(bbl_path) {
-            if let Ok(result) = extract_references_from_bbl_str(&content) {
-                let titles = deduplicate_titles(refs_to_titles(&result));
-                if !titles.is_empty() {
-                    return Some(GroundTruth {
-                        source: "bbl",
-                        titles,
-                    });
-                }
-            }
+    if let Some(bbl_path) = &pair.bbl_path
+        && let Ok(content) = std::fs::read_to_string(bbl_path)
+        && let Ok(result) = extract_references_from_bbl_str(&content)
+    {
+        let titles = deduplicate_titles(refs_to_titles(&result));
+        if !titles.is_empty() {
+            return Some(GroundTruth {
+                source: "bbl",
+                titles,
+            });
         }
     }
 
     // Fall back to .bib (superset — may contain uncited entries).
-    if let Some(bib_path) = &pair.bib_path {
-        if let Ok(content) = std::fs::read_to_string(bib_path) {
-            if let Ok(result) = extract_references_from_bib_str(&content) {
-                let titles = deduplicate_titles(refs_to_titles(&result));
-                if !titles.is_empty() {
-                    return Some(GroundTruth {
-                        source: "bib",
-                        titles,
-                    });
-                }
-            }
+    if let Some(bib_path) = &pair.bib_path
+        && let Ok(content) = std::fs::read_to_string(bib_path)
+        && let Ok(result) = extract_references_from_bib_str(&content)
+    {
+        let titles = deduplicate_titles(refs_to_titles(&result));
+        if !titles.is_empty() {
+            return Some(GroundTruth {
+                source: "bib",
+                titles,
+            });
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
+++ b/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
@@ -779,16 +779,16 @@ fn export_text(
                     r.ref_authors.join(", ")
                 ));
             }
-            if let Status::Mismatch(kind) = &r.status {
-                if kind.contains(MismatchKind::AUTHOR) {
-                    if !r.found_authors.is_empty() {
-                        out.push_str(&format!(
-                            "       Authors (DB):  {}\n",
-                            r.found_authors.join(", ")
-                        ));
-                    } else {
-                        out.push_str("       Authors (DB):  (no authors returned)\n");
-                    }
+            if let Status::Mismatch(kind) = &r.status
+                && kind.contains(MismatchKind::AUTHOR)
+            {
+                if !r.found_authors.is_empty() {
+                    out.push_str(&format!(
+                        "       Authors (DB):  {}\n",
+                        r.found_authors.join(", ")
+                    ));
+                } else {
+                    out.push_str("       Authors (DB):  (no authors returned)\n");
                 }
             }
 
@@ -1275,24 +1275,24 @@ fn write_html_ref(out: &mut String, ref_num: usize, r: &ValidationResult, fp: Op
     }
 
     // Author comparison for mismatches
-    if let Status::Mismatch(kind) = &r.status {
-        if kind.contains(MismatchKind::AUTHOR) {
-            out.push_str("<div class=\"author-compare\">\n");
-            out.push_str(&format!(
-                "<div class=\"pdf-authors\"><strong>PDF:</strong> {}</div>\n",
-                html_escape(&r.ref_authors.join(", "))
-            ));
-            let db_authors_text = if r.found_authors.is_empty() {
-                "<em>(no authors returned)</em>".to_string()
-            } else {
-                html_escape(&r.found_authors.join(", "))
-            };
-            out.push_str(&format!(
-                "<div class=\"db-authors\"><strong>DB:</strong> {}</div>\n",
-                db_authors_text
-            ));
-            out.push_str("</div>\n");
-        }
+    if let Status::Mismatch(kind) = &r.status
+        && kind.contains(MismatchKind::AUTHOR)
+    {
+        out.push_str("<div class=\"author-compare\">\n");
+        out.push_str(&format!(
+            "<div class=\"pdf-authors\"><strong>PDF:</strong> {}</div>\n",
+            html_escape(&r.ref_authors.join(", "))
+        ));
+        let db_authors_text = if r.found_authors.is_empty() {
+            "<em>(no authors returned)</em>".to_string()
+        } else {
+            html_escape(&r.found_authors.join(", "))
+        };
+        out.push_str(&format!(
+            "<div class=\"db-authors\"><strong>DB:</strong> {}</div>\n",
+            db_authors_text
+        ));
+        out.push_str("</div>\n");
     }
 
     // DOI / arXiv

--- a/hallucinator-rs/crates/hallucinator-scowl/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-scowl/src/lib.rs
@@ -66,6 +66,7 @@ impl ScowlDictionary {
     ///
     /// Each line should contain one word. Empty lines and lines starting
     /// with '#' are ignored.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(content: &str) -> Self {
         let words = content
             .lines()


### PR DESCRIPTION
## Summary

- Adds a new `Standards` database backend that verifies references to technical standards documents (RFCs, 3GPP specs, IEEE standards, ITU-T, ISO/IEC, ETSI, W3C, NIST)
- **Tier 2** (registry lookup): IETF RFCs query `rfc-editor.org` JSON API, Internet-Drafts query IETF Datatracker — returns title + authors for strong verification
- **Tier 1** (pattern recognition): 3GPP TS/TR, IEEE, ITU-T, ISO/IEC, ETSI, W3C, and NIST identifiers recognized by their rigid format — shown as `VERIFIED (Standards (pattern))` in results
- Enabled by default (no API key needed), zero cost for non-standards references via regex pre-filtering
- Adds `DbQueryResult::source_label` field for per-result source name overrides, wired through the pool's `VerifiedInfo` and `MismatchInfo` paths

Motivated by false positives on papers citing many 3GPP specs (e.g., `TS 38.300`, `TR 22.926`) which no academic database indexes.

## Test plan

- [x] 14 new unit tests for pattern detection covering all standards types
- [x] Tests for real-world 3GPP references from SIGCOMM '25 paper
- [x] Full test suite passes (726 tests, 0 failures)
- [ ] Manual test: run against `3718958.3750522.pdf` (SIGCOMM satellite paper with ~25 3GPP refs)
- [ ] Manual test: run against a paper with RFC references to verify Tier 2 API lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)