### PR TITLE
Respect mark-safe overrides throughout the TUI and fix cached-URL-check regression

### DIFF
--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -472,6 +472,136 @@ async fn report_result(
     }
 }
 
+/// Run the URL-liveness and SearxNG web-search fallbacks when the primary
+/// DB aggregation came back `NotFound`. Returns the possibly-updated
+/// `(status, source, found_authors, paper_url, db_results)` tuple.
+///
+/// Shared by three call sites in `pool.rs`:
+///
+///   * `finalize_collector` — after concurrent drainers finish.
+///   * `coordinator_loop`'s no-remote-DBs branch — when the user has
+///     disabled every remote backend.
+///   * `coordinator_loop`'s all-cache-hit-none-verified branch — where
+///     this used to be missing. Regression symptom: on a fresh run the
+///     URL-check fallback correctly verified refs that only lived on
+///     GitHub / blog posts, but on any subsequent run against the same
+///     cache every remote DB was a NotFound cache hit, the branch skipped
+///     straight to building a `Status::NotFound` result, and URL Check
+///     never ran — so previously-URL-verified refs came back as
+///     hallucinations. Folding all three sites through this helper makes
+///     it harder for one to drift again.
+///
+/// The retraction field is *not* touched here (it's threaded through
+/// separately from the cached CrossRef response).
+async fn apply_fallbacks(
+    status: Status,
+    source: Option<String>,
+    found_authors: Vec<String>,
+    paper_url: Option<String>,
+    mut db_results: Vec<DbResult>,
+    urls: &[String],
+    title: &str,
+    config: &Config,
+    client: &reqwest::Client,
+    progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+    ref_index: usize,
+) -> (
+    Status,
+    Option<String>,
+    Vec<String>,
+    Option<String>,
+    Vec<DbResult>,
+) {
+    // ── URL liveness check ─────────────────────────────────────────────
+    if status == Status::NotFound && !urls.is_empty() {
+        let timeout = Duration::from_secs(config.db_timeout_secs);
+        let start = std::time::Instant::now();
+        let url_result = UrlChecker::check_first_live(urls, client, timeout).await;
+        let elapsed = start.elapsed();
+
+        if let Some(url_result) = url_result {
+            let url = url_result.final_url.unwrap_or(url_result.url);
+            progress(ProgressEvent::DatabaseQueryComplete {
+                paper_index: 0,
+                ref_index,
+                db_name: "URL Check".to_string(),
+                status: DbStatus::Match,
+                elapsed,
+            });
+            db_results.push(DbResult {
+                db_name: "URL Check".into(),
+                status: DbStatus::Match,
+                elapsed: Some(elapsed),
+                found_authors: vec![],
+                paper_url: Some(url.clone()),
+                error_message: None,
+            });
+            return (
+                Status::Verified,
+                Some("URL Check".into()),
+                vec![],
+                Some(url),
+                db_results,
+            );
+        }
+        progress(ProgressEvent::DatabaseQueryComplete {
+            paper_index: 0,
+            ref_index,
+            db_name: "URL Check".to_string(),
+            status: DbStatus::NoMatch,
+            elapsed,
+        });
+    }
+
+    // ── SearxNG web-search fallback ────────────────────────────────────
+    if status == Status::NotFound
+        && let Some(ref searxng_url) = config.searxng_url
+    {
+        let searxng = Searxng::new(searxng_url.clone());
+        let timeout = Duration::from_secs(config.db_timeout_secs);
+        let start = std::time::Instant::now();
+        let searxng_result = searxng.query(title, client, timeout).await;
+        let elapsed = start.elapsed();
+
+        if let Ok(ref qr) = searxng_result
+            && qr.is_found()
+        {
+            let url = qr.paper_url.clone();
+            progress(ProgressEvent::DatabaseQueryComplete {
+                paper_index: 0,
+                ref_index,
+                db_name: "Web Search".to_string(),
+                status: DbStatus::Match,
+                elapsed,
+            });
+            db_results.push(DbResult {
+                db_name: "Web Search".into(),
+                status: DbStatus::Match,
+                elapsed: Some(elapsed),
+                found_authors: vec![],
+                paper_url: url.clone(),
+                error_message: None,
+            });
+            return (
+                Status::Verified,
+                Some("Web Search".into()),
+                vec![],
+                url,
+                db_results,
+            );
+        }
+        progress(ProgressEvent::DatabaseQueryComplete {
+            paper_index: 0,
+            ref_index,
+            db_name: "Web Search".to_string(),
+            status: DbStatus::NoMatch,
+            elapsed,
+        });
+    }
+
+    (status, source, found_authors, paper_url, db_results)
+}
+
 /// Build the final result and send it on the oneshot channel.
 ///
 /// Called exactly once, by whichever drainer decrements `remaining` to 0.
@@ -520,113 +650,21 @@ async fn finalize_collector(collector: &RefCollector) {
         }
     };
 
