### PR TITLE
Recover URL / title when PDFs render filename underscores as spaces

### DIFF
--- a/hallucinator-rs/crates/hallucinator-core/src/text_utils.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/text_utils.rs
@@ -137,6 +137,35 @@ fn fix_url_spacing(url_region: &str) -> String {
     static SPACED_HYPHEN: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\w)\s*-\s*(\w)").unwrap());
     result = SPACED_HYPHEN.replace_all(&result, "$1-$2").to_string();
 
+    // Restore underscores lost by PDF font rendering in a trailing filename.
+    //
+    // Some PDFs render `_` inside a URL path as literal whitespace, so
+    // `fuzzing/cjson_read_fuzzer.c` comes through as `fuzzing/cjson read
+    // fuzzer.c`. To recover without touching narrative text that might
+    // follow a URL, the rewrite is gated on:
+    //
+    //   * the match starting at a `/` (inside a path segment),
+    //   * the token sequence ending in a short file extension
+    //     (`.[A-Za-z]{1,6}`), and
+    //   * the match anchoring to end-of-region (`\s*$`).
+    //
+    // That last anchor is the main safety: the pattern only rewrites a
+    // filename-like suffix at the very end of the URL region. It does not
+    // fire on `https://example.com/page Section 3 has ref.txt` (trailing
+    // narrative) because there the extension-bearing token is not the
+    // end-of-region — the file-extension check plus anchor together keep
+    // the rewrite confined to legitimate filename suffixes.
+    static FILENAME_LOST_UNDERSCORES: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"/([A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)+\.[A-Za-z0-9]{1,6})\s*$").unwrap()
+    });
+    static INTERNAL_WS: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
+    result = FILENAME_LOST_UNDERSCORES
+        .replace(&result, |caps: &regex::Captures| {
+            let rebuilt = INTERNAL_WS.replace_all(&caps[1], "_");
+            format!("/{}", rebuilt)
+        })
+        .to_string();
+
     result
 }
 
