### PR TITLE
Broader URL verification: arXiv version history, Wayback Machine fallback, separator-variant retries

### DIFF
--- a/hallucinator-rs/crates/hallucinator-core/src/checker.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/checker.rs
@@ -234,13 +234,22 @@ pub async fn check_single_reference(
     )
     .await;
 
+    // Expand `_` / `-` / <none> separator variants so URL Check and
+    // Wayback can recover URLs whose PDF-extracted separators got
+    // guessed wrong. See `expand_url_variants` for rationale.
+    let candidate_urls: Vec<String> = if reference.urls.is_empty() {
+        Vec::new()
+    } else {
+        crate::db::url_check::expand_url_variants(&reference.urls)
+    };
+
     // Step 2.5: URL liveness check for references with embedded URLs
-    if db_result.status == Status::NotFound && !reference.urls.is_empty() {
+    if db_result.status == Status::NotFound && !candidate_urls.is_empty() {
         let timeout = Duration::from_secs(config.db_timeout_secs);
         let start = std::time::Instant::now();
 
         if let Some(url_result) =
-            UrlChecker::check_first_live(&reference.urls, client, timeout).await
+            UrlChecker::check_first_live(&candidate_urls, client, timeout).await
         {
             let elapsed = start.elapsed();
             let paper_url = url_result.final_url.unwrap_or(url_result.url);
@@ -279,11 +288,11 @@ pub async fn check_single_reference(
     // If URL Check found no live URL, a cited URL may still have been
     // real when the paper was written — check archive.org for a valid
     // snapshot. Mirrors the same logic as the pool's `apply_fallbacks`.
-    if db_result.status == Status::NotFound && !reference.urls.is_empty() {
+    if db_result.status == Status::NotFound && !candidate_urls.is_empty() {
         let timeout = Duration::from_secs(config.db_timeout_secs);
         let start = std::time::Instant::now();
         let wayback_result =
-            crate::db::wayback::check_first_snapshot(&reference.urls, client, timeout).await;
+            crate::db::wayback::check_first_snapshot(&candidate_urls, client, timeout).await;
         let elapsed = start.elapsed();
 
         if let Some(result) = wayback_result {

--- a/hallucinator-rs/crates/hallucinator-core/src/checker.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/checker.rs
@@ -275,6 +275,47 @@ pub async fn check_single_reference(
         }
     }
 
+    // Step 2.55: Wayback Machine fallback for link-rotted URLs.
+    // If URL Check found no live URL, a cited URL may still have been
+    // real when the paper was written — check archive.org for a valid
+    // snapshot. Mirrors the same logic as the pool's `apply_fallbacks`.
+    if db_result.status == Status::NotFound && !reference.urls.is_empty() {
+        let timeout = Duration::from_secs(config.db_timeout_secs);
+        let start = std::time::Instant::now();
+        let wayback_result =
+            crate::db::wayback::check_first_snapshot(&reference.urls, client, timeout).await;
+        let elapsed = start.elapsed();
+
+        if let Some(result) = wayback_result {
+            let wayback_db_result = DbResult {
+                db_name: "Wayback Machine".into(),
+                status: DbStatus::Match,
+                elapsed: Some(elapsed),
+                found_authors: vec![],
+                paper_url: Some(result.snapshot_url.clone()),
+                error_message: None,
+            };
+            if let Some(cb) = on_db_complete {
+                cb(wayback_db_result.clone());
+            }
+            db_result.db_results.push(wayback_db_result);
+
+            db_result.status = Status::Verified;
+            db_result.source = Some("Wayback Machine".into());
+            db_result.found_authors = vec![];
+            db_result.paper_url = Some(result.snapshot_url);
+        } else if let Some(cb) = on_db_complete {
+            cb(DbResult {
+                db_name: "Wayback Machine".into(),
+                status: DbStatus::NoMatch,
+                elapsed: Some(elapsed),
+                found_authors: vec![],
+                paper_url: None,
+                error_message: None,
+            });
+        }
+    }
+
     // Step 2.6: SearxNG fallback for NotFound references
     if db_result.status == Status::NotFound
         && let Some(ref searxng_url) = config.searxng_url

--- a/hallucinator-rs/crates/hallucinator-core/src/db/arxiv.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/arxiv.rs
@@ -1,9 +1,26 @@
 use super::{ArxivIdQueryResult, DatabaseBackend, DbQueryError, DbQueryResult};
 use crate::matching::titles_match;
 use crate::text_utils::get_query_words;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
+
+/// Parsed subset of one `<entry>` block from an arXiv Atom XML response.
+#[derive(Debug, Clone)]
+struct ArxivEntry {
+    title: String,
+    authors: Vec<String>,
+    link: Option<String>,
+    /// Version number parsed from the entry's `<id>` URL suffix, e.g.,
+    /// `2` for `http://arxiv.org/abs/2403.00108v2`. `None` on old-format
+    /// IDs without a version suffix, or when `<id>` was missing.
+    version: Option<u32>,
+}
+
+/// Match a trailing `v\d+` version suffix on an arXiv ID.
+static ARXIV_VERSION_SUFFIX: Lazy<Regex> = Lazy::new(|| Regex::new(r"v(\d+)$").unwrap());
 
 pub struct Arxiv;
 
@@ -76,40 +93,116 @@ impl DatabaseBackend for Arxiv {
         timeout: Duration,
     ) -> ArxivIdQueryResult<'a> {
         Box::pin(async move {
-            // Use id_list parameter for direct lookup by arXiv ID
-            let url = format!(
-                "https://export.arxiv.org/api/query?id_list={}&max_results=1",
-                urlencoding::encode(arxiv_id)
-            );
-
-            let resp = match client.get(&url).timeout(timeout).send().await {
-                Ok(r) => r,
-                Err(e) => return Some(Err(DbQueryError::Other(e.to_string()))),
+            // Step 1: fetch the latest version (what `id_list=<id>` without
+            // a version suffix resolves to). This is what the old code
+            // did, and for papers whose title didn't change across
+            // versions it's still the happy path.
+            let latest_entries = match fetch_arxiv_id_entries(arxiv_id, client, timeout).await {
+                Ok(e) => e,
+                Err(e) => return Some(Err(e)),
             };
+            let latest = latest_entries.into_iter().next();
 
-            if let Err(e) = check_arxiv_status(&resp) {
-                return Some(Err(e));
+            if let Some(entry) = &latest
+                && !entry.authors.is_empty()
+                && titles_match(title, &entry.title)
+            {
+                return Some(Ok(DbQueryResult::found(
+                    entry.title.clone(),
+                    entry.authors.clone(),
+                    entry.link.clone(),
+                )));
             }
 
-            let body = match resp.text().await {
-                Ok(b) => b,
-                Err(e) => return Some(Err(DbQueryError::Other(e.to_string()))),
+            // Step 2: arXiv papers sometimes get retitled between
+            // versions. A citation like `arXiv:2403.00108` (no explicit
+            // version) typically captures the title as it was at
+            // submission time (v1), which may differ from the current
+            // latest-version title. Example: NDSS 2026 paper f168 ref 8
+            // cites "Lora-as-an-attack! piercing llm safety under the
+            // share-and-play scenario" (v1), but arXiv 2403.00108's
+            // latest version is titled "LoRATK: LoRA Once, Backdoor
+            // Everywhere in the Share-and-Play Ecosystem". Walk earlier
+            // versions when the latest doesn't match.
+            //
+            // Skip the fallback when:
+            //   * the citation already specifies an explicit version
+            //     (the user chose v1, honor that — don't fall back to
+            //     "any version with a matching title"), or
+            //   * the latest version is v1 (nothing earlier to try), or
+            //   * we couldn't parse the latest version number from the
+            //     Atom `<id>` URL (unexpected response shape).
+            if ARXIV_VERSION_SUFFIX.is_match(arxiv_id) {
+                return Some(Ok(DbQueryResult::not_found()));
+            }
+            let Some(latest_version) = latest.as_ref().and_then(|e| e.version) else {
+                return Some(Ok(DbQueryResult::not_found()));
             };
+            if latest_version < 2 {
+                return Some(Ok(DbQueryResult::not_found()));
+            }
 
-            // Validate the title at the claimed ID actually matches the citation —
-            // fabricated IDs often resolve to unrelated real papers.
-            Some(parse_arxiv_id_response(&body, title))
+            // Batch-fetch v1..v{latest-1} in one id_list call (arXiv API
+            // accepts comma-separated IDs). This keeps the extra cost at
+            // exactly one additional request even when a paper has many
+            // versions, so we don't multiply rate-limit pressure.
+            let older_ids: Vec<String> = (1..latest_version)
+                .map(|v| format!("{}v{}", arxiv_id, v))
+                .collect();
+            let joined = older_ids.join(",");
+            let older_entries = match fetch_arxiv_id_entries(&joined, client, timeout).await {
+                Ok(e) => e,
+                Err(_) => return Some(Ok(DbQueryResult::not_found())),
+            };
+            for entry in older_entries {
+                if !entry.authors.is_empty() && titles_match(title, &entry.title) {
+                    return Some(Ok(DbQueryResult::found(
+                        entry.title,
+                        entry.authors,
+                        entry.link,
+                    )));
+                }
+            }
+
+            Some(Ok(DbQueryResult::not_found()))
         })
     }
 }
 
-/// Parse arXiv Atom XML response for direct ID lookup.
+/// Fetch one or more arXiv IDs via the `id_list` endpoint and parse the
+/// Atom XML response into a list of entries.
 ///
-/// Returns not-found if the paper at the claimed ID has a title that doesn't
-/// match `expected_title`. An arXiv ID that someone fabricated will typically
-/// resolve to *some* real paper, so without this check an unrelated paper gets
-/// reported as merely an author mismatch rather than a hallucination.
-fn parse_arxiv_id_response(xml: &str, expected_title: &str) -> Result<DbQueryResult, DbQueryError> {
+/// Accepts a comma-separated list (the arXiv API natively supports
+/// `id_list=id1,id2,id3`), so callers can batch version lookups into a
+/// single request.
+async fn fetch_arxiv_id_entries(
+    id_list: &str,
+    client: &reqwest::Client,
+    timeout: Duration,
+) -> Result<Vec<ArxivEntry>, DbQueryError> {
+    let url = format!(
+        "https://export.arxiv.org/api/query?id_list={}&max_results=10",
+        urlencoding::encode(id_list)
+    );
+    let resp = client
+        .get(&url)
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| DbQueryError::Other(e.to_string()))?;
+    check_arxiv_status(&resp)?;
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| DbQueryError::Other(e.to_string()))?;
+    parse_arxiv_id_entries(&body)
+}
+
+/// Parse an arXiv Atom XML `id_list` response into one entry per
+/// returned paper. Title-matching is deliberately left to the caller —
+/// a single response may carry multiple versions of the same paper, and
+/// which version we consider "the match" depends on caller intent.
+fn parse_arxiv_id_entries(xml: &str) -> Result<Vec<ArxivEntry>, DbQueryError> {
     use quick_xml::Reader;
     use quick_xml::events::Event;
 
@@ -119,12 +212,15 @@ fn parse_arxiv_id_response(xml: &str, expected_title: &str) -> Result<DbQueryRes
     let mut in_title = false;
     let mut in_author = false;
     let mut in_name = false;
+    let mut in_id = false;
 
     let mut current_title = String::new();
     let mut current_authors: Vec<String> = Vec::new();
     let mut current_name = String::new();
     let mut current_link = String::new();
+    let mut current_id = String::new();
 
+    let mut out: Vec<ArxivEntry> = Vec::new();
     let mut buf = Vec::new();
 
     loop {
@@ -137,6 +233,7 @@ fn parse_arxiv_id_response(xml: &str, expected_title: &str) -> Result<DbQueryRes
                         current_title.clear();
                         current_authors.clear();
                         current_link.clear();
+                        current_id.clear();
                     }
                     b"title" if in_entry => {
                         in_title = true;
@@ -149,6 +246,10 @@ fn parse_arxiv_id_response(xml: &str, expected_title: &str) -> Result<DbQueryRes
                     b"name" if in_author => {
                         in_name = true;
                         current_name.clear();
+                    }
+                    b"id" if in_entry => {
+                        in_id = true;
+                        current_id.clear();
                     }
                     _ => {}
                 }
@@ -178,27 +279,31 @@ fn parse_arxiv_id_response(xml: &str, expected_title: &str) -> Result<DbQueryRes
                 if in_name {
                     current_name.push_str(&text);
                 }
+                if in_id {
+                    current_id.push_str(&text);
+                }
             }
             Ok(Event::End(ref e)) => {
                 let local = e.local_name();
                 match local.as_ref() {
                     b"entry" => {
-                        // Return the first entry (direct ID lookup returns exactly one)
-                        let entry_title = current_title.trim().to_string();
-                        if !entry_title.is_empty()
-                            && !current_authors.is_empty()
-                            && titles_match(expected_title, &entry_title)
-                        {
+                        let title = current_title.trim().to_string();
+                        if !title.is_empty() {
                             let link = if current_link.is_empty() {
                                 None
                             } else {
                                 Some(current_link.clone())
                             };
-                            return Ok(DbQueryResult::found(
-                                entry_title,
-                                current_authors.clone(),
+                            let version = ARXIV_VERSION_SUFFIX
+                                .captures(current_id.trim())
+                                .and_then(|c| c.get(1))
+                                .and_then(|m| m.as_str().parse::<u32>().ok());
+                            out.push(ArxivEntry {
+                                title,
+                                authors: std::mem::take(&mut current_authors),
                                 link,
-                            ));
+                                version,
+                            });
                         }
                         in_entry = false;
                     }
@@ -210,6 +315,7 @@ fn parse_arxiv_id_response(xml: &str, expected_title: &str) -> Result<DbQueryRes
                         in_author = false;
                     }
                     b"name" => in_name = false,
+                    b"id" => in_id = false,
                     _ => {}
                 }
             }
@@ -220,7 +326,7 @@ fn parse_arxiv_id_response(xml: &str, expected_title: &str) -> Result<DbQueryRes
         buf.clear();
     }
 
-    Ok(DbQueryResult::not_found())
+    Ok(out)
 }
 
 /// Parse arXiv Atom XML response and find matching entries.
@@ -336,4 +442,118 @@ fn parse_arxiv_response(xml: &str, title: &str) -> Result<DbQueryResult, DbQuery
     }
 
     Ok(DbQueryResult::not_found())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one_entry_xml(id_url: &str, title: &str, authors: &[&str]) -> String {
+        let authors_xml: String = authors
+            .iter()
+            .map(|a| format!("<author><name>{}</name></author>", a))
+            .collect();
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>{id_url}</id>
+    <title>{title}</title>
+    {authors_xml}
+    <link href="{id_url}" rel="alternate" type="text/html"/>
+  </entry>
+</feed>"#
+        )
+    }
+
+    #[test]
+    fn parses_single_entry_with_version() {
+        // Typical id_list=<bare-id> response: one <entry> whose <id>
+        // carries the latest version suffix.
+        let xml = one_entry_xml(
+            "http://arxiv.org/abs/2403.00108v2",
+            "LoRATK: LoRA Once, Backdoor Everywhere in the Share-and-Play Ecosystem",
+            &["Hongyi Liu", "Shaochen Zhong"],
+        );
+        let entries = parse_arxiv_id_entries(&xml).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "LoRATK: LoRA Once, Backdoor Everywhere in the Share-and-Play Ecosystem");
+        assert_eq!(entries[0].authors, vec!["Hongyi Liu", "Shaochen Zhong"]);
+        assert_eq!(entries[0].version, Some(2));
+        assert_eq!(
+            entries[0].link.as_deref(),
+            Some("http://arxiv.org/abs/2403.00108v2")
+        );
+    }
+
+    #[test]
+    fn parses_multiple_entries_for_batched_id_list() {
+        // When we issue `id_list=X v1, X v2, X v3`, the response is a
+        // multi-entry feed. The parser must return all entries in order
+        // so the caller can scan for a title match across versions.
+        let xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2403.00108v1</id>
+    <title>Lora-as-an-attack! piercing llm safety under the share-and-play scenario</title>
+    <author><name>Hongyi Liu</name></author>
+    <link href="http://arxiv.org/abs/2403.00108v1" rel="alternate"/>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2403.00108v2</id>
+    <title>LoRATK: LoRA Once, Backdoor Everywhere in the Share-and-Play Ecosystem</title>
+    <author><name>Hongyi Liu</name></author>
+    <link href="http://arxiv.org/abs/2403.00108v2" rel="alternate"/>
+  </entry>
+</feed>"#
+        );
+        let entries = parse_arxiv_id_entries(&xml).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].title.starts_with("Lora-as-an-attack"));
+        assert_eq!(entries[0].version, Some(1));
+        assert!(entries[1].title.starts_with("LoRATK:"));
+        assert_eq!(entries[1].version, Some(2));
+    }
+
+    #[test]
+    fn version_none_for_id_without_suffix() {
+        // Old-format or otherwise version-less `<id>` URL — the caller
+        // then skips the earlier-versions fallback because it doesn't
+        // know how many to try.
+        let xml = one_entry_xml(
+            "http://arxiv.org/abs/hep-th/9901001",
+            "Some old paper",
+            &["A. Einstein"],
+        );
+        let entries = parse_arxiv_id_entries(&xml).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].version, None);
+    }
+
+    #[test]
+    fn arxiv_id_explicit_version_suffix_detected() {
+        // `ARXIV_VERSION_SUFFIX` gates whether the fallback fires:
+        // citations that already pinned a version shouldn't fall back to
+        // "any version", and old-format IDs don't carry a suffix at all.
+        assert!(ARXIV_VERSION_SUFFIX.is_match("2403.00108v1"));
+        assert!(ARXIV_VERSION_SUFFIX.is_match("2403.00108v42"));
+        assert!(ARXIV_VERSION_SUFFIX.is_match("hep-th/9901001v1"));
+        assert!(!ARXIV_VERSION_SUFFIX.is_match("2403.00108"));
+        assert!(!ARXIV_VERSION_SUFFIX.is_match("hep-th/9901001"));
+    }
+
+    #[test]
+    fn returns_empty_on_no_matches_feed() {
+        // Arxiv returns a <feed> with no <entry> when the id_list
+        // doesn't resolve (e.g., all fabricated IDs). Parser must not
+        // panic.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>ArXiv Query: search_query=&amp;id_list=2403.99999</title>
+  <id>http://arxiv.org/api/fake</id>
+</feed>"#;
+        let entries = parse_arxiv_id_entries(xml).unwrap();
+        assert!(entries.is_empty());
+    }
 }