-    // URL liveness check for references with embedded URLs
-    let (status, source, found_authors, paper_url, remote_db_results) =
-        if status == Status::NotFound && !collector.reference.urls.is_empty() {
-            let timeout = Duration::from_secs(collector.config.db_timeout_secs);
-            let start = std::time::Instant::now();
-
-            if let Some(url_result) =
-                UrlChecker::check_first_live(&collector.reference.urls, &collector.client, timeout)
-                    .await
-            {
-                let elapsed = start.elapsed();
-                let url = url_result.final_url.unwrap_or(url_result.url);
-                (collector.progress)(ProgressEvent::DatabaseQueryComplete {
-                    paper_index: 0,
-                    ref_index: collector.ref_index,
-                    db_name: "URL Check".to_string(),
-                    status: DbStatus::Match,
-                    elapsed,
-                });
-                let mut db_results = remote_db_results;
-                db_results.push(DbResult {
-                    db_name: "URL Check".into(),
-                    status: DbStatus::Match,
-                    elapsed: Some(elapsed),
-                    found_authors: vec![],
-                    paper_url: Some(url.clone()),
-                    error_message: None,
-                });
-                (
-                    Status::Verified,
-                    Some("URL Check".into()),
-                    vec![],
-                    Some(url),
-                    db_results,
-                )
-            } else {
-                let elapsed = start.elapsed();
-                (collector.progress)(ProgressEvent::DatabaseQueryComplete {
-                    paper_index: 0,
-                    ref_index: collector.ref_index,
-                    db_name: "URL Check".to_string(),
-                    status: DbStatus::NoMatch,
-                    elapsed,
-                });
-                (status, source, found_authors, paper_url, remote_db_results)
-            }
-        } else {
-            (status, source, found_authors, paper_url, remote_db_results)
-        };
-
-    // SearxNG fallback for NotFound references
-    let (status, source, found_authors, paper_url, remote_db_results) =
-        if status == Status::NotFound {
-            if let Some(ref searxng_url) = collector.config.searxng_url {
-                let searxng = Searxng::new(searxng_url.clone());
-                let timeout = Duration::from_secs(collector.config.db_timeout_secs);
-
-                let start = std::time::Instant::now();
-                let searxng_result = searxng
-                    .query(&collector.title, &collector.client, timeout)
-                    .await;
-                let elapsed = start.elapsed();
-
-                if let Ok(ref qr) = searxng_result
-                    && qr.is_found()
-                {
-                    let url = qr.paper_url.clone();
-                    (collector.progress)(ProgressEvent::DatabaseQueryComplete {
-                        paper_index: 0,
-                        ref_index: collector.ref_index,
-                        db_name: "Web Search".to_string(),
-                        status: DbStatus::Match,
-                        elapsed,
-                    });
-                    // Web search found the paper
-                    let mut db_results = remote_db_results;
-                    db_results.push(DbResult {
-                        db_name: "Web Search".into(),
-                        status: DbStatus::Match,
-                        elapsed: Some(elapsed),
-                        found_authors: vec![],
-                        paper_url: url.clone(),
-                        error_message: None,
-                    });
-                    (
-                        Status::Verified,
-                        Some("Web Search".into()),
-                        vec![],
-                        url,
-                        db_results,
-                    )
-                } else {
-                    (collector.progress)(ProgressEvent::DatabaseQueryComplete {
-                        paper_index: 0,
-                        ref_index: collector.ref_index,
-                        db_name: "Web Search".to_string(),
-                        status: DbStatus::NoMatch,
-                        elapsed,
-                    });
-                    (status, source, found_authors, paper_url, remote_db_results)
-                }
-            } else {
-                (status, source, found_authors, paper_url, remote_db_results)
-            }
-        } else {
-            (status, source, found_authors, paper_url, remote_db_results)
-        };
+    // URL liveness + SearxNG fallbacks (shared helper)
+    let (status, source, found_authors, paper_url, remote_db_results) = apply_fallbacks(
+        status,
+        source,
+        found_authors,
+        paper_url,
+        remote_db_results,
+        &collector.reference.urls,
+        &collector.title,
+        &collector.config,
+        &collector.client,
+        collector.progress.as_ref(),
+        collector.ref_index,
+    )
+    .await;
 
     // Merge local + remote results
     let mut all_db_results = collector.local_result.db_results.clone();
