### PR TITLE
Export directory picker (#112) + CI hygiene (fmt/clippy)

### DIFF
--- a/hallucinator-rs/crates/hallucinator-arxiv-offline/src/db.rs
+++ b/hallucinator-rs/crates/hallucinator-arxiv-offline/src/db.rs
@@ -99,9 +99,8 @@ pub fn upsert_record(conn: &Connection, rec: &ArxivRecord) -> Result<(), ArxivEr
         stmt.execute(params![rec.id])?;
     }
     {
-        let mut stmt = conn.prepare_cached(
-            "INSERT INTO authors (arxiv_id, position, name) VALUES (?1, ?2, ?3)",
-        )?;
+        let mut stmt = conn
+            .prepare_cached("INSERT INTO authors (arxiv_id, position, name) VALUES (?1, ?2, ?3)")?;
         for (i, name) in rec.authors.iter().enumerate() {
             stmt.execute(params![rec.id, i as i64, name])?;
         }
@@ -158,9 +157,8 @@ pub fn upsert_record_no_fts(conn: &Connection, rec: &ArxivRecord) -> Result<(), 
         stmt.execute(params![rec.id])?;
     }
     {
-        let mut stmt = conn.prepare_cached(
-            "INSERT INTO authors (arxiv_id, position, name) VALUES (?1, ?2, ?3)",
-        )?;
+        let mut stmt = conn
+            .prepare_cached("INSERT INTO authors (arxiv_id, position, name) VALUES (?1, ?2, ?3)")?;
         for (i, name) in rec.authors.iter().enumerate() {
             stmt.execute(params![rec.id, i as i64, name])?;
         }
@@ -283,9 +281,8 @@ pub fn search_by_title(
 }
 
 fn load_authors(conn: &Connection, arxiv_id: &str) -> Result<Vec<String>, ArxivError> {
-    let mut stmt = conn.prepare_cached(
-        "SELECT name FROM authors WHERE arxiv_id = ?1 ORDER BY position",
-    )?;
+    let mut stmt =
+        conn.prepare_cached("SELECT name FROM authors WHERE arxiv_id = ?1 ORDER BY position")?;
     let rows = stmt
         .query_map(params![arxiv_id], |row| row.get::<_, String>(0))?
         .collect::<Result<Vec<_>, _>>()?;

--- a/hallucinator-rs/crates/hallucinator-arxiv-offline/src/download.rs
+++ b/hallucinator-rs/crates/hallucinator-arxiv-offline/src/download.rs
@@ -58,8 +58,8 @@ pub fn load_credentials() -> Result<(String, String), ArxivError> {
     {
         return Ok((u, k));
     }
-    let home = dirs::home_dir()
-        .ok_or_else(|| ArxivError::Harvest("HOME directory not found".into()))?;
+    let home =
+        dirs::home_dir().ok_or_else(|| ArxivError::Harvest("HOME directory not found".into()))?;
     let path = home.join(".kaggle").join("kaggle.json");
     let file = File::open(&path).map_err(|e| {
         ArxivError::Harvest(format!(
@@ -69,9 +69,8 @@ pub fn load_credentials() -> Result<(String, String), ArxivError> {
             path.display()
         ))
     })?;
-    let creds: KaggleCredentials = serde_json::from_reader(file).map_err(|e| {
-        ArxivError::Harvest(format!("parsing {}: {e}", path.display()))
-    })?;
+    let creds: KaggleCredentials = serde_json::from_reader(file)
+        .map_err(|e| ArxivError::Harvest(format!("parsing {}: {e}", path.display())))?;
     if creds.username.is_empty() || creds.key.is_empty() {
         return Err(ArxivError::Harvest(format!(
             "{} contains an empty username or key",
@@ -84,10 +83,7 @@ pub fn load_credentials() -> Result<(String, String), ArxivError> {
 /// Download the Kaggle dataset zip to `dest_path`, streaming to disk.
 /// Returns the number of bytes written. `reqwest` follows the
 /// Kaggle → S3 pre-signed-URL redirect automatically.
-pub async fn download_kaggle_zip<P>(
-    dest_path: &Path,
-    mut progress: P,
-) -> Result<u64, ArxivError>
+pub async fn download_kaggle_zip<P>(dest_path: &Path, mut progress: P) -> Result<u64, ArxivError>
 where
     P: FnMut(DownloadProgress),
 {
@@ -201,8 +197,7 @@ mod tests {
         // We can't easily hide the real ~/.kaggle/kaggle.json, but the
         // error message contract is still exercised when it's absent.
         // Skip if the dev machine happens to have one.
-        let path = dirs::home_dir()
-            .map(|h| h.join(".kaggle").join("kaggle.json"));
+        let path = dirs::home_dir().map(|h| h.join(".kaggle").join("kaggle.json"));
         if path.as_ref().is_some_and(|p| p.exists()) {
             return;
         }

--- a/hallucinator-rs/crates/hallucinator-arxiv-offline/src/ingest.rs
+++ b/hallucinator-rs/crates/hallucinator-arxiv-offline/src/ingest.rs
@@ -83,9 +83,9 @@ where
     let mut emitted_start = false;
     let every = progress_every.max(1);
 
-    let mut line_no: u64 = 0;
-    for line in reader.lines() {
-        line_no += 1;
+    for (line_idx, line) in reader.lines().enumerate() {
+        // Line numbers are 1-based in error messages for human readability.
+        let line_no = line_idx as u64 + 1;
         let line = line.map_err(|e| ArxivError::Harvest(format!("read line {line_no}: {e}")))?;
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -100,7 +100,7 @@ where
             emitted_start = true;
             progress(IngestProgress::Started);
         }
-        if count % every == 0 {
+        if count.is_multiple_of(every) {
             progress(IngestProgress::Progress {
                 records_parsed: count,
             });
@@ -121,8 +121,11 @@ impl KaggleRecord {
             .into_iter()
             .filter_map(format_author)
             .collect();
-        let mut versions: Vec<ArxivVersion> =
-            self.versions.into_iter().filter_map(parse_version).collect();
+        let mut versions: Vec<ArxivVersion> = self
+            .versions
+            .into_iter()
+            .filter_map(parse_version)
+            .collect();
         // v1 fallback when the dump omits version history (rare, seen
         // on very old records). Keeps downstream code from having to
         // handle an empty versions list.

--- a/hallucinator-rs/crates/hallucinator-arxiv-offline/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-arxiv-offline/src/lib.rs
@@ -106,9 +106,7 @@ impl ArxivDatabase {
             |row| row.get(0),
         )?;
         if !exists {
-            return Err(ArxivError::Database(
-                rusqlite::Error::QueryReturnedNoRows,
-            ));
+            return Err(ArxivError::Database(rusqlite::Error::QueryReturnedNoRows));
         }
         // Pragmas for read-heavy workload (matches dblp/acl setup).
         conn.execute_batch(
@@ -220,8 +218,7 @@ impl ArxivDatabase {
     /// (begin_bulk weakens it to OFF for throughput).
     pub fn commit_bulk(&self) -> Result<(), ArxivError> {
         self.conn.execute_batch("COMMIT")?;
-        self.conn
-            .execute_batch("PRAGMA synchronous = NORMAL;")?;
+        self.conn.execute_batch("PRAGMA synchronous = NORMAL;")?;
         Ok(())
     }
 

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -1883,10 +1883,7 @@ async fn update_arxiv(
                 .map(|p| p.to_path_buf())
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join("arxiv-kaggle.zip");
-            println!(
-                "Downloading Kaggle arxiv snapshot to: {}",
-                dest.display()
-            );
+            println!("Downloading Kaggle arxiv snapshot to: {}", dest.display());
             println!(
                 "(If this is your first run, open https://www.kaggle.com/datasets/Cornell-University/arxiv\n\
                  once in a browser and accept the dataset license.)"
@@ -1963,14 +1960,13 @@ async fn update_arxiv(
         db.upsert_bulk(&rec)
             .map_err(|e| hallucinator_arxiv_offline::ArxivError::Harvest(e.to_string()))?;
         inserted += 1;
-        if inserted % 1_000 == 0 {
+        if inserted.is_multiple_of(1_000) {
             bar_for_sink.set_position(inserted);
         }
-        if inserted % COMMIT_EVERY == 0 {
-            db.commit_and_continue()
-                .map_err(|e| hallucinator_arxiv_offline::ArxivError::Harvest(
-                    format!("mid-ingest commit: {e}"),
-                ))?;
+        if inserted.is_multiple_of(COMMIT_EVERY) {
+            db.commit_and_continue().map_err(|e| {
+                hallucinator_arxiv_offline::ArxivError::Harvest(format!("mid-ingest commit: {e}"))
+            })?;
         }
         Ok(())
     };
@@ -2004,8 +2000,7 @@ async fn update_arxiv(
             // otherwise look like the CLI hung.
             let fts_bar = ProgressBar::new_spinner();
             fts_bar.set_style(
-                ProgressStyle::with_template("{spinner:.cyan} {msg} [{elapsed_precise}]")
-                    .unwrap(),
+                ProgressStyle::with_template("{spinner:.cyan} {msg} [{elapsed_precise}]").unwrap(),
             );
             fts_bar.enable_steady_tick(Duration::from_millis(100));
             fts_bar.set_message("rebuilding FTS title index …");
@@ -2036,13 +2031,14 @@ async fn update_arxiv(
 
     // 4. Clean up the downloaded zip — unless --keep-download was
     // passed or the user supplied their own file (which we don't own).
-    if downloaded_fresh && !keep_download {
-        if let Err(e) = std::fs::remove_file(&dump_path) {
-            eprintln!(
-                "warning: could not remove downloaded zip {}: {e}",
-                dump_path.display()
-            );
-        }
+    if downloaded_fresh
+        && !keep_download
+        && let Err(e) = std::fs::remove_file(&dump_path)
+    {
+        eprintln!(
+            "warning: could not remove downloaded zip {}: {e}",
+            dump_path.display()
+        );
     }
 
     let canonical = std::fs::canonicalize(db_path).unwrap_or_else(|_| db_path.clone());
@@ -2074,7 +2070,9 @@ fn ingest_dump<F, P>(
     progress: P,
 ) -> Result<u64, hallucinator_arxiv_offline::ArxivError>
 where
-    F: FnMut(hallucinator_arxiv_offline::ArxivRecord) -> Result<(), hallucinator_arxiv_offline::ArxivError>,
+    F: FnMut(
+        hallucinator_arxiv_offline::ArxivRecord,
+    ) -> Result<(), hallucinator_arxiv_offline::ArxivError>,
     P: FnMut(hallucinator_arxiv_offline::ingest::IngestProgress),
 {
     use hallucinator_arxiv_offline::ArxivError;

--- a/hallucinator-rs/crates/hallucinator-core/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/authors.rs
@@ -227,7 +227,8 @@ pub fn validate_authors(ref_authors: &[String], found_authors: &[String]) -> boo
 /// tokens, both begin with an uppercase letter, and neither is an initial or
 /// carries a period (i.e. we cannot tell Given-Family from Family-Given).
 fn is_ambiguous_two_token(name: &str) -> bool {
-    let parts: Vec<&str> = name.trim().split_whitespace().collect();
+    // split_whitespace already handles leading/trailing whitespace.
+    let parts: Vec<&str> = name.split_whitespace().collect();
     if parts.len() != 2 {
         return false;
     }
@@ -246,7 +247,7 @@ fn is_ambiguous_two_token(name: &str) -> bool {
 /// Lowercase first whitespace-separated token (with trailing punctuation
 /// trimmed). Used only by the LNF fallback above.
 fn first_token_lower(name: &str) -> Option<String> {
-    let first = name.trim().split_whitespace().next()?;
+    let first = name.split_whitespace().next()?;
     let first = first.trim_end_matches(|c: char| !c.is_alphanumeric());
     if first.is_empty() {
         None

--- a/hallucinator-rs/crates/hallucinator-core/src/cache.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/cache.rs
@@ -1791,9 +1791,7 @@ mod tests {
     fn compute_fp_identity_rejects_empty_authors() {
         assert!(compute_fp_identity("Some Paper", &[]).is_none());
         // Whitespace-only strings are also treated as empty.
-        assert!(
-            compute_fp_identity("Some Paper", &["".into(), "   ".into()]).is_none()
-        );
+        assert!(compute_fp_identity("Some Paper", &["".into(), "   ".into()]).is_none());
     }
 
     #[test]
@@ -1807,23 +1805,16 @@ mod tests {
 
     #[test]
     fn compute_fp_identity_is_order_independent() {
-        let ab = compute_fp_identity(
-            "A Paper",
-            &["Alice Aardvark".into(), "Bob Badger".into()],
-        )
-        .unwrap();
-        let ba = compute_fp_identity(
-            "A Paper",
-            &["Bob Badger".into(), "Alice Aardvark".into()],
-        )
-        .unwrap();
+        let ab = compute_fp_identity("A Paper", &["Alice Aardvark".into(), "Bob Badger".into()])
+            .unwrap();
+        let ba = compute_fp_identity("A Paper", &["Bob Badger".into(), "Alice Aardvark".into()])
+            .unwrap();
         assert_eq!(ab, ba);
     }
 
     #[test]
     fn compute_fp_identity_strips_diacritics() {
-        let with_accent =
-            compute_fp_identity("A Paper", &["C. Balázs".into()]).unwrap();
+        let with_accent = compute_fp_identity("A Paper", &["C. Balázs".into()]).unwrap();
         let plain = compute_fp_identity("A Paper", &["C. Balazs".into()]).unwrap();
         assert_eq!(with_accent, plain);
     }
@@ -1854,13 +1845,9 @@ mod tests {
         // Defensive: if the extractor emits the same author twice
         // (happens on some malformed citations), identity should
         // still be deterministic and not double-count.
-        let once =
-            compute_fp_identity("A Paper", &["John Smith".into()]).unwrap();
-        let twice = compute_fp_identity(
-            "A Paper",
-            &["John Smith".into(), "J. Smith".into()],
-        )
-        .unwrap();
+        let once = compute_fp_identity("A Paper", &["John Smith".into()]).unwrap();
+        let twice =
+            compute_fp_identity("A Paper", &["John Smith".into(), "J. Smith".into()]).unwrap();
         assert_eq!(once, twice);
     }
 

--- a/hallucinator-rs/crates/hallucinator-core/src/db/arxiv.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/arxiv.rs
@@ -477,7 +477,10 @@ mod tests {
         );
         let entries = parse_arxiv_id_entries(&xml).unwrap();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].title, "LoRATK: LoRA Once, Backdoor Everywhere in the Share-and-Play Ecosystem");
+        assert_eq!(
+            entries[0].title,
+            "LoRATK: LoRA Once, Backdoor Everywhere in the Share-and-Play Ecosystem"
+        );
         assert_eq!(entries[0].authors, vec!["Hongyi Liu", "Shaochen Zhong"]);
         assert_eq!(entries[0].version, Some(2));
         assert_eq!(
@@ -491,8 +494,7 @@ mod tests {
         // When we issue `id_list=X v1, X v2, X v3`, the response is a
         // multi-entry feed. The parser must return all entries in order
         // so the caller can scan for a title match across versions.
-        let xml = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <entry>
     <id>http://arxiv.org/abs/2403.00108v1</id>
@@ -506,9 +508,8 @@ mod tests {
     <author><name>Hongyi Liu</name></author>
     <link href="http://arxiv.org/abs/2403.00108v2" rel="alternate"/>
   </entry>
-</feed>"#
-        );
-        let entries = parse_arxiv_id_entries(&xml).unwrap();
+</feed>"#;
+        let entries = parse_arxiv_id_entries(xml).unwrap();
         assert_eq!(entries.len(), 2);
         assert!(entries[0].title.starts_with("Lora-as-an-attack"));
         assert_eq!(entries[0].version, Some(1));

--- a/hallucinator-rs/crates/hallucinator-core/src/db/dblp.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/dblp.rs
@@ -86,7 +86,11 @@ impl DatabaseBackend for DblpOffline {
                         .into_iter()
                         .map(|a| strip_dblp_suffix(&a))
                         .collect();
-                    Ok(DbQueryResult::found(qr.record.title, authors, qr.record.url))
+                    Ok(DbQueryResult::found(
+                        qr.record.title,
+                        authors,
+                        qr.record.url,
+                    ))
                 }
                 None => Ok(DbQueryResult::not_found()),
             }

--- a/hallucinator-rs/crates/hallucinator-core/src/db/url_check.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/url_check.rs
@@ -218,8 +218,7 @@ mod tests {
     fn expand_variants_url_with_underscore_yields_three() {
         // Original + `_` → `-` + `_` → ``. Original comes first so the
         // common case (legitimate underscore in path) hits on first try.
-        let got =
-            expand_url_variants(&["https://example.com/my_page".into()]);
+        let got = expand_url_variants(&["https://example.com/my_page".into()]);
         assert_eq!(
             got,
             vec![
@@ -275,14 +274,14 @@ mod tests {
         // returns 403 via DataDome to our HTTP client. The URL is real; the
         // server just declines to serve bots. Accept 401/403 as "exists".
         assert!(status_counts_as_live(StatusCode::UNAUTHORIZED)); // 401
-        assert!(status_counts_as_live(StatusCode::FORBIDDEN));   // 403
+        assert!(status_counts_as_live(StatusCode::FORBIDDEN)); // 403
     }
 
     #[test]
     fn status_not_live_on_definitive_absence() {
         // 404 / 410 definitively mean "not here" — do NOT treat as live.
-        assert!(!status_counts_as_live(StatusCode::NOT_FOUND));           // 404
-        assert!(!status_counts_as_live(StatusCode::GONE));                // 410
+        assert!(!status_counts_as_live(StatusCode::NOT_FOUND)); // 404
+        assert!(!status_counts_as_live(StatusCode::GONE)); // 410
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-core/src/db/wayback.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/wayback.rs
@@ -73,9 +73,7 @@ pub async fn check_first_snapshot(
 /// Parse the Availability API's JSON response into a `WaybackResult`.
 fn parse_availability_response(original_url: &str, body: &str) -> Option<WaybackResult> {
     let value: serde_json::Value = serde_json::from_str(body).ok()?;
-    let closest = value
-        .get("archived_snapshots")?
-        .get("closest")?;
+    let closest = value.get("archived_snapshots")?.get("closest")?;
     if !closest
         .get("available")
         .and_then(|v| v.as_bool())
@@ -84,10 +82,7 @@ fn parse_availability_response(original_url: &str, body: &str) -> Option<Wayback
         return None;
     }
     // `status` is a string in the API response, e.g. "200".
-    let status = closest
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let status = closest.get("status").and_then(|v| v.as_str()).unwrap_or("");
     if !status_counts_as_captured(status) {
         return None;
     }

--- a/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/orchestrator.rs
@@ -878,8 +878,7 @@ mod tests {
                 url: Some("https://dblp.org/rec/books/sp/voecking2011/Blomer11".into()),
             },
         ));
-        let result =
-            query_single_mock_db(mock, &["Adi Shamir".into()]).await;
+        let result = query_single_mock_db(mock, &["Adi Shamir".into()]).await;
         assert_eq!(result.status, Status::Verified);
         assert_eq!(result.source.as_deref(), Some("DBLP"));
         assert!(result.found_authors.is_empty());

--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -494,6 +494,7 @@ async fn report_result(
 ///
 /// The retraction field is *not* touched here (it's threaded through
 /// separately from the cached CrossRef response).
+#[allow(clippy::too_many_arguments)] // fallback surface area is what it is
 async fn apply_fallbacks(
     status: Status,
     source: Option<String>,
@@ -574,8 +575,7 @@ async fn apply_fallbacks(
     if status == Status::NotFound && !candidate_urls.is_empty() {
         let timeout = Duration::from_secs(config.db_timeout_secs);
         let start = std::time::Instant::now();
-        let wayback_result =
-            wayback::check_first_snapshot(&candidate_urls, client, timeout).await;
+        let wayback_result = wayback::check_first_snapshot(&candidate_urls, client, timeout).await;
         let elapsed = start.elapsed();
 
         if let Some(result) = wayback_result {

--- a/hallucinator-rs/crates/hallucinator-core/src/text_utils.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/text_utils.rs
@@ -152,8 +152,7 @@ fn fix_url_spacing(url_region: &str) -> String {
     // lowercase-or-digit after the dot lets `cs. cmu.edu` (lowercase `c`)
     // still collapse while leaving sentence-ending `downloader. GitHub`
     // (uppercase `G`) alone.
-    static SPACED_DOT: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(\w)\s*\.\s*([a-z0-9])").unwrap());
+    static SPACED_DOT: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\w)\s*\.\s*([a-z0-9])").unwrap());
     result = SPACED_DOT.replace_all(&result, "$1.$2").to_string();
 
     // Remove spaces around slashes when between URL parts: " / " or "/ " → "/"
@@ -210,9 +209,8 @@ fn fix_url_spacing(url_region: &str) -> String {
     // (first pass rewrites `/foo_bar/`; the second pass catches
     // `/baz_qux/`). Typical URL has <10 passes; terminates fast.
     static INTERNAL_WS: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
-    static MIDDLE_SPACED_SEGMENT: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"/([A-Za-z0-9\-]+(?:\s+[A-Za-z0-9\-]+)+)/").unwrap()
-    });
+    static MIDDLE_SPACED_SEGMENT: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"/([A-Za-z0-9\-]+(?:\s+[A-Za-z0-9\-]+)+)/").unwrap());
     loop {
         let next = MIDDLE_SPACED_SEGMENT
             .replace_all(&result, |caps: &regex::Captures| {
@@ -1034,7 +1032,11 @@ mod tests {
         // Critical post-condition: "file.pdf" must NOT have been pulled
         // into the URL as "file_pdf" or similar; the new rule stays off.
         assert!(!url.contains("_pdf"), "unexpected mangle: {}", url);
-        assert!(!url.contains("file.pdf"), "trailing narrative pulled in: {}", url);
+        assert!(
+            !url.contains("file.pdf"),
+            "trailing narrative pulled in: {}",
+            url
+        );
     }
 
     #[test]
@@ -1069,8 +1071,7 @@ mod tests {
         // of the current URL. URL_RE previously excluded only `]`, so it
         // kept eating through `[N`, producing URLs like "url/page[42".
         // Excluding `[` as well stops at the right place.
-        let text =
-            "See https://www.cve.org/about/Metrics[2] (2025) MITRE ATT&CK Framework";
+        let text = "See https://www.cve.org/about/Metrics[2] (2025) MITRE ATT&CK Framework";
         let urls = extract_urls(text);
         assert_eq!(urls, vec!["https://www.cve.org/about/Metrics"]);
     }
@@ -1081,8 +1082,7 @@ mod tests {
         // corpus, e.g. f700 ref [6]: "Yore-Wednesday.pdf.[6"). After `[`
         // is excluded, URL_RE stops at `[` and the existing trailing-punct
         // trim strips the `.`.
-        let text =
-            "Blah. https://i.blackhat.com/BH-US-24/Presentations/US24-Sialveras-Bugs-Of-Yore-Wednesday.pdf.[6] next ref";
+        let text = "Blah. https://i.blackhat.com/BH-US-24/Presentations/US24-Sialveras-Bugs-Of-Yore-Wednesday.pdf.[6] next ref";
         let urls = extract_urls(text);
         assert_eq!(
             urls,
@@ -1135,7 +1135,8 @@ mod tests {
         // `chi2010 tabbedbrowsing.pdf` with a trailing `, 2010` citation
         // year (which is what forced the companion change to
         // FILENAME_LOST_UNDERSCORES' anchor).
-        let text = "P. Dubroy, https://www.dgp.toronto.edu/∼ravin/papers/chi2010 tabbedbrowsing.pdf, 2010";
+        let text =
+            "P. Dubroy, https://www.dgp.toronto.edu/∼ravin/papers/chi2010 tabbedbrowsing.pdf, 2010";
         let urls = extract_urls(text);
         assert_eq!(
             urls,

--- a/hallucinator-rs/crates/hallucinator-dblp/src/query.rs
+++ b/hallucinator-rs/crates/hallucinator-dblp/src/query.rs
@@ -51,11 +51,11 @@ pub fn strip_title_decorations(title: &str) -> String {
         )
         .unwrap()
     });
-    static SUFFIX_BRACKET: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?i)\s*\[(?:invited paper|extended abstract)\]\s*\.?\s*$").unwrap());
+    static SUFFIX_BRACKET: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\s*\[(?:invited paper|extended abstract)\]\s*\.?\s*$").unwrap()
+    });
     static SUFFIX_PAREN: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"(?i)\s*\((?:extended abstract|invited paper|short paper)\)\s*\.?\s*$")
-            .unwrap()
+        Regex::new(r"(?i)\s*\((?:extended abstract|invited paper|short paper)\)\s*\.?\s*$").unwrap()
     });
     static SUFFIX_CORRECTION: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"(?i),\s*correction\s*\.?\s*$").unwrap());
@@ -131,8 +131,8 @@ pub fn get_query_words(title: &str) -> Vec<String> {
             // Short (2-3 char) prepositions / articles / copulas. Needed now
             // that short non-acronym tokens can pass the filter as a fallback
             // when the strong-token set is sparse.
-            "is", "as", "of", "to", "in", "on", "at", "it", "or", "an", "be", "we", "by",
-            "if", "so", "up", "do", "no",
+            "is", "as", "of", "to", "in", "on", "at", "it", "or", "an", "be", "we", "by", "if",
+            "so", "up", "do", "no",
         ]
         .into_iter()
         .collect()
@@ -185,7 +185,10 @@ pub fn get_query_words(title: &str) -> Vec<String> {
             .filter_map(|(o, l, p, s)| if s { Some((o, l, p)) } else { None })
             .collect()
     } else {
-        all_tokens.into_iter().map(|(o, l, p, _)| (o, l, p)).collect()
+        all_tokens
+            .into_iter()
+            .map(|(o, l, p, _)| (o, l, p))
+            .collect()
     };
 
     if words_with_info.len() <= 6 {
@@ -355,12 +358,8 @@ fn fts_match(
                     norm_candidate.chars(),
                 ))
             } else {
-                let a =
-                    rapidfuzz::fuzz::ratio(norm_query.chars(), norm_stripped.chars());
-                let b = rapidfuzz::fuzz::ratio(
-                    norm_query_stripped.chars(),
-                    norm_stripped.chars(),
-                );
+                let a = rapidfuzz::fuzz::ratio(norm_query.chars(), norm_stripped.chars());
+                let b = rapidfuzz::fuzz::ratio(norm_query_stripped.chars(), norm_stripped.chars());
                 raw_score.max(a).max(b)
             }
         };
@@ -682,7 +681,9 @@ mod tests {
     fn test_strip_title_decorations() {
         // Prefixes
         assert_eq!(
-            strip_title_decorations("Extended Abstract: HotStuff-2: Optimal Two-Phase Responsive BFT."),
+            strip_title_decorations(
+                "Extended Abstract: HotStuff-2: Optimal Two-Phase Responsive BFT."
+            ),
             "HotStuff-2: Optimal Two-Phase Responsive BFT"
         );
         assert_eq!(
@@ -695,12 +696,16 @@ mod tests {
         );
         // Bracket suffixes
         assert_eq!(
-            strip_title_decorations("LTE-advanced: next-generation wireless broadband technology [Invited Paper]."),
+            strip_title_decorations(
+                "LTE-advanced: next-generation wireless broadband technology [Invited Paper]."
+            ),
             "LTE-advanced: next-generation wireless broadband technology"
         );
         // Paren suffix
         assert_eq!(
-            strip_title_decorations("A Note on Efficient Zero-Knowledge Proofs and Arguments (Extended Abstract)"),
+            strip_title_decorations(
+                "A Note on Efficient Zero-Knowledge Proofs and Arguments (Extended Abstract)"
+            ),
             "A Note on Efficient Zero-Knowledge Proofs and Arguments"
         );
         // ", correction." suffix
@@ -714,10 +719,7 @@ mod tests {
             "Attention is All You Need"
         );
         // Case-insensitive prefix match
-        assert_eq!(
-            strip_title_decorations("EXTENDED ABSTRACT: X"),
-            "X"
-        );
+        assert_eq!(strip_title_decorations("EXTENDED ABSTRACT: X"), "X");
     }
 
     /// Populate a DB with a target paper plus enough noise to push it out of the
@@ -738,12 +740,9 @@ mod tests {
             )
             .unwrap();
         }
-        let target = insert_or_get_publication(
-            &conn,
-            "conf/podc/KeidarKNS21",
-            "All You Need is DAG.",
-        )
-        .unwrap();
+        let target =
+            insert_or_get_publication(&conn, "conf/podc/KeidarKNS21", "All You Need is DAG.")
+                .unwrap();
 
         let mut batch = InsertBatch::new();
         batch.publication_authors.push((target, keidar));
@@ -878,8 +877,16 @@ mod tests {
 
     #[test]
     fn test_surname_overlap() {
-        let ref_a = vec!["Loi Luu".into(), "Duc-Hiep Chu".into(), "Aquinas Hobor".into()];
-        let correct = vec!["Loi Luu".into(), "Duc-Hiep Chu".into(), "Aquinas Hobor".into()];
+        let ref_a = vec![
+            "Loi Luu".into(),
+            "Duc-Hiep Chu".into(),
+            "Aquinas Hobor".into(),
+        ];
+        let correct = vec![
+            "Loi Luu".into(),
+            "Duc-Hiep Chu".into(),
+            "Aquinas Hobor".into(),
+        ];
         let wrong = vec!["Ram Dantu".into(), "Mark Thompson".into()];
         assert_eq!(surname_overlap(&ref_a, &correct), 3);
         assert_eq!(surname_overlap(&ref_a, &wrong), 0);
@@ -941,10 +948,9 @@ mod tests {
         // records share an identical title, so whichever wins must be
         // stable across invocations.
         let conn = setup_db_with_shared_title();
-        let result =
-            query_fts(&conn, "Making smart contracts smarter", DEFAULT_THRESHOLD)
-                .unwrap()
-                .expect("title match exists");
+        let result = query_fts(&conn, "Making smart contracts smarter", DEFAULT_THRESHOLD)
+            .unwrap()
+            .expect("title match exists");
         // Two entries share the exact same title — the returned URL must
         // be one of them, and the call must not panic or return None.
         let url = result.record.url.unwrap();
@@ -1004,7 +1010,12 @@ mod tests {
         .unwrap()
         .expect("title match exists");
         assert!(
-            result.record.url.as_deref().unwrap().contains("/BadruddojaDHUT21"),
+            result
+                .record
+                .url
+                .as_deref()
+                .unwrap()
+                .contains("/BadruddojaDHUT21"),
             "expected Badruddoja entry, got {:?}",
             result.record.url
         );
@@ -1020,12 +1031,8 @@ mod tests {
         init_database(&conn).unwrap();
 
         // Target: perfect title match, no author overlap with citation.
-        let target = insert_or_get_publication(
-            &conn,
-            "conf/correct/X99",
-            "The Exact Target Title",
-        )
-        .unwrap();
+        let target =
+            insert_or_get_publication(&conn, "conf/correct/X99", "The Exact Target Title").unwrap();
         let stranger = insert_or_get_author(&conn, "Stranger Author").unwrap();
 
         // Decoy: partial title match with the citation's author.

--- a/hallucinator-rs/crates/hallucinator-parsing/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/authors.rs
@@ -114,7 +114,9 @@ pub(crate) fn extract_authors_from_reference_with_config(
     let authors = if ALL_CAPS_CHECK.is_match(author_section) {
         parse_all_caps_authors_with_max(author_section, config.max_authors)
     } else if author_section.contains("; ")
-        && Regex::new(r"[A-Z][A-Za-z]+,\s+[A-Z]\.").unwrap().is_match(author_section)
+        && Regex::new(r"[A-Z][A-Za-z]+,\s+[A-Z]\.")
+            .unwrap()
+            .is_match(author_section)
     // AAAI format (semicolon-separated): Surname, I.; Surname, I.
     // Also handles ALL CAPS variant: SURNAME, I.; SURNAME, I.
     {
@@ -141,8 +143,7 @@ pub(crate) fn extract_authors_from_reference_with_config(
 ///
 /// Applied iteratively to catch cascaded breaks such as `Man-galve-dhe`.
 pub(crate) fn repair_line_break_hyphen(name: &str) -> String {
-    static BROKEN: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"([A-Za-z])-([a-z])").unwrap());
+    static BROKEN: Lazy<Regex> = Lazy::new(|| Regex::new(r"([A-Za-z])-([a-z])").unwrap());
 
     let mut out = name.to_string();
     loop {
@@ -280,9 +281,11 @@ fn parse_general_authors_with_max(section: &str, max_authors: usize) -> Vec<Stri
 
         // Skip if it looks like a sentence/title (lowercase words that aren't prepositions)
         static NAME_PREPOSITIONS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-            ["and", "de", "van", "von", "la", "del", "di", "le", "jr", "sr"]
-                .into_iter()
-                .collect()
+            [
+                "and", "de", "van", "von", "la", "del", "di", "le", "jr", "sr",
+            ]
+            .into_iter()
+            .collect()
         });
 
         let lowercase_words: Vec<&&str> = words

--- a/hallucinator-rs/crates/hallucinator-parsing/src/extractor.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/extractor.rs
@@ -684,7 +684,10 @@ mod tests {
                 );
             }
             ParsedRef::Skip(reason, _, _) => {
-                panic!("URL-bearing ref should not be skipped (skipped due to {:?})", reason);
+                panic!(
+                    "URL-bearing ref should not be skipped (skipped due to {:?})",
+                    reason
+                );
             }
         }
     }
@@ -710,7 +713,10 @@ mod tests {
                 }
             }
             ParsedRef::Skip(reason, _, _) => {
-                panic!("URL-bearing ref should not be skipped (skipped due to {:?})", reason);
+                panic!(
+                    "URL-bearing ref should not be skipped (skipped due to {:?})",
+                    reason
+                );
             }
         }
     }

--- a/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
@@ -2068,7 +2068,8 @@ pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
     static AUTHOR_AFTER: Lazy<Vec<Regex>> = Lazy::new(|| {
         let sc = r"[a-zA-Z\u{00A0}-\u{017F}\u{02B0}-\u{02FF}\u{0300}-\u{036F}'\-`\u{00B4}\u{2018}\u{2019}]"; // surname chars (incl. curly quotes)
         // Surname particles that can start a multi-word last name
-        let particle = r"(?:van|von|de|del|della|di|da|le|la|den|der|ten|ter|dos|das|du|op|het|el|al|ben|ibn)";
+        let particle =
+            r"(?:van|von|de|del|della|di|da|le|la|den|der|ten|ter|dos|das|du|op|het|el|al|ben|ibn)";
         // Uppercase character class including Latin Extended (for names like Łukasz, Øystein, Ñoño)
         // - ASCII: A-Z
         // - Latin-1 Supplement uppercase: À-Ö (U+00C0-U+00D6), Ø-Þ (U+00D8-U+00DE)
@@ -2143,11 +2144,7 @@ pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
             // Surname particle + surname + period: "Le Dantec." (end of author list)
             Regex::new(&format!(r"(?i)^{}\s+[A-Z]{}+\.\s+[A-Z]", particle, sc)).unwrap(),
             // Name suffix after surname: "Sullivan Jr.," or "Smith Sr."
-            Regex::new(&format!(
-                r"^([A-Z]{}+)\s+(?:Jr|Sr|III|II|IV|V)\.\s*,?",
-                sc
-            ))
-            .unwrap(),
+            Regex::new(&format!(r"^([A-Z]{}+)\s+(?:Jr|Sr|III|II|IV|V)\.\s*,?", sc)).unwrap(),
             // Surname + "et al." pattern: "Smith et al."
             Regex::new(&format!(r"^([A-Z]{}+)\s+et\s+al\.", sc)).unwrap(),
             // Surname, Firstname I. (inverted format with middle initial, followed by next name)
@@ -2585,10 +2582,7 @@ mod tests {
                 "cjson read fuzzer.c.: [Online]. Available: https://github.com/DaveGamble/cJSON",
                 "cjson read fuzzer.c",
             ),
-            (
-                "Some page.: [Available]. see link",
-                "Some page",
-            ),
+            ("Some page.: [Available]. see link", "Some page"),
         ];
         for (input, expected) in cases {
             let cleaned = clean_title(input, true);

--- a/hallucinator-rs/crates/hallucinator-tui/src/action.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/action.rs
@@ -41,6 +41,9 @@ pub enum Action {
     CursorEnd,
     DeleteForward,
     CycleConfigSection,
+    /// Open file picker in directory-select mode from the export
+    /// modal's path field. (Issue #112.)
+    BrowsePath,
     Tick,
     Resize(u16, u16),
     None,

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
@@ -85,6 +85,11 @@ pub enum FilePickerContext {
         /// 0 = DBLP offline path, 1 = ACL offline path
         config_item: usize,
     },
+    /// Selecting a destination directory for an export report. The
+    /// filename stem is captured on entry so the export modal can
+    /// reconstruct the full `<dir>/<stem>` path when the picker
+    /// returns. (Issue #112.)
+    SelectExportDirectory { filename_stem: String },
 }
 
 /// State for the file picker screen.
@@ -346,6 +351,12 @@ pub struct App {
     /// Active mark-safe propagation confirmation popup (issue #266).
     /// `Some` while the dialog is open; `None` otherwise.
     pub pending_propagation: Option<PendingPropagation>,
+
+    /// Screen to restore when the file picker returns from a
+    /// `SelectExportDirectory` session. `None` when the file picker
+    /// was entered from its normal contexts (Queue / Config).
+    /// (Issue #112.)
+    pub pre_file_picker_screen: Option<Screen>,
 }
 
 impl App {
@@ -412,6 +423,7 @@ impl App {
             measured_fps: 0.0,
             measured_rss_bytes: get_rss_bytes().unwrap_or(0),
             pending_propagation: None,
+            pre_file_picker_screen: None,
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -157,6 +157,31 @@ impl App {
                 Action::MoveUp => {
                     self.export_state.cursor = self.export_state.cursor.saturating_sub(1);
                 }
+                Action::BrowsePath => {
+                    // Issue #112: when the user is on the path field,
+                    // `.` opens the file picker in directory-select
+                    // mode. The file picker, on confirm, rebuilds the
+                    // output_path as `<picked_dir>/<filename_stem>`
+                    // and restores this screen. Inline-edit (Enter on
+                    // cursor=3) is still available for users who
+                    // prefer typing the path directly.
+                    if self.export_state.cursor == 3 {
+                        // Extract just the filename part of the
+                        // current output_path so we preserve the
+                        // user's chosen stem across the browse
+                        // round-trip.
+                        let stem = std::path::Path::new(&self.export_state.output_path)
+                            .file_name()
+                            .map(|s| s.to_string_lossy().to_string())
+                            .unwrap_or_else(|| self.export_state.output_path.clone());
+                        self.pre_file_picker_screen = Some(self.screen.clone());
+                        self.file_picker_context =
+                            FilePickerContext::SelectExportDirectory {
+                                filename_stem: stem,
+                            };
+                        self.screen = Screen::FilePicker;
+                    }
+                }
                 Action::DrillIn => match self.export_state.cursor {
                     0 => {
                         let formats = crate::view::export::ExportFormat::all();
@@ -944,6 +969,9 @@ impl App {
             Action::Resize(_w, h) => {
                 self.visible_rows = (h as usize).saturating_sub(11);
             }
+            // No-op outside the export modal — handled above when
+            // `export_state.active` is true.
+            Action::BrowsePath => {}
             Action::None => {}
         }
         false

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -56,8 +56,12 @@ impl App {
             return false;
         }
 
-        // Export modal intercepts
-        if self.export_state.active {
+        // Export modal intercepts — but not while the file picker
+        // is open on top of it (issue #112 browse flow). Without
+        // this guard, MoveDown/MoveUp would cycle the export modal
+        // cursor instead of moving the file picker cursor, making
+        // the picker appear frozen.
+        if self.export_state.active && self.screen != Screen::FilePicker {
             // If editing path, handle text input
             if self.export_state.editing_path {
                 match action {

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -175,10 +175,9 @@ impl App {
                             .map(|s| s.to_string_lossy().to_string())
                             .unwrap_or_else(|| self.export_state.output_path.clone());
                         self.pre_file_picker_screen = Some(self.screen.clone());
-                        self.file_picker_context =
-                            FilePickerContext::SelectExportDirectory {
-                                filename_stem: stem,
-                            };
+                        self.file_picker_context = FilePickerContext::SelectExportDirectory {
+                            filename_stem: stem,
+                        };
                         self.screen = Screen::FilePicker;
                     }
                 }
@@ -1147,8 +1146,7 @@ pub(crate) fn collect_propagation_targets(
             if (p_idx, r_idx) == (origin_paper_idx, origin_ref_idx) {
                 continue;
             }
-            let Some(ident) =
-                hallucinator_core::cache::compute_fp_identity(&rs.title, &rs.authors)
+            let Some(ident) = hallucinator_core::cache::compute_fp_identity(&rs.title, &rs.authors)
             else {
                 continue;
             };
@@ -1192,10 +1190,7 @@ pub(crate) fn summarize_targets_by_paper(
 
 /// Count of distinct papers (excluding the origin paper) in a target
 /// set. Used to decide threshold-crossing for the confirmation popup.
-pub(crate) fn distinct_other_papers(
-    targets: &[(usize, usize)],
-    origin_paper_idx: usize,
-) -> usize {
+pub(crate) fn distinct_other_papers(targets: &[(usize, usize)], origin_paper_idx: usize) -> usize {
     use std::collections::BTreeSet;
     targets
         .iter()
@@ -1247,8 +1242,7 @@ fn propagate_fp_override(
             if (p_idx, r_idx) == (origin_paper_idx, origin_ref_idx) {
                 continue;
             }
-            let Some(ident) =
-                hallucinator_core::cache::compute_fp_identity(&rs.title, &rs.authors)
+            let Some(ident) = hallucinator_core::cache::compute_fp_identity(&rs.title, &rs.authors)
             else {
                 continue;
             };
@@ -1388,13 +1382,21 @@ mod propagation_tests {
 
     #[test]
     fn propagate_ignores_nonmatching_titles() {
-        let mut papers = vec![PaperState::new("a.pdf".into()), PaperState::new("b.pdf".into())];
+        let mut papers = vec![
+            PaperState::new("a.pdf".into()),
+            PaperState::new("b.pdf".into()),
+        ];
         papers[0].init_results(1);
         papers[0].record_status(0, Status::NotFound, false);
         papers[1].init_results(1);
         papers[1].record_status(0, Status::NotFound, false);
         let mut ref_states = vec![
-            vec![refs("Some Paper", &["A. Author"], Some(Status::NotFound), None)],
+            vec![refs(
+                "Some Paper",
+                &["A. Author"],
+                Some(Status::NotFound),
+                None,
+            )],
             vec![refs(
                 "A Completely Different Paper",
                 &["A. Author"],
@@ -1468,8 +1470,7 @@ mod propagation_tests {
 
     #[test]
     fn propagate_some_to_some_does_not_shift_counts() {
-        let (mut papers, mut ref_states) =
-            fixture(2, "Shared", &["A. Author"], Status::NotFound);
+        let (mut papers, mut ref_states) = fixture(2, "Shared", &["A. Author"], Status::NotFound);
         for i in 0..2 {
             ref_states[i][0].fp_reason = Some(FpReason::KnownGood);
             papers[i].apply_fp_delta(&Status::NotFound, false, 1);
@@ -1546,12 +1547,25 @@ mod propagation_tests {
             },
         ];
         let mut ref_states = vec![
-            vec![refs(real_title, &real_authors, Some(Status::NotFound), None)],
-            vec![refs(real_title, &fake_authors, Some(Status::NotFound), None)],
+            vec![refs(
+                real_title,
+                &real_authors,
+                Some(Status::NotFound),
+                None,
+            )],
+            vec![refs(
+                real_title,
+                &fake_authors,
+                Some(Status::NotFound),
+                None,
+            )],
         ];
         let key = compute_fp_identity(
             real_title,
-            &real_authors.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            &real_authors
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
         )
         .unwrap();
 
@@ -1572,19 +1586,19 @@ mod propagation_tests {
 
     #[test]
     fn collect_targets_is_empty_when_no_other_refs_match() {
-        let (_papers, ref_states) =
-            fixture(1, "Lonely Paper", &["A. Author"], Status::NotFound);
+        let (_papers, ref_states) = fixture(1, "Lonely Paper", &["A. Author"], Status::NotFound);
         let key = compute_fp_identity("Lonely Paper", &["A. Author".into()]).unwrap();
-        let targets = super::collect_propagation_targets(&ref_states, 0, 0, &key, Some(FpReason::KnownGood));
+        let targets =
+            super::collect_propagation_targets(&ref_states, 0, 0, &key, Some(FpReason::KnownGood));
         assert!(targets.is_empty());
     }
 
     #[test]
     fn collect_targets_finds_all_matching_refs_across_papers() {
-        let (_papers, ref_states) =
-            fixture(4, "Shared", &["A. Author"], Status::NotFound);
+        let (_papers, ref_states) = fixture(4, "Shared", &["A. Author"], Status::NotFound);
         let key = compute_fp_identity("Shared", &["A. Author".into()]).unwrap();
-        let targets = super::collect_propagation_targets(&ref_states, 0, 0, &key, Some(FpReason::KnownGood));
+        let targets =
+            super::collect_propagation_targets(&ref_states, 0, 0, &key, Some(FpReason::KnownGood));
         // 4 papers with 1 matching ref each; origin skipped → 3 matches.
         assert_eq!(targets.len(), 3);
         assert!(!targets.contains(&(0, 0)));
@@ -1595,13 +1609,13 @@ mod propagation_tests {
 
     #[test]
     fn collect_targets_skips_refs_already_at_target_state() {
-        let (_papers, mut ref_states) =
-            fixture(3, "Shared", &["A. Author"], Status::NotFound);
+        let (_papers, mut ref_states) = fixture(3, "Shared", &["A. Author"], Status::NotFound);
         // Pre-mark paper 1 with the target reason — propagation should
         // skip it (no net change).
         ref_states[1][0].fp_reason = Some(FpReason::KnownGood);
         let key = compute_fp_identity("Shared", &["A. Author".into()]).unwrap();
-        let targets = super::collect_propagation_targets(&ref_states, 0, 0, &key, Some(FpReason::KnownGood));
+        let targets =
+            super::collect_propagation_targets(&ref_states, 0, 0, &key, Some(FpReason::KnownGood));
         assert_eq!(targets.len(), 1); // only paper 2 still needs flipping
         assert_eq!(targets[0], (2, 0));
     }
@@ -1620,11 +1634,14 @@ mod propagation_tests {
         let targets = vec![(0, 0), (1, 0), (1, 1), (2, 0)];
         let summary = super::summarize_targets_by_paper(&targets, &papers);
         // Sorted by filename ascending.
-        assert_eq!(summary, vec![
-            ("a.pdf".into(), 2),
-            ("b.pdf".into(), 1),
-            ("c.pdf".into(), 1),
-        ]);
+        assert_eq!(
+            summary,
+            vec![
+                ("a.pdf".into(), 2),
+                ("b.pdf".into(), 1),
+                ("c.pdf".into(), 1),
+            ]
+        );
     }
 
     #[test]
@@ -1680,4 +1697,3 @@ mod propagation_tests {
         assert!(ref_states[1][0].fp_reason.is_none());
     }
 }
-

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update_file_picker.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update_file_picker.rs
@@ -35,10 +35,7 @@ impl App {
                         // is still active and rerenders on the
                         // restored screen.
                         self.file_picker_context = FilePickerContext::AddFiles;
-                        self.screen = self
-                            .pre_file_picker_screen
-                            .take()
-                            .unwrap_or(Screen::Queue);
+                        self.screen = self.pre_file_picker_screen.take().unwrap_or(Screen::Queue);
                     }
                     FilePickerContext::AddFiles => {
                         // Normal mode: add any selected files, go back to queue
@@ -103,10 +100,7 @@ impl App {
                         .to_string();
                     self.export_state.output_path = full;
                     self.file_picker_context = FilePickerContext::AddFiles;
-                    self.screen = self
-                        .pre_file_picker_screen
-                        .take()
-                        .unwrap_or(Screen::Queue);
+                    self.screen = self.pre_file_picker_screen.take().unwrap_or(Screen::Queue);
                 } else {
                     // Normal mode: toggle selection of current entry
                     self.file_picker.toggle_selected();

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update_file_picker.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update_file_picker.rs
@@ -29,6 +29,17 @@ impl App {
                         self.file_picker_context = FilePickerContext::AddFiles;
                         self.screen = Screen::Config;
                     }
+                    FilePickerContext::SelectExportDirectory { .. } => {
+                        // Cancel: restore the screen we came from,
+                        // don't touch output_path. The export modal
+                        // is still active and rerenders on the
+                        // restored screen.
+                        self.file_picker_context = FilePickerContext::AddFiles;
+                        self.screen = self
+                            .pre_file_picker_screen
+                            .take()
+                            .unwrap_or(Screen::Queue);
+                    }
                     FilePickerContext::AddFiles => {
                         // Normal mode: add any selected files, go back to queue
                         if !self.file_picker.selected.is_empty() {
@@ -77,6 +88,25 @@ impl App {
                             self.file_picker.selected.push(entry.path.clone());
                         }
                     }
+                } else if let FilePickerContext::SelectExportDirectory { filename_stem } =
+                    &self.file_picker_context
+                {
+                    // Space in export-directory mode confirms the
+                    // CURRENT directory (the one being browsed) as
+                    // the destination — not the entry at the cursor.
+                    // Rebuild output_path as <current_dir>/<stem>.
+                    let stem = filename_stem.clone();
+                    let canonical = super::clean_canonicalize(&self.file_picker.current_dir);
+                    let full = std::path::Path::new(&canonical)
+                        .join(&stem)
+                        .to_string_lossy()
+                        .to_string();
+                    self.export_state.output_path = full;
+                    self.file_picker_context = FilePickerContext::AddFiles;
+                    self.screen = self
+                        .pre_file_picker_screen
+                        .take()
+                        .unwrap_or(Screen::Queue);
                 } else {
                     // Normal mode: toggle selection of current entry
                     self.file_picker.toggle_selected();

--- a/hallucinator-rs/crates/hallucinator-tui/src/input.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/input.rs
@@ -61,6 +61,7 @@ fn map_key_normal(key: &KeyEvent) -> Action {
         KeyCode::Char('y') => Action::CopyToClipboard,
         KeyCode::Char('p') => Action::OpenPdf,
         KeyCode::Char(',') | KeyCode::Char('c') => Action::OpenConfig,
+        KeyCode::Char('.') => Action::BrowsePath,
         KeyCode::Char(' ') => Action::ToggleSafe,
         KeyCode::Tab => Action::ToggleActivityPanel,
         KeyCode::Char('b') => Action::BuildDatabase,

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
@@ -500,10 +500,7 @@ fn collect_links(rs: &crate::model::paper::RefState) -> Vec<LinkEntry> {
         let title_query = encode_url_param(&rs.title);
         links.push(LinkEntry {
             label: "Open in Google Scholar".into(),
-            url: format!(
-                "https://scholar.google.com/scholar?q=%22{}%22",
-                title_query
-            ),
+            url: format!("https://scholar.google.com/scholar?q=%22{}%22", title_query),
         });
         links.push(LinkEntry {
             label: "Open in Google".into(),
@@ -632,10 +629,18 @@ mod tests {
         let links = collect_links(&rs);
         assert_eq!(links.len(), 2);
         assert_eq!(links[0].label, "Open in Google Scholar");
-        assert!(links[0].url.starts_with("https://scholar.google.com/scholar?q=%22"));
+        assert!(
+            links[0]
+                .url
+                .starts_with("https://scholar.google.com/scholar?q=%22")
+        );
         assert!(links[0].url.contains("Attention+Is+All+You+Need"));
         assert_eq!(links[1].label, "Open in Google");
-        assert!(links[1].url.starts_with("https://www.google.com/search?q=%22"));
+        assert!(
+            links[1]
+                .url
+                .starts_with("https://www.google.com/search?q=%22")
+        );
         assert!(links[1].url.contains("Attention+Is+All+You+Need"));
         // Both queries wrap the title in %22 (URL-encoded double quotes)
         // so the engines treat it as a literal phrase search.

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/export.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/export.rs
@@ -173,6 +173,8 @@ pub fn render(f: &mut Frame, app: &App) {
     lines.push(Line::from(""));
     let hint = if export.editing_path {
         "  Type filename, Enter:confirm, Esc:cancel"
+    } else if export.cursor == 3 {
+        "  Enter:edit filename   .:browse directory   Esc:cancel"
     } else {
         "  j/k:navigate  Enter:select/cycle  Esc:cancel"
     };

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/file_picker.rs
@@ -36,17 +36,22 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
     let chunks = Layout::vertical(constraints).split(area);
 
     // Header — context-aware
-    let header_text =
-        if let FilePickerContext::SelectDatabase { config_item } = &app.file_picker_context {
+    let header_text = match &app.file_picker_context {
+        FilePickerContext::SelectDatabase { config_item } => {
             if *config_item == 2 {
                 " > Select OpenAlex Index Directory".to_string()
             } else {
                 let db_name = if *config_item == 0 { "DBLP" } else { "ACL" };
                 format!(" > Select {} Database (.db / .sqlite)", db_name)
             }
-        } else {
+        }
+        FilePickerContext::SelectExportDirectory { filename_stem } => {
+            format!(" > Select Export Directory (will save as: {filename_stem}.<ext>)")
+        }
+        FilePickerContext::AddFiles => {
             " > Select PDFs / .bbl / .bib / Archives / Results (.json)".to_string()
-        };
+        }
+    };
     let header = Line::from(vec![
         Span::styled(" Files ", theme.header_style()),
         Span::styled(
@@ -283,7 +288,13 @@ pub fn render_in(f: &mut Frame, app: &App, area: Rect) {
     }
 
     // Footer — context-aware
-    let footer_text = if is_dir_mode {
+    let is_export_dir_mode = matches!(
+        app.file_picker_context,
+        FilePickerContext::SelectExportDirectory { .. }
+    );
+    let footer_text = if is_export_dir_mode {
+        " j/k:navigate  Enter:open dir  Space:save here  Esc:cancel  ?:help  q:quit"
+    } else if is_dir_mode {
         " j/k:navigate  Enter:open dir  Space:select dir  Esc:confirm  ?:help  q:quit"
     } else if is_db_mode {
         " j/k:navigate  Enter:select & confirm  Esc:cancel  ?:help  q:quit"

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/propagation_confirm.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/propagation_confirm.rs
@@ -35,7 +35,11 @@ pub fn render(f: &mut Frame, theme: &Theme, pending: &PendingPropagation) {
         format!(
             "  Mark safe across {} other paper{}?",
             distinct_papers(pending),
-            if distinct_papers(pending) == 1 { "" } else { "s" }
+            if distinct_papers(pending) == 1 {
+                ""
+            } else {
+                "s"
+            }
         ),
         Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
     ));


### PR DESCRIPTION
Closes #112. Also unblocks CI for all future PRs (#268's CI failure carried fmt/clippy issues into main).

## Summary

Two commits, independently reviewable:

**\`645e177\` — File-picker directory selection for export destination (#112)**
- New \`FilePickerContext::SelectExportDirectory { filename_stem }\` captures the current filename stem on entry, so the round-trip through the file picker preserves the user's chosen name.
- \`Action::BrowsePath\` (mapped to \`.\`) opens the file picker when the export modal is on the path field. Inline-edit via Enter still works for users who prefer typing paths directly.
- In the picker, Space = "save here" (confirms the current directory as destination), Esc = cancel (no change to output_path).
- File picker header + footer adapt when in this mode — header shows the pending filename, footer advertises \`Space: save here\`.

**\`5f5ce15\` — Fix CI: cargo fmt + clippy across workspace**
- \`cargo fmt --all\` reflow (21 files, mechanical).
- Clippy fixes across 5 files: \`is_multiple_of\` rewrites, redundant \`.trim()\` drops, nested-\`if\` collapse to let-chain, unnecessary \`format!\` on static XML, \`#[allow(too_many_arguments)]\` on the \`apply_fallbacks\` fallback helper where the signature is inherent.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace -- --test-threads=1\` — 896 passed, 0 failed
- [ ] #112 not exercised end-to-end in the TUI; key routing and path-joining logic are not covered by unit tests. Manual smoke: launch TUI, \`e\` → arrow to path field → \`.\` → browse → Space on a dir → verify the export modal reopens with \`<dir>/<stem>\`, then Confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)