### PR TITLE
Make skipped refs readable on dark backgrounds — #234

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/theme.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/theme.rs
@@ -16,6 +16,11 @@ pub struct Theme {
     pub border: Color,
     pub text: Color,
     pub dim: Color,
+    /// Foreground for references in the `Skipped` phase. Deliberately
+    /// lighter than [`Theme::dim`] (and rendered without the `DIM`
+    /// modifier) so skipped rows stay legible on both the default
+    /// background and the cursor-highlight background. Issue #234.
+    pub skipped: Color,
     pub highlight_bg: Color,
     pub active: Color,
     pub queued: Color,
@@ -41,6 +46,9 @@ impl Theme {
             border: Color::DarkGray,
             text: Color::White,
             dim: Color::DarkGray,
+            // Medium gray — readable on both black and the dark-green
+            // highlight bar; still distinct from `text` white.
+            skipped: Color::Rgb(160, 160, 160),
             highlight_bg: Color::Rgb(30, 50, 30),
             active: Color::Cyan,
             queued: Color::DarkGray,
@@ -64,6 +72,9 @@ impl Theme {
             border: Color::Rgb(60, 60, 80),
             text: Color::White,
             dim: Color::Rgb(120, 120, 140),
+            // Soft blue-gray — lifts the dim family off the dark-blue
+            // highlight bar while staying below `text` in visual weight.
+            skipped: Color::Rgb(180, 180, 200),
             highlight_bg: Color::Rgb(30, 40, 80),
             active: Color::Rgb(60, 140, 255),
             queued: Color::Rgb(80, 80, 100),
@@ -87,6 +98,10 @@ impl Theme {
             border: Color::Rgb(100, 0, 0),      // muted red
             text: Color::Rgb(200, 200, 200),    // light gray
             dim: Color::Rgb(140, 60, 60),       // muted reddish gray
+            // Lighter red-gray that reads over the deep-red highlight
+            // bg; intentionally staying in the warm family so skipped
+            // rows still feel "same universe" as the rest of the HUD.
+            skipped: Color::Rgb(210, 150, 150),
             highlight_bg: Color::Rgb(50, 0, 0), // dark red selection
             active: Color::Rgb(255, 0, 0),      // T-800 red
             queued: Color::Rgb(80, 0, 0),
@@ -131,7 +146,14 @@ impl Theme {
                 .fg(self.mismatch)
                 .add_modifier(Modifier::BOLD),
             RefPhase::Done => Style::default().fg(self.text),
-            RefPhase::Skipped(_) => Style::default().fg(self.dim).add_modifier(Modifier::DIM),
+            // Skipped refs: dedicated `skipped` color (readable on
+            // the highlight bar) plus italic for visual distinction.
+            // The previous `self.dim + Modifier::DIM` combination
+            // stacked two forms of darkening and collapsed to near-
+            // invisibility on dark themes. Issue #234.
+            RefPhase::Skipped(_) => Style::default()
+                .fg(self.skipped)
+                .add_modifier(Modifier::ITALIC),
         }
     }
 


### PR DESCRIPTION
Closes #234.

## Summary

Skipped references were rendered with \`fg = self.dim + Modifier::DIM\` — \`self.dim\` is already a dark-gray color per theme, and the DIM modifier further halves brightness. On dark backgrounds (every theme qualifies) the row collapsed to near-invisibility, and under the cursor-highlight bar it was completely unreadable (see the screenshot on the issue).

Fix — Option C from the proposal:
- New \`Theme::skipped\` field — a dedicated color per theme, chosen to contrast both the default background and the cursor-highlight background.
  - \`hacker\`: \`Rgb(160, 160, 160)\` (medium gray)
  - \`modern\`: \`Rgb(180, 180, 200)\` (soft blue-gray)
  - \`t800\`:   \`Rgb(210, 150, 150)\` (light red-gray — stays in the warm palette)
- Swap \`Modifier::DIM\` for \`Modifier::ITALIC\` in the \`Skipped\` arm of \`ref_phase_style\` — the "this is muted" signal is now stylistic rather than contrast-destroying.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` — 896 passed, 0 failed
- [ ] Manual: launch TUI on each theme (\`--theme hacker|modern\`, plus t800 via the usual trigger), confirm skipped rows are visible both normally and when highlighted under the cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)