@@ -958,124 +996,36 @@ async fn coordinator_loop(
 
         // --- Fan out to drainer queues ---
         if drainer_txs.is_empty() {
-            // No remote DBs enabled — try URL check and SearxNG fallbacks
-            let result = if local_result.status == Status::NotFound {
-                // Try URL liveness check first
-                let url_check_result = if !reference.urls.is_empty() {
-                    let timeout = Duration::from_secs(config.db_timeout_secs);
-                    let start = std::time::Instant::now();
-                    let result =
-                        UrlChecker::check_first_live(&reference.urls, &client, timeout).await;
-                    let elapsed = start.elapsed();
-
-                    if let Some(url_result) = result {
-                        let url = url_result.final_url.unwrap_or(url_result.url);
-                        progress(ProgressEvent::DatabaseQueryComplete {
-                            paper_index: 0,
-                            ref_index,
-                            db_name: "URL Check".to_string(),
-                            status: DbStatus::Match,
-                            elapsed,
-                        });
-                        let mut db_results = local_result.db_results.clone();
-                        db_results.push(DbResult {
-                            db_name: "URL Check".into(),
-                            status: DbStatus::Match,
-                            elapsed: Some(elapsed),
-                            found_authors: vec![],
-                            paper_url: Some(url.clone()),
-                            error_message: None,
-                        });
-                        Some(ValidationResult {
-                            title: title.clone(),
-                            raw_citation: reference.raw_citation.clone(),
-                            ref_authors: reference.authors.clone(),
-                            status: Status::Verified,
-                            source: Some("URL Check".into()),
-                            found_authors: vec![],
-                            paper_url: Some(url),
-                            failed_dbs: local_result.failed_dbs.clone(),
-                            db_results,
-                            doi_info: None,
-                            arxiv_info: None,
-                            retraction_info: None,
-                        })
-                    } else {
-                        progress(ProgressEvent::DatabaseQueryComplete {
-                            paper_index: 0,
-                            ref_index,
-                            db_name: "URL Check".to_string(),
-                            status: DbStatus::NoMatch,
-                            elapsed,
-                        });
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                // If URL check succeeded, use that result
-                if let Some(result) = url_check_result {
-                    result
-                } else if let Some(ref searxng_url) = config.searxng_url {
-                    // Otherwise try SearxNG fallback
-                    let searxng = Searxng::new(searxng_url.clone());
-                    let timeout = Duration::from_secs(config.db_timeout_secs);
-
-                    let start = std::time::Instant::now();
-                    let searxng_result = searxng.query(&title, &client, timeout).await;
-                    let elapsed = start.elapsed();
-
-                    if let Ok(ref qr) = searxng_result
-                        && qr.is_found()
-                    {
-                        let url = qr.paper_url.clone();
-                        progress(ProgressEvent::DatabaseQueryComplete {
-                            paper_index: 0,
-                            ref_index,
-                            db_name: "Web Search".to_string(),
-                            status: DbStatus::Match,
-                            elapsed,
-                        });
-                        // Web search found the paper
-                        let mut db_results = local_result.db_results.clone();
-                        db_results.push(DbResult {
-                            db_name: "Web Search".into(),
-                            status: DbStatus::Match,
-                            elapsed: Some(elapsed),
-                            found_authors: vec![],
-                            paper_url: url.clone(),
-                            error_message: None,
-                        });
-                        ValidationResult {
-                            title: title.clone(),
-                            raw_citation: reference.raw_citation.clone(),
-                            ref_authors: reference.authors.clone(),
-                            status: Status::Verified,
-                            source: Some("Web Search".into()),
-                            found_authors: vec![],
-                            paper_url: url,
-                            failed_dbs: local_result.failed_dbs.clone(),
-                            db_results,
-                            doi_info: None,
-                            arxiv_info: None, // TODO(#124): implement arXiv ID validation
-                            retraction_info: None,
-                        }
-                    } else {
-                        progress(ProgressEvent::DatabaseQueryComplete {
-                            paper_index: 0,
-                            ref_index,
-                            db_name: "Web Search".to_string(),
-                            status: DbStatus::NoMatch,
-                            elapsed,
-                        });
-                        build_validation_result(&reference, &title, local_result, None)
-                    }
-                } else {
-                    build_validation_result(&reference, &title, local_result, None)
-                }
-            } else {
-                build_validation_result(&reference, &title, local_result, None)
+            // No remote DBs enabled — URL-check + SearxNG fallbacks only
+            // (on NotFound). The helper is a no-op when status is already
+            // Verified or Mismatch, so we always pass through it.
+            let (status, source, found_authors, paper_url, db_results) = apply_fallbacks(
+                local_result.status.clone(),
+                local_result.source.clone(),
+                local_result.found_authors.clone(),
+                local_result.paper_url.clone(),
+                local_result.db_results.clone(),
+                &reference.urls,
+                &title,
+                &config,
+                &client,
+                progress.as_ref(),
+                ref_index,
+            )
+            .await;
+            let result = ValidationResult {
+                title: title.clone(),
+                raw_citation: reference.raw_citation.clone(),
+                ref_authors: reference.authors.clone(),
+                status,
+                source,
+                found_authors,
+                paper_url,
+                failed_dbs: local_result.failed_dbs.clone(),
+                db_results,
+                doi_info: None,
+                arxiv_info: None,
+                retraction_info: None,
             };
             emit_final_events(progress.as_ref(), &result, ref_index, total, &title);
             let _ = result_tx.send(result);
@@ -1211,6 +1161,25 @@ async fn coordinator_loop(
             } else {
                 (Status::NotFound, None, vec![], None)
             };
+
+            // Run URL Check + SearxNG fallbacks on NotFound even though
+            // every DB was a cache hit — this is the path where a
+            // reference that was previously URL-verified would otherwise
+            // regress to NotFound on the second run.
+            let (status, source, found_authors, paper_url, all_db_results) = apply_fallbacks(
+                status,
+                source,
+                found_authors,
+                paper_url,
+                all_db_results,
+                &reference.urls,
+                &title,
+                &config,
+                &client,
+                progress.as_ref(),
+                ref_index,
+            )
+            .await;
 
             let result = ValidationResult {
                 title: title.clone(),

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
@@ -235,16 +235,31 @@ impl App {
             }
             ProgressEvent::Result { index, result, .. } => {
                 let result = *result;
+                let is_retracted = result
+                    .retraction_info
+                    .as_ref()
+                    .is_some_and(|r| r.is_retracted);
+                // Capture any fp_reason already on this ref (restored from
+                // the query cache during extraction, before validation
+                // completed). `record_status` will bump the raw bucket
+                // based on the validation outcome, and we then need to
+                // move the ref into `verified` via apply_fp_delta so the
+                // user's prior mark-safe decision continues to be
+                // reflected in the live queue counters.
+                let fp_preexisting = self
+                    .ref_states
+                    .get(paper_index)
+                    .and_then(|refs| refs.get(index))
+                    .is_some_and(|rs| rs.fp_reason.is_some());
                 if let Some(paper) = self.papers.get_mut(paper_index) {
                     // Track retry progress
                     if paper.phase == PaperPhase::Retrying {
                         paper.retry_done += 1;
                     }
-                    let is_retracted = result
-                        .retraction_info
-                        .as_ref()
-                        .is_some_and(|r| r.is_retracted);
                     paper.record_status(index, result.status.clone(), is_retracted);
+                    if fp_preexisting {
+                        paper.apply_fp_delta(&result.status, is_retracted, 1);
+                    }
                 }
                 if let Some(refs) = self.ref_states.get_mut(paper_index)
                     && let Some(rs) = refs.get_mut(index)

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -779,31 +779,26 @@ impl App {
                         let indices = self.paper_ref_indices(idx);
                         if self.paper_cursor < indices.len() {
                             let ref_idx = indices[self.paper_cursor];
-                            if let Some(refs) = self.ref_states.get_mut(idx)
-                                && let Some(rs) = refs.get_mut(ref_idx)
-                            {
-                                rs.fp_reason = FpReason::cycle(rs.fp_reason);
-                                if let Some(cache) = &self.current_query_cache {
-                                    cache.set_fp_override(
-                                        &rs.title,
-                                        rs.fp_reason.map(|r| r.as_str()),
-                                    );
-                                }
-                            }
+                            cycle_fp_reason_and_adjust_stats(
+                                &mut self.papers,
+                                &mut self.ref_states,
+                                idx,
+                                ref_idx,
+                                self.current_query_cache.as_ref(),
+                            );
                         }
                     }
                     Screen::RefDetail(paper_idx, ref_idx) => {
                         // Space on detail: cycle FP reason
                         let paper_idx = *paper_idx;
                         let ref_idx = *ref_idx;
-                        if let Some(refs) = self.ref_states.get_mut(paper_idx)
-                            && let Some(rs) = refs.get_mut(ref_idx)
-                        {
-                            rs.fp_reason = FpReason::cycle(rs.fp_reason);
-                            if let Some(cache) = &self.current_query_cache {
-                                cache.set_fp_override(&rs.title, rs.fp_reason.map(|r| r.as_str()));
-                            }
-                        }
+                        cycle_fp_reason_and_adjust_stats(
+                            &mut self.papers,
+                            &mut self.ref_states,
+                            paper_idx,
+                            ref_idx,
+                            self.current_query_cache.as_ref(),
+                        );
                     }
                     Screen::Config => {
                         // Space on config: toggle database or cycle theme
@@ -939,5 +934,62 @@ impl App {
             Action::None => {}
         }
         false
+    }
+}
+
+/// Cycle the FP reason on one reference and keep the paper-level
+/// stats in sync.
+///
+/// Pressing Space cycles `rs.fp_reason` through None → Some(r1) →
+/// Some(r2) → ... → None. Only the None ↔ Some transitions move the
+/// reference between the problematic bucket (not_found /
+/// mismatch / retracted) and `verified`; going between two Some
+/// variants is a purely-informational change. For the None↔Some
+/// transitions we call `PaperState::apply_fp_delta` so the queue
+/// table columns, the bottom-of-screen totals, and the paper-view
+/// "problems" counter all reflect the override immediately.
+///
+/// Takes disjoint mutable borrows (&mut papers, &mut ref_states)
+/// instead of &mut self so it can be called from both Screen::Paper
+/// and Screen::RefDetail arms without fighting the borrow checker
+/// over the enclosing match.
+fn cycle_fp_reason_and_adjust_stats(
+    papers: &mut [crate::model::queue::PaperState],
+    ref_states: &mut [Vec<crate::model::paper::RefState>],
+    paper_idx: usize,
+    ref_idx: usize,
+    cache: Option<&std::sync::Arc<hallucinator_core::QueryCache>>,
+) {
+    let Some(refs) = ref_states.get_mut(paper_idx) else {
+        return;
+    };
+    let Some(rs) = refs.get_mut(ref_idx) else {
+        return;
+    };
+
+    let was_safe = rs.fp_reason.is_some();
+    rs.fp_reason = FpReason::cycle(rs.fp_reason);
+    let is_safe = rs.fp_reason.is_some();
+
+    if let Some(cache) = cache {
+        cache.set_fp_override(&rs.title, rs.fp_reason.map(|r| r.as_str()));
+    }
+
+    // Only adjust stats on None↔Some boundary transitions. Some(r1)↔Some(r2)
+    // keeps the ref marked-safe, so the stats are already adjusted.
+    if was_safe == is_safe {
+        return;
+    }
+    let Some(result) = &rs.result else {
+        return; // ref hasn't been validated yet — no stats to adjust
+    };
+    let is_retracted = result
+        .retraction_info
+        .as_ref()
+        .is_some_and(|r| r.is_retracted);
+    let status = result.status.clone();
+    let dir: i32 = if is_safe { 1 } else { -1 };
+    if let Some(paper) = papers.get_mut(paper_idx) {
+        paper.apply_fp_delta(&status, is_retracted, dir);
     }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -179,12 +179,17 @@ impl App {
                                     .unwrap_or_else(|| (0..self.papers.len()).collect())
                             }
                             crate::view::export::ExportScope::ProblematicPapers => {
+                                // Exclude papers where every problematic ref
+                                // has been marked safe (fp_reason set). The
+                                // raw `p.stats.*` counters don't decrement
+                                // on fp_reason, so consult the actual ref
+                                // states instead — `has_unresolved_problems`
+                                // returns true only when at least one ref is
+                                // still an unresolved problem.
                                 (0..self.papers.len())
                                     .filter(|&i| {
-                                        self.papers.get(i).is_some_and(|p| {
-                                            p.stats.not_found > 0
-                                                || p.stats.author_mismatch > 0
-                                                || p.stats.retracted > 0
+                                        self.ref_states.get(i).is_some_and(|refs| {
+                                            crate::model::paper::has_unresolved_problems(refs)
                                         })
                                     })
                                     .collect::<Vec<_>>()

--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -292,6 +292,12 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>) {
             .as_ref()
             .is_some_and(|r| r.is_retracted);
         paper.record_status(loaded_ref.index, result.status.clone(), is_retracted);
+        // If this ref was persisted with an fp_reason, carry the
+        // mark-safe adjustment into the paper stats so the queue table
+        // and totals line reflect the prior user decision on load.
+        if fp_reason.is_some() {
+            paper.apply_fp_delta(&result.status, is_retracted, 1);
+        }
 
         let raw_cit = loaded_ref.raw_citation.clone().unwrap_or_default();
         let ref_authors = loaded_ref.ref_authors.clone().unwrap_or_default();

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
@@ -1,4 +1,4 @@
-use hallucinator_core::{Reference, Status, ValidationResult};
+use hallucinator_core::{MismatchKind, Reference, Status, ValidationResult};
 
 pub use hallucinator_reporting::FpReason;
 
@@ -65,6 +65,32 @@ impl RefState {
         self.fp_reason.is_some()
     }
 
+    /// Whether this reference is an unresolved problem — i.e., validation
+    /// flagged it as not-found / author-mismatch / retracted AND the user
+    /// has not yet marked it safe.
+    ///
+    /// Matches the problem definition used by the paper-level stats
+    /// counters (`stats.not_found`, `stats.author_mismatch`,
+    /// `stats.retracted`): a DOI-only or arXiv-only mismatch without an
+    /// author mismatch does not count here (consistent with the paper
+    /// stats, which track author mismatches separately from DOI/arXiv
+    /// ID mismatches).
+    pub fn is_unresolved_problem(&self) -> bool {
+        if self.fp_reason.is_some() {
+            return false;
+        }
+        let Some(result) = &self.result else {
+            return false;
+        };
+        let status_problem = matches!(result.status, Status::NotFound)
+            || matches!(result.status, Status::Mismatch(kind) if kind.contains(MismatchKind::AUTHOR));
+        let retracted = result
+            .retraction_info
+            .as_ref()
+            .is_some_and(|ri| ri.is_retracted);
+        status_problem || retracted
+    }
+
     pub fn verdict_label(&self) -> String {
         if let Some(reason) = self.fp_reason {
             return format!("\u{2713} Safe ({})", reason.short_label());
@@ -108,6 +134,21 @@ impl RefState {
             None => "\u{2014}",
         }
     }
+}
+
+/// Whether a paper has at least one reference that is still an unresolved
+/// problem. Used by the export "Problematic papers" scope filter: a
+/// paper where every problematic ref has been marked safe by the user
+/// is excluded, because there is nothing left to show on the report.
+///
+/// This is the ref-level truth corresponding to
+/// `hallucinator_reporting::adjusted_stats`'s post-adjustment buckets —
+/// we can't call that helper directly from the TUI (it lives inside a
+/// private export module and operates on ReportRef/ReportPaper rather
+/// than RefState), so the predicate is duplicated here against the TUI
+/// model.
+pub fn has_unresolved_problems(ref_states: &[RefState]) -> bool {
+    ref_states.iter().any(RefState::is_unresolved_problem)
 }
 
 /// Sort order for references in the paper view.
@@ -156,5 +197,220 @@ impl PaperFilter {
             Self::All => "all",
             Self::ProblemsOnly => "problems",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hallucinator_core::{MismatchKind, RetractionInfo, Status, ValidationResult};
+
+    fn empty_val_result(status: Status) -> ValidationResult {
+        ValidationResult {
+            title: String::new(),
+            raw_citation: String::new(),
+            ref_authors: Vec::new(),
+            status,
+            source: None,
+            found_authors: Vec::new(),
+            paper_url: None,
+            failed_dbs: Vec::new(),
+            db_results: Vec::new(),
+            doi_info: None,
+            arxiv_info: None,
+            retraction_info: None,
+        }
+    }
+
+    fn ref_state(
+        phase: RefPhase,
+        result: Option<ValidationResult>,
+        fp_reason: Option<FpReason>,
+    ) -> RefState {
+        RefState {
+            index: 0,
+            title: "some title".into(),
+            phase,
+            result,
+            fp_reason,
+            raw_citation: String::new(),
+            authors: Vec::new(),
+            doi: None,
+            arxiv_id: None,
+            urls: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn unresolved_problem_not_found_with_no_fp_reason() {
+        let rs = ref_state(
+            RefPhase::Done,
+            Some(empty_val_result(Status::NotFound)),
+            None,
+        );
+        assert!(rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_goes_false_once_marked_safe() {
+        let rs = ref_state(
+            RefPhase::Done,
+            Some(empty_val_result(Status::NotFound)),
+            Some(FpReason::KnownGood),
+        );
+        assert!(!rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_author_mismatch_counts() {
+        let rs = ref_state(
+            RefPhase::Done,
+            Some(empty_val_result(Status::Mismatch(MismatchKind::AUTHOR))),
+            None,
+        );
+        assert!(rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_doi_only_mismatch_does_not_count() {
+        // Matches paper stats semantics: stats.author_mismatch is the
+        // TUI's problematic-mismatch counter. A DOI-only or arXiv-ID-only
+        // mismatch is a separate bucket and not flagged as problematic
+        // by the existing export filter, so keep that behavior here.
+        let rs = ref_state(
+            RefPhase::Done,
+            Some(empty_val_result(Status::Mismatch(MismatchKind::DOI))),
+            None,
+        );
+        assert!(!rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_retracted_counts_even_if_verified() {
+        let mut result = empty_val_result(Status::Verified);
+        result.retraction_info = Some(RetractionInfo {
+            is_retracted: true,
+            retraction_doi: Some("10.9/retr".into()),
+            retraction_source: None,
+        });
+        let rs = ref_state(RefPhase::Done, Some(result), None);
+        assert!(rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_retracted_goes_false_when_marked_safe() {
+        let mut result = empty_val_result(Status::Verified);
+        result.retraction_info = Some(RetractionInfo {
+            is_retracted: true,
+            retraction_doi: None,
+            retraction_source: None,
+        });
+        let rs = ref_state(RefPhase::Done, Some(result), Some(FpReason::KnownGood));
+        assert!(!rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_false_for_verified_ref() {
+        let rs = ref_state(
+            RefPhase::Done,
+            Some(empty_val_result(Status::Verified)),
+            None,
+        );
+        assert!(!rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_false_for_pending_ref() {
+        // No validation result yet — not problematic (and not verified
+        // either). A paper that is still processing should not be
+        // flagged as problematic by the export filter.
+        let rs = ref_state(RefPhase::Pending, None, None);
+        assert!(!rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn unresolved_problem_false_for_skipped_ref() {
+        // Skipped references have no validation result and are not
+        // problematic for export purposes.
+        let rs = ref_state(RefPhase::Skipped("short_title".into()), None, None);
+        assert!(!rs.is_unresolved_problem());
+    }
+
+    // ── has_unresolved_problems (paper-level) ────────────────────────
+
+    #[test]
+    fn paper_clean_when_all_refs_verified() {
+        let refs = vec![
+            ref_state(
+                RefPhase::Done,
+                Some(empty_val_result(Status::Verified)),
+                None,
+            ),
+            ref_state(
+                RefPhase::Done,
+                Some(empty_val_result(Status::Verified)),
+                None,
+            ),
+        ];
+        assert!(!has_unresolved_problems(&refs));
+    }
+
+    #[test]
+    fn paper_clean_when_all_problematic_refs_marked_safe() {
+        // This is the bug the user reported: a paper with previously
+        // problematic references that have all been marked safe should
+        // be excluded from the "Problematic papers" export scope. The
+        // raw paper stats would still show positive counters, but this
+        // predicate correctly looks at the overridden ref states.
+        let refs = vec![
+            ref_state(
+                RefPhase::Done,
+                Some(empty_val_result(Status::NotFound)),
+                Some(FpReason::KnownGood),
+            ),
+            ref_state(
+                RefPhase::Done,
+                Some(empty_val_result(Status::Mismatch(MismatchKind::AUTHOR))),
+                Some(FpReason::ExistsElsewhere),
+            ),
+            ref_state(
+                RefPhase::Done,
+                Some(empty_val_result(Status::Verified)),
+                None,
+            ),
+        ];
+        assert!(!has_unresolved_problems(&refs));
+    }
+
+    #[test]
+    fn paper_problematic_when_one_unmarked_problem_remains() {
+        let refs = vec![
+            // Marked safe — shouldn't count.
+            ref_state(
+                RefPhase::Done,
+                Some(empty_val_result(Status::NotFound)),
+                Some(FpReason::KnownGood),
+            ),
+            // Still problematic — should tip the paper into
+            // "has unresolved problems".
+            ref_state(
+                RefPhase::Done,
+                Some(empty_val_result(Status::NotFound)),
+                None,
+            ),
+        ];
+        assert!(has_unresolved_problems(&refs));
+    }
+
+    #[test]
+    fn paper_problematic_when_retracted_ref_is_not_marked_safe() {
+        let mut retracted = empty_val_result(Status::Verified);
+        retracted.retraction_info = Some(RetractionInfo {
+            is_retracted: true,
+            retraction_doi: None,
+            retraction_source: None,
+        });
+        let refs = vec![ref_state(RefPhase::Done, Some(retracted), None)];
+        assert!(has_unresolved_problems(&refs));
     }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
@@ -137,6 +137,60 @@ impl PaperState {
         });
     }
 
+    /// Adjust the status-bucket counters for a false-positive override
+    /// on a single reference.
+    ///
+    /// `dir = +1` means "user just marked this ref safe" — move it out
+    /// of its current status bucket (not_found / mismatch / retracted)
+    /// into `verified`.  `dir = -1` undoes that (user un-marked it).
+    ///
+    /// Mirrors the bucket structure of `record_status`: Status::Verified
+    /// is unchanged (already counted in `verified`); Status::Mismatch
+    /// decrements the overall `mismatch` counter plus each matching
+    /// sub-flag (`author_mismatch`, `doi_mismatch`, `arxiv_mismatch`);
+    /// `is_retracted` is an independent counter and is always toggled.
+    ///
+    /// Called from three places:
+    ///   * `app/update.rs` when the user cycles the fp reason with Space,
+    ///   * `app/backend.rs` when a ProgressEvent::Result arrives for a
+    ///     ref whose fp override was already restored from the query
+    ///     cache during extraction,
+    ///   * `load.rs` after loading a JSON export whose refs carry
+    ///     persisted fp_reason fields.
+    pub fn apply_fp_delta(&mut self, status: &Status, is_retracted: bool, dir: i32) {
+        debug_assert!(dir == 1 || dir == -1, "dir must be +1 or -1");
+        let add = |n: &mut usize, delta: i32| {
+            if delta >= 0 {
+                *n = n.saturating_add(delta as usize);
+            } else {
+                *n = n.saturating_sub(delta.unsigned_abs() as usize);
+            }
+        };
+        match status {
+            Status::Verified => {}
+            Status::NotFound => {
+                add(&mut self.stats.not_found, -dir);
+                add(&mut self.stats.verified, dir);
+            }
+            Status::Mismatch(kind) => {
+                add(&mut self.stats.mismatch, -dir);
+                if kind.contains(MismatchKind::AUTHOR) {
+                    add(&mut self.stats.author_mismatch, -dir);
+                }
+                if kind.contains(MismatchKind::DOI) {
+                    add(&mut self.stats.doi_mismatch, -dir);
+                }
+                if kind.contains(MismatchKind::ARXIV_ID) {
+                    add(&mut self.stats.arxiv_mismatch, -dir);
+                }
+                add(&mut self.stats.verified, dir);
+            }
+        }
+        if is_retracted {
+            add(&mut self.stats.retracted, -dir);
+        }
+    }
+
     /// Number of completed results.
     pub fn completed_count(&self) -> usize {
         self.results.iter().filter(|r| r.is_some()).count()
@@ -271,4 +325,101 @@ pub fn filtered_indices(
         })
         .map(|(i, _)| i)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paper_with_recorded(statuses: &[(Status, bool)]) -> PaperState {
+        // Helper: build a paper and run record_status for each entry so
+        // the raw counters land in the exact shape the live event loop
+        // would produce. `.1` is `is_retracted`.
+        let mut p = PaperState::new("t".into());
+        p.init_results(statuses.len());
+        for (i, (status, is_retracted)) in statuses.iter().enumerate() {
+            p.record_status(i, status.clone(), *is_retracted);
+        }
+        p.stats.total = statuses.len();
+        p.total_refs = statuses.len();
+        p
+    }
+
+    #[test]
+    fn apply_fp_delta_not_found_marks_safe() {
+        // Single not_found ref → raw stats: not_found=1, verified=0.
+        // Mark safe → not_found=0, verified=1.
+        let mut p = paper_with_recorded(&[(Status::NotFound, false)]);
+        assert_eq!(p.stats.not_found, 1);
+        assert_eq!(p.stats.verified, 0);
+        p.apply_fp_delta(&Status::NotFound, false, 1);
+        assert_eq!(p.stats.not_found, 0);
+        assert_eq!(p.stats.verified, 1);
+    }
+
+    #[test]
+    fn apply_fp_delta_not_found_is_reversible() {
+        // Mark safe then un-mark → back to original raw counts.
+        let mut p = paper_with_recorded(&[(Status::NotFound, false)]);
+        p.apply_fp_delta(&Status::NotFound, false, 1);
+        p.apply_fp_delta(&Status::NotFound, false, -1);
+        assert_eq!(p.stats.not_found, 1);
+        assert_eq!(p.stats.verified, 0);
+    }
+
+    #[test]
+    fn apply_fp_delta_mismatch_decrements_all_matching_subflags() {
+        let kind = MismatchKind::AUTHOR | MismatchKind::DOI;
+        let mut p = paper_with_recorded(&[(Status::Mismatch(kind), false)]);
+        assert_eq!(p.stats.mismatch, 1);
+        assert_eq!(p.stats.author_mismatch, 1);
+        assert_eq!(p.stats.doi_mismatch, 1);
+        assert_eq!(p.stats.arxiv_mismatch, 0);
+        p.apply_fp_delta(&Status::Mismatch(kind), false, 1);
+        assert_eq!(p.stats.mismatch, 0);
+        assert_eq!(p.stats.author_mismatch, 0);
+        assert_eq!(p.stats.doi_mismatch, 0);
+        assert_eq!(p.stats.arxiv_mismatch, 0);
+        assert_eq!(p.stats.verified, 1);
+    }
+
+    #[test]
+    fn apply_fp_delta_retracted_toggles_independently_of_status() {
+        // A retracted ref can coexist with any status; the `retracted`
+        // counter is separate and must be toggled on apply_fp_delta.
+        let mut p = paper_with_recorded(&[(Status::Verified, true)]);
+        assert_eq!(p.stats.verified, 1);
+        assert_eq!(p.stats.retracted, 1);
+        p.apply_fp_delta(&Status::Verified, true, 1);
+        // Status::Verified: verified unchanged. Retracted decrements.
+        assert_eq!(p.stats.verified, 1);
+        assert_eq!(p.stats.retracted, 0);
+    }
+
+    #[test]
+    fn apply_fp_delta_verified_status_only_retracted_flips() {
+        let mut p = paper_with_recorded(&[(Status::Verified, false)]);
+        let before = p.stats.clone();
+        p.apply_fp_delta(&Status::Verified, false, 1);
+        // Status::Verified + not_retracted → nothing to move.
+        assert_eq!(p.stats.verified, before.verified);
+        assert_eq!(p.stats.not_found, before.not_found);
+        assert_eq!(p.stats.mismatch, before.mismatch);
+    }
+
+    #[test]
+    fn problems_count_drops_when_all_refs_marked_safe() {
+        // End-to-end: a paper with 2 not_found + 1 verified refs. After
+        // marking both not_found refs safe, problems() must read 0.
+        let mut p = paper_with_recorded(&[
+            (Status::NotFound, false),
+            (Status::NotFound, false),
+            (Status::Verified, false),
+        ]);
+        assert_eq!(p.problems(), 2);
+        p.apply_fp_delta(&Status::NotFound, false, 1);
+        p.apply_fp_delta(&Status::NotFound, false, 1);
+        assert_eq!(p.problems(), 0);
+        assert_eq!(p.stats.verified, 3);
+    }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/queue.rs
@@ -140,10 +140,12 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
     let theme = &app.theme;
     let wide = area.width >= 80;
 
-    // Build header row
+    // Build header row. `Safe` counts references the user has marked safe
+    // (any FpReason). Grouped next to `OK` because both represent
+    // references the user / auto-check believe to be legitimate.
     let header_cells = if wide {
         vec![
-            "#", "Paper", "Refs", "OK", "Mis", "NF", "Skip", "%", "Ret", "Status",
+            "#", "Paper", "Refs", "OK", "Safe", "Mis", "NF", "Skip", "%", "Ret", "Status",
         ]
     } else {
         vec!["#", "Paper", "Refs", "Prob", "Status"]
@@ -237,12 +239,27 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
                     Style::default().fg(theme.dim)
                 };
                 let skip_text = format!("{}", paper.stats.skipped);
+                // `Safe` = count of refs where the user pressed Space to
+                // cycle an FP reason on. Derived on-the-fly from
+                // ref_states rather than stored on PaperState so it can
+                // never drift from the per-ref fp_reason source of truth.
+                let safe_count = app
+                    .ref_states
+                    .get(paper_idx)
+                    .map(|refs| refs.iter().filter(|rs| rs.is_marked_safe()).count())
+                    .unwrap_or(0);
+                let safe_style = if safe_count > 0 {
+                    Style::default().fg(theme.verified)
+                } else {
+                    Style::default().fg(theme.dim)
+                };
                 Row::new(vec![
                     Cell::from(num),
                     Cell::from(name).style(name_style),
                     Cell::from(refs),
                     Cell::from(format!("{}", paper.stats.verified))
                         .style(Style::default().fg(theme.verified)),
+                    Cell::from(format!("{}", safe_count)).style(safe_style),
                     Cell::from(format!("{}", paper.stats.mismatch))
                         .style(Style::default().fg(theme.mismatch)),
                     Cell::from(format!("{}", paper.stats.not_found))
@@ -281,6 +298,7 @@ fn render_table(f: &mut Frame, area: Rect, app: &App) {
             Constraint::Min(15),    // Paper
             Constraint::Length(5),  // Refs
             Constraint::Length(5),  // OK
+            Constraint::Length(5),  // Safe
             Constraint::Length(5),  // Mis
             Constraint::Length(5),  // NF
             Constraint::Length(5),  // Skip


### PR DESCRIPTION
## Summary

Three related fixes, all landing together because they surfaced in the same user-flow (mark a ref safe in the TUI, then export or re-run with a populated cache):

- **Export filter** (`a2cfaff`): the "Problematic papers" export scope now excludes papers where every previously-problematic reference has been marked safe. Previously it consulted raw `p.stats.*` counters, which are never decremented when the user presses Space, so those papers kept showing up in the export.
- **Live TUI counters** (`62d9785`): the queue-table columns (Not Found / Mismatch / Retracted / %), bottom-of-screen totals (V/M/NF), paper-view percentages, and the `problems()` / `problematic_pct()` methods now all update immediately when a ref is marked safe. Added a `PaperState::apply_fp_delta` helper mirroring `record_status`'s bucket structure and wired it into the three places that can change fp-state: the Space toggle, `ProgressEvent::Result` (for fp_reason restored from the query cache during extraction), and JSON load.
- **Cached URL-Check regression** (`2bc5a9b`): on a re-run with a populated cache, references that were verified by URL Check on the first run came back as Not Found. `pool.rs` has three post-cache branches; the "all remote DBs cache-hit, none verified" branch built a `Status::NotFound` result directly without running the URL Check / SearxNG fallbacks that the other two branches did. Extracted a shared `apply_fallbacks` helper and wired it into all three sites, removing the duplication that let the bug slip in.

## Test plan

- [x] `cargo test --workspace --release`: all 0 failed.
- [x] New tests pinning the fix behavior (13 for the safe-refs model, 8 for the detail-view links already on main, 6 for paper-stats mark-safe transitions).
- [x] Manual verification on `~/Documents/Papers/bluesky-blocks-paper/main.pdf`:
  - Fresh cache: 38 verified / 1 not found.
  - Same paper against the populated cache, pre-fix: 29 / 10 (9 regressions, all URL-Check-backed refs).
  - Same paper against the populated cache, post-fix: 38 / 1 on second and third runs.
- [x] Export modal: marking every problematic ref as safe now hides the paper from the "Problematic papers" scope (previously still included).
- [x] Queue-table counters: Space-to-cycle-fp-reason now updates the Not Found / Mismatch / Retracted columns and the bottom totals live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)