--- a/hallucinator-rs/crates/hallucinator-core/src/db/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/mod.rs
@@ -18,6 +18,7 @@ pub mod semantic_scholar;
 pub mod ssrn;
 pub mod standards;
 pub mod url_check;
+pub mod wayback;
 
 #[cfg(test)]
 pub(crate) mod mock;

--- a/hallucinator-rs/crates/hallucinator-core/src/db/url_check.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/url_check.rs
@@ -161,9 +161,95 @@ impl UrlChecker {
     }
 }
 
+/// Expand a URL list with separator variants for fallback matching.
+///
+/// When the PDF extraction pipeline recovers a URL with an internal
+/// whitespace gap (e.g., a word that was line-broken without a hyphen),
+/// `fix_url_spacing` guesses that the intended join is an underscore.
+/// That's the right guess for file-path URLs (`cjson_read_fuzzer.c`) but
+/// wrong for blog-slug URLs where the space sat *inside* a single word —
+/// e.g., NDSS 2026 f1059 ref 41:
+///
+///   raw       `...authentication-s urvey-a-world-of-difference...`
+///   extracted `...authentication-s_urvey-a-world-of-difference...`
+///   correct   `...authentication-survey-a-world-of-difference...`
+///
+/// We can't tell at extraction time which is which, so the liveness and
+/// archive checkers try all three: the original, `_` → `-`, and
+/// `_` → ``. The first live URL wins. URLs that legitimately contain
+/// `_` (GitHub blob paths, etc.) are unaffected because the unmodified
+/// original is tried first; variants only fire when the original fails.
+///
+/// Order: always the original first, then the `-` variant, then the
+/// no-separator variant. Deduplicated (a URL without `_` contributes
+/// exactly one entry).
+pub fn expand_url_variants(urls: &[String]) -> Vec<String> {
+    use std::collections::HashSet;
+    let mut out = Vec::with_capacity(urls.len() * 3);
+    let mut seen: HashSet<String> = HashSet::new();
+    for url in urls {
+        for variant in [url.clone(), url.replace('_', "-"), url.replace('_', "")] {
+            if seen.insert(variant.clone()) {
+                out.push(variant);
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── expand_url_variants (hermetic) ──────────────────────────────────
+
+    #[test]
+    fn expand_variants_urls_without_underscore_unchanged() {
+        // Nothing to swap → exactly one entry per input URL.
+        let got = expand_url_variants(&[
+            "https://github.com/user/repo".into(),
+            "https://example.com/a/b/c".into(),
+        ]);
+        assert_eq!(got.len(), 2);
+        assert!(got.contains(&"https://github.com/user/repo".to_string()));
+    }
+
+    #[test]
+    fn expand_variants_url_with_underscore_yields_three() {
+        // Original + `_` → `-` + `_` → ``. Original comes first so the
+        // common case (legitimate underscore in path) hits on first try.
+        let got =
+            expand_url_variants(&["https://example.com/my_page".into()]);
+        assert_eq!(
+            got,
+            vec![
+                "https://example.com/my_page",
+                "https://example.com/my-page",
+                "https://example.com/mypage",
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_variants_dedupes_collision_between_urls() {
+        // Two different inputs whose variants collapse to the same URL
+        // (e.g. both lose `_` the same way) must be emitted once.
+        let got = expand_url_variants(&[
+            "https://example.com/a_b".into(),
+            "https://example.com/a_b".into(),
+        ]);
+        assert_eq!(got.len(), 3);
+    }
+
+    #[test]
+    fn expand_variants_f1059_ref41_yubico_blog_slug() {
+        // The motivating case: the blog slug's `-s_urvey-` variants must
+        // include the no-separator form that matches the real URL.
+        let got = expand_url_variants(&[
+            "https://www.yubico.com/blog/2025-global-state-of-authentication-s_urvey-a-world-of-difference-in-cybersecurity-habits/".into(),
+        ]);
+        assert!(got.contains(&"https://www.yubico.com/blog/2025-global-state-of-authentication-survey-a-world-of-difference-in-cybersecurity-habits/".to_string()));
+    }
 
     // ── hermetic classification tests (no network) ──────────────────────
 

--- a/hallucinator-rs/crates/hallucinator-core/src/db/wayback.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/wayback.rs
@@ -1,0 +1,209 @@
+//! Wayback Machine (Internet Archive) availability fallback.
+//!
+//! Some references cite URLs that were live when the paper was written
+//! but have since 404'd — link rot, not fabrication. Treating these as
+//! hallucinations is a false positive the user then has to hand-mark
+//! safe. This module queries archive.org's Availability API so we can
+//! recognise "URL is dead now but existed once" as a real citation,
+//! distinct from "URL never existed".
+//!
+//! API: `https://archive.org/wayback/available?url=<url>` — returns
+//! JSON with the closest snapshot (or an empty object if the URL was
+//! never archived). Only snapshots whose capture-time HTTP status was
+//! 2xx / 3xx count: a Wayback record of a 404 response doesn't prove
+//! the URL was ever live.
+
+use std::time::Duration;
+
+/// Result of a successful Wayback lookup.
+#[derive(Debug, Clone)]
+pub struct WaybackResult {
+    /// The original URL the user checked (useful for building the
+    /// citation's own DB result row).
+    pub original_url: String,
+    /// The `web.archive.org/web/<timestamp>/...` URL. Clickable and
+    /// serves the captured page content.
+    pub snapshot_url: String,
+    /// Wayback timestamp, e.g. "20230612123456". Callers can display
+    /// the capture date alongside the snapshot link.
+    pub timestamp: String,
+}
+
+/// Check one URL against the Wayback Machine's Availability API.
+///
+/// Returns `Some` only when the closest snapshot both exists
+/// (`available: true`) and captured a successful HTTP response
+/// (`status` = 2xx or 3xx). Network errors and missing snapshots both
+/// collapse to `None`.
+pub async fn check_url(
+    url: &str,
+    client: &reqwest::Client,
+    timeout: Duration,
+) -> Option<WaybackResult> {
+    let api = format!(
+        "https://archive.org/wayback/available?url={}",
+        urlencoding::encode(url)
+    );
+    let resp = client.get(&api).timeout(timeout).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body = resp.text().await.ok()?;
+    parse_availability_response(url, &body)
+}
+
+/// Check a list of URLs and return the first successful snapshot.
+///
+/// Mirrors `UrlChecker::check_first_live`: sequential, short-circuits
+/// on the first hit. Usually a ref has exactly one URL, so the loop is
+/// either one request or a couple.
+pub async fn check_first_snapshot(
+    urls: &[String],
+    client: &reqwest::Client,
+    timeout: Duration,
+) -> Option<WaybackResult> {
+    for url in urls {
+        if let Some(result) = check_url(url, client, timeout).await {
+            return Some(result);
+        }
+    }
+    None
+}
+
+/// Parse the Availability API's JSON response into a `WaybackResult`.
+fn parse_availability_response(original_url: &str, body: &str) -> Option<WaybackResult> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let closest = value
+        .get("archived_snapshots")?
+        .get("closest")?;
+    if !closest
+        .get("available")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    // `status` is a string in the API response, e.g. "200".
+    let status = closest
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if !status_counts_as_captured(status) {
+        return None;
+    }
+    let snapshot_url = closest.get("url")?.as_str()?.to_string();
+    let timestamp = closest
+        .get("timestamp")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some(WaybackResult {
+        original_url: original_url.to_string(),
+        snapshot_url,
+        timestamp,
+    })
+}
+
+/// A Wayback snapshot only counts as "the URL existed" when the
+/// capture itself was a successful fetch. A snapshot of a 404 page
+/// would be misleading.
+fn status_counts_as_captured(status: &str) -> bool {
+    let Ok(n) = status.parse::<u16>() else {
+        return false;
+    };
+    (200..400).contains(&n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_successful_snapshot() {
+        let body = r#"{
+            "url": "https://example.com/page",
+            "archived_snapshots": {
+                "closest": {
+                    "status": "200",
+                    "available": true,
+                    "url": "http://web.archive.org/web/20230612123456/https://example.com/page",
+                    "timestamp": "20230612123456"
+                }
+            }
+        }"#;
+        let result = parse_availability_response("https://example.com/page", body).unwrap();
+        assert_eq!(result.original_url, "https://example.com/page");
+        assert_eq!(
+            result.snapshot_url,
+            "http://web.archive.org/web/20230612123456/https://example.com/page"
+        );
+        assert_eq!(result.timestamp, "20230612123456");
+    }
+
+    #[test]
+    fn returns_none_on_empty_snapshots() {
+        // Wayback shape when the URL was never archived.
+        let body = r#"{"url":"https://example.com/page","archived_snapshots":{}}"#;
+        assert!(parse_availability_response("https://example.com/page", body).is_none());
+    }
+
+    #[test]
+    fn rejects_snapshot_of_404_capture() {
+        // A capture of a 404 response doesn't prove the URL was ever
+        // live — that would just let a hallucinated URL slip through
+        // because archive.org crawled it once and got a 404 too.
+        let body = r#"{
+            "archived_snapshots": {
+                "closest": {
+                    "status": "404",
+                    "available": true,
+                    "url": "http://web.archive.org/web/20230612123456/https://example.com/page",
+                    "timestamp": "20230612123456"
+                }
+            }
+        }"#;
+        assert!(parse_availability_response("https://example.com/page", body).is_none());
+    }
+
+    #[test]
+    fn rejects_snapshot_with_available_false() {
+        // `available: false` happens when the record exists in the
+        // index but the capture itself is gone. Don't count it.
+        let body = r#"{
+            "archived_snapshots": {
+                "closest": {
+                    "status": "200",
+                    "available": false,
+                    "url": "http://web.archive.org/web/20230612123456/https://example.com/page",
+                    "timestamp": "20230612123456"
+                }
+            }
+        }"#;
+        assert!(parse_availability_response("https://example.com/page", body).is_none());
+    }
+
+    #[test]
+    fn accepts_redirect_status_captures() {
+        // A 301/302 capture means the archived version was itself a
+        // redirect — still evidence the URL existed.
+        let body = r#"{
+            "archived_snapshots": {
+                "closest": {
+                    "status": "301",
+                    "available": true,
+                    "url": "http://web.archive.org/web/20230101000000/https://example.com/page",
+                    "timestamp": "20230101000000"
+                }
+            }
+        }"#;
+        assert!(parse_availability_response("https://example.com/page", body).is_some());
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        // Defensive: archive.org occasionally returns HTML error pages
+        // under load. Parsing failure should collapse to "no snapshot".
+        let body = "<html>service unavailable</html>";
+        assert!(parse_availability_response("https://example.com/page", body).is_none());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use crate::authors::validate_authors;
 use crate::db::DatabaseBackend;
 use crate::db::searxng::Searxng;
-use crate::db::url_check::UrlChecker;
+use crate::db::url_check::{UrlChecker, expand_url_variants};
 use crate::db::wayback;
 use crate::orchestrator::{build_database_list, query_local_databases};
 use crate::rate_limit::{self, ArxivIdContext, DbQueryError, DoiContext};
@@ -513,11 +513,21 @@ async fn apply_fallbacks(
     Option<String>,
     Vec<DbResult>,
 ) {
+    // Expand URL separator variants (see `expand_url_variants` docs).
+    // URL Check and Wayback both operate on this expanded list so that
+    // URLs whose `_`/`-`/<none> separator got guessed wrong during
+    // extraction still have a chance to resolve.
+    let candidate_urls: Vec<String> = if urls.is_empty() {
+        Vec::new()
+    } else {
+        expand_url_variants(urls)
+    };
+
     // ── URL liveness check ─────────────────────────────────────────────
-    if status == Status::NotFound && !urls.is_empty() {
+    if status == Status::NotFound && !candidate_urls.is_empty() {
         let timeout = Duration::from_secs(config.db_timeout_secs);
         let start = std::time::Instant::now();
-        let url_result = UrlChecker::check_first_live(urls, client, timeout).await;
+        let url_result = UrlChecker::check_first_live(&candidate_urls, client, timeout).await;
         let elapsed = start.elapsed();
 
         if let Some(url_result) = url_result {
@@ -561,10 +571,11 @@ async fn apply_fallbacks(
     // since 404'd (link rot). If the Internet Archive has a valid
     // snapshot, that's strong evidence the citation was real; report the
     // archived URL so the user can read the captured content.
-    if status == Status::NotFound && !urls.is_empty() {
+    if status == Status::NotFound && !candidate_urls.is_empty() {
         let timeout = Duration::from_secs(config.db_timeout_secs);
         let start = std::time::Instant::now();
-        let wayback_result = wayback::check_first_snapshot(urls, client, timeout).await;
+        let wayback_result =
+            wayback::check_first_snapshot(&candidate_urls, client, timeout).await;
         let elapsed = start.elapsed();
 
         if let Some(result) = wayback_result {

--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -17,6 +17,7 @@ use crate::authors::validate_authors;
 use crate::db::DatabaseBackend;
 use crate::db::searxng::Searxng;
 use crate::db::url_check::UrlChecker;
+use crate::db::wayback;
 use crate::orchestrator::{build_database_list, query_local_databases};
 use crate::rate_limit::{self, ArxivIdContext, DbQueryError, DoiContext};
 use crate::{
@@ -548,6 +549,52 @@ async fn apply_fallbacks(
             paper_index: 0,
             ref_index,
             db_name: "URL Check".to_string(),
+            status: DbStatus::NoMatch,
+            elapsed,
+        });
+    }
+
+    // ── Wayback Machine fallback ───────────────────────────────────────
+    //
+    // URL Check didn't find anything live at any of the cited URLs — but
+    // the URLs may have been live when the citation was written and
+    // since 404'd (link rot). If the Internet Archive has a valid
+    // snapshot, that's strong evidence the citation was real; report the
+    // archived URL so the user can read the captured content.
+    if status == Status::NotFound && !urls.is_empty() {
+        let timeout = Duration::from_secs(config.db_timeout_secs);
+        let start = std::time::Instant::now();
+        let wayback_result = wayback::check_first_snapshot(urls, client, timeout).await;
+        let elapsed = start.elapsed();
+
+        if let Some(result) = wayback_result {
+            progress(ProgressEvent::DatabaseQueryComplete {
+                paper_index: 0,
+                ref_index,
+                db_name: "Wayback Machine".to_string(),
+                status: DbStatus::Match,
+                elapsed,
+            });
+            db_results.push(DbResult {
+                db_name: "Wayback Machine".into(),
+                status: DbStatus::Match,
+                elapsed: Some(elapsed),
+                found_authors: vec![],
+                paper_url: Some(result.snapshot_url.clone()),
+                error_message: None,
+            });
+            return (
+                Status::Verified,
+                Some("Wayback Machine".into()),
+                vec![],
+                Some(result.snapshot_url),
+                db_results,
+            );
+        }
+        progress(ProgressEvent::DatabaseQueryComplete {
+            paper_index: 0,
+            ref_index,
+            db_name: "Wayback Machine".to_string(),
             status: DbStatus::NoMatch,
             elapsed,
         });


### PR DESCRIPTION
## Summary

Three related improvements aimed at reducing false-positive hallucination reports for reference URLs and arXiv IDs. All surfaced while triaging residual NDSS 2026 not-founds.

- **arXiv version history** (`52dc048`): arXiv papers sometimes get retitled between versions. A citation with the v1 title against an arXiv ID whose latest is v2+ with a different title used to be flagged as a hallucination. When the latest-version title doesn't match, the backend now batches a single comma-separated `id_list=Xv1,Xv2,…,Xv{N-1}` request and scans all earlier versions for a title match. Cost is bounded at one additional request regardless of how many versions a paper has. Fallback is skipped when the citation already pins an explicit version (`arXiv:2403.00108v1` — honor the user's choice).
  - Real case: NDSS 2026 f168 ref 8 (cites v1 title `"Lora-as-an-attack! …"`, arXiv latest v2 is `"LoRATK: …"`) — now verifies against v1.

- **Wayback Machine fallback** (`54df5d7`): URL Check correctly reports link-rotted URLs as not-live, but the citation was still real — the URL just 404'd. A new step between URL Check and SearxNG queries archive.org's Availability API and, if a capture exists (with capture-time status 2xx/3xx and `available: true`), verifies the ref with `source = "Wayback Machine"` and a clickable `web.archive.org/web/<ts>/<original>` `paper_url`. Captures of 404 responses don't count. Wired into both the pool's `apply_fallbacks` and `checker.rs`'s retry path.

- **URL separator variants** (`516255c`): `fix_url_spacing`'s `MIDDLE_SPACED_SEGMENT` rule guesses `_` when joining a PDF-broken path segment. That's right for file paths but wrong for blog slugs where the PDF broke a single word without a hyphen. Example NDSS 2026 f1059 ref 41: `authentication-s urvey-…` joined as `s_urvey` (404) instead of `survey` (200). Rather than guess at extraction time, `expand_url_variants` produces the original, `_` → `-`, and `_` → `<none>` as candidates; URL Check and Wayback iterate all three. Original is tried first, so URLs with legitimate `_` (GitHub paths, etc.) still hit 200 immediately and variants never fire.

## Safety against false positives

- **Academic URLs** (`doi.org`, `arxiv.org`, `acm.org`, `ieee.org`, …) are explicitly excluded from URL Check / Wayback by `extract_urls`, so a DOI or arXiv URL that resolves to a *different* paper than the citation claims goes through the DOI / arXiv backends (which validate title match), not URL Check (which only tests liveness).
- Wayback only accepts captures whose own status was 2xx/3xx — a Wayback record of a 404 page doesn't slip through.
- URL variant expansion is deferred to fallback — the original URL is always tried first, so URLs with legitimate `_` are never rewritten.

## Test plan

- [x] 15 new hermetic unit tests: 5 for arXiv `<entry>` parsing and version extraction, 6 for the Wayback Availability JSON parser (success, empty, 404-capture rejection, `available: false`, redirects, malformed input), 4 for `expand_url_variants` (no-underscore unchanged, 3-variant emission order, dedup, f1059 shape).
- [x] Full workspace test suite: green.
- [x] End-to-end verification on NDSS 2026:
  - f168 ref 8: NOT FOUND → VERIFIED (arXiv) via v1 title match.
  - f1059 ref 41: NOT FOUND → VERIFIED (URL Check) via `_` → `<none>` variant.
  - bluesky-blocks-paper: 38/1 unchanged (no link-rotted URLs in that corpus, so Wayback never fires — the code path is covered by unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)