@@ -792,5 +821,80 @@ mod tests {
         let text3 = "[96] Julien. n.d.. Reverse-Engineering. https://www.julien\nverneaut.com/en/experiments Accessed";
         let urls3 = extract_urls(text3);
         assert_eq!(urls3, vec!["https://www.julienverneaut.com/en/experiments"]);
+    }
+
+    // ── Filename-lost-underscores recovery (2026-s820-paper ref 21) ──
+
+    #[test]
+    fn test_extract_urls_filename_lost_underscores() {
+        // Regression test for NDSS 2026 f168/s820 pattern: some PDF fonts
+        // render `_` inside a URL path as literal whitespace, so the source
+        // URL `.../fuzzing/cjson_read_fuzzer.c` comes through as
+        // `.../fuzzing/cjson read fuzzer.c`. Combined with a line break after
+        // `github.com/`, extract_urls previously truncated at the first
+        // internal space. The post-fix pass should restore the trailing
+        // filename so URL Check can verify the link.
+        let text = r#""cjson read fuzzer.c." [Online]. Available: https://github.com/ DaveGamble/cJSON/blob/master/fuzzing/cjson read fuzzer.c"#;
+        let urls = extract_urls(text);
+        assert_eq!(
+            urls,
+            vec![
+                "https://github.com/DaveGamble/cJSON/blob/master/fuzzing/cjson_read_fuzzer.c"
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_extract_urls_multi_word_filename() {
+        // Same pattern with three internal spaces, all lost underscores.
+        let text = "see https://example.com/path/very long file.py";
+        let urls = extract_urls(text);
+        assert_eq!(urls, vec!["https://example.com/path/very_long_file.py"]);
+    }
+
+    #[test]
+    fn test_extract_urls_narrative_after_short_url_untouched() {
+        // Guard: a URL with no file-extension suffix followed by narrative
+        // text must not have its trailing words collapsed into the path.
+        // Here `"foo for details"` has no `.ext`, so the restoration rule
+        // does not fire; extract_urls still stops at the first space.
+        let text = "Code at https://github.com/user/repo for details.";
+        let urls = extract_urls(text);
+        assert_eq!(urls, vec!["https://github.com/user/repo"]);
+    }
+
+    #[test]
+    fn test_extract_urls_url_then_filename_elsewhere_not_mangled_by_new_rule() {
+        // Guard: the filename-lost-underscores rule must NOT merge trailing
+        // narrative into the URL. The rule requires the match to start at
+        // `/`; `page.` contains no later slash that the rewrite could
+        // anchor on, so the new rule does not fire.
+        //
+        // (Separately, the pre-existing SPACED_DOT rule collapses
+        // `page. Download` to `page.Download`; this test only asserts the
+        // NEW rule behaves, not the pre-existing space-around-dot rule.)
+        let text = "See https://example.com/page. Download file.pdf.";
+        let urls = extract_urls(text);
+        assert_eq!(urls.len(), 1);
+        let url = &urls[0];
+        // Critical post-condition: "file.pdf" must NOT have been pulled
+        // into the URL as "file_pdf" or similar; the new rule stays off.
+        assert!(!url.contains("_pdf"), "unexpected mangle: {}", url);
+        assert!(!url.contains("file.pdf"), "trailing narrative pulled in: {}", url);
+    }
+
+    #[test]
+    fn test_extract_urls_nested_slash_filename_only_tail_joined() {
+        // Ensure only the *trailing* filename-like segment is rewritten —
+        // earlier path segments that happen to contain whitespace but no
+        // extension are left intact (defensive; real PDFs don't produce
+        // this shape but we want the anchor to matter).
+        let text = "https://example.com/some dir/other dir/real_file.py";
+        let urls = extract_urls(text);
+        // Leading "some dir"/"other dir" have no file extension so are not
+        // rewritten. The URL extractor correctly stops at the first space
+        // that wasn't restored.
+        assert_eq!(urls, vec!["https://example.com/some"]);
     }
 }

--- a/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
@@ -2448,17 +2448,20 @@ pub(crate) static DEFAULT_CUTOFF_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
         Regex::new(r"(?i)\.\s*KI-K\u{00FC}nstliche.*$").unwrap(),
         // Handle BUG #5: IEEE-style `"Title," in VENUE, …` references that
         // get mis-segmented as `Title.: in VENUE, …` or `Title.: VENUE, …`.
-        // The `.:` sequence before a capital letter is essentially never a
-        // legitimate title punctuation (a real title never ends one clause
-        // with `.:` and starts the next with a capitalised word). Stripping
-        // `.:` plus everything that follows recovers titles like:
+        // The `.:` sequence before a capital letter — or before a bracketed
+        // annotation like `[Online]` / `[Available]` that web-citation PDFs
+        // emit — is essentially never legitimate title punctuation (a real
+        // title never ends one clause with `.:` and starts the next with a
+        // capitalised word or bracketed marker). Stripping `.:` plus
+        // everything that follows recovers titles like:
         //   "Opaque control-flow integrity.: in NDSS, vol. 26, 2015"
         //   "Snow white: Provably secure proofs of stake.: IACR Cryptol. …"
         //   "Sanc-tuary: Arming trustzone ….: in NDSS"
+        //   "cjson read fuzzer.c.: [Online]. Available: https://…"
         //
         // The `?:` / `!:` variants are handled in `clean_title_with_config`
         // directly (ahead of this table) so the `?` / `!` can be preserved.
-        Regex::new(r"\.:\s+(?:[Ii]n\s+)?[A-Z].*$").unwrap(),
+        Regex::new(r"\.:\s+(?:[Ii]n\s+)?(?:[A-Z]|\[).*$").unwrap(),
         Regex::new(r"\s+arXiv\s+preprint.*$").unwrap(),
         Regex::new(r"\s+arXiv:\d+.*$").unwrap(),
         Regex::new(r"\s+CoRR\s+abs/.*$").unwrap(),
@@ -2543,6 +2546,18 @@ mod tests {
             (
                 "Private set intersection: Are garbled circuits better than custom protocols?: in NDSS. The Internet Society",
                 "Private set intersection: Are garbled circuits better than custom protocols?",
+            ),
+            // `[Online]` / web-citation bracketed annotation (NDSS 2026
+            // s820 ref 21) — previously left trailing "cjson read
+            // fuzzer.c.: [Online]" because the cutoff regex required a
+            // capital letter immediately after `.:` and `[` was not one.
+            (
+                "cjson read fuzzer.c.: [Online]. Available: https://github.com/DaveGamble/cJSON",
+                "cjson read fuzzer.c",
+            ),
+            (
+                "Some page.: [Available]. see link",
+                "Some page",
             ),
         ];
         for (input, expected) in cases {


### PR DESCRIPTION
## Summary

Stacked on top of #259 (usenix-fp-fix). Addresses a failure mode seen on NDSS 2026 paper `2026-s820-paper.pdf` ref 21, where the cited URL
```
https://github.com/DaveGamble/cJSON/blob/master/fuzzing/cjson_read_fuzzer.c
```
came through PDF extraction as
```
https://github.com/ DaveGamble/cJSON/blob/master/fuzzing/cjson read fuzzer.c
```
— the line break after `github.com/` becomes a literal space, and every `_` in the filename is rendered as whitespace by the PDF font. Two independent fixes:

### Fix 1 — URL cleaner: restore filename underscores (`text_utils::fix_url_spacing`)

New last-step rewrite inside `fix_url_spacing`: when a URL region ends with a filename-like trailing segment that has internal whitespace, replace the whitespace with underscores.

Gated three ways to keep narrative text safe:
1. Must start at a `/` (inside a path segment).
2. Must end in a short file extension `.[A-Za-z0-9]{1,6}`.
3. Must anchor to end-of-region (`\s*$`) — the extension-bearing token has to be the final token of the URL region.

Covered by:
- `test_extract_urls_filename_lost_underscores` (the cjson case)
- `test_extract_urls_multi_word_filename`
- `test_extract_urls_narrative_after_short_url_untouched` (guard — URL without extension keeps trailing narrative out)
- `test_extract_urls_url_then_filename_elsewhere_not_mangled_by_new_rule` (guard — `See https://example.com/page. Download file.pdf` does not merge)
- `test_extract_urls_nested_slash_filename_only_tail_joined` (guard — earlier path segments with whitespace are not rewritten)

### Fix 2 — Title cleaner: extend `.:` cutoff to bracketed annotations (`title::clean_title_with_config`)

The existing `.:` venue-bleed regex required a capital letter immediately after `.:`, so the IEEE-format citation
```
"Title." [Online]. Available: https://…
```
survived with a title of `Title.: [Online]`. Widen the regex from
```
\.:\s+(?:[Ii]n\s+)?[A-Z].*$
```
to
```
\.:\s+(?:[Ii]n\s+)?(?:[A-Z]|\[).*$
```
so bracketed web-citation annotations are stripped. Two new cases added to the existing `test_clean_title_colon_in_acronym_venue` table (cjson case + generic `[Available]` case).

## Test plan

- [x] `cargo test --workspace` — **788 passed, 0 failed, 14 ignored** (up from 783 on `usenix-fp-fix`; 5 new tests added, 0 pre-existing tests affected)
- [x] End-to-end rerun on `2026-s820-paper.pdf`:
  - Before: 46 verified, 1 not_found (ref 21 `cjson read fuzzer.c.: [Online]`)
  - After: **47 verified, 0 not_found** — ref 21 now verified via URL Check at the restored URL `https://github.com/DaveGamble/cJSON/blob/master/fuzzing/cjson_read_fuzzer.c`
- [x] No regressions on the NDSS 2026 sample (75 PDFs, DBLP-only). The 9 apparent "verified → not-verified" diffs between the pre-PR comparison JSON and a fresh run were traced to **cache artefacts** in the pre-PR JSON (which had URL-Check results cached from earlier full-DB runs). Verified by re-running the pre-fix binary on a fresh cache: it produces the same `not_found` result as the post-fix binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)