### PR TITLE
Add pre-commit hook: cargo fmt --check on Rust-touching commits

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Pre-commit hook: make sure rustfmt is satisfied before letting
+# a commit land. CI runs the same check; catching it locally saves
+# a push round-trip.
+#
+# Scope:
+# - Only runs when something under hallucinator-rs/ is staged.
+# - Only runs `cargo fmt --all --check` (fast, ~500 ms). Clippy and
+#   the test suite are CI's job — a pre-commit hook that takes
+#   tens of seconds trains people to bypass it with `--no-verify`.
+#
+# Enable once per clone with:
+#   git config core.hooksPath .githooks
+#
+# Bypass for a single commit (e.g. stash / fixup commits) with:
+#   git commit --no-verify
+set -eu
+
+# Skip the hook when no Rust files are staged — trivial repo edits
+# (docs, Python legacy, configs) shouldn't block on rustfmt.
+if ! git diff --cached --name-only --diff-filter=ACMR \
+    | grep -qE '^hallucinator-rs/.*\.rs$'; then
+    exit 0
+fi
+
+cd hallucinator-rs
+if ! cargo fmt --all --check; then
+    cat <<'EOF' >&2
+
+  rustfmt found formatting issues. Run:
+      (cd hallucinator-rs && cargo fmt --all)
+  then `git add -u` the changes and commit again.
+  To bypass (not recommended), use `git commit --no-verify`.
+
+EOF
+    exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -312,6 +312,18 @@ If something is flagged as "not found," verify manually with Google Scholar befo
 
 ---
 
+## Contributing
+
+The repo ships a small pre-commit hook that runs `cargo fmt --all --check` on any commit that touches Rust sources. Enable it once per clone with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook exits quickly on non-Rust commits (docs, config, Python legacy). To bypass it for a single commit — e.g. a work-in-progress stash commit — use `git commit --no-verify`. CI runs the same check, plus clippy and the workspace test suite.
+
+---
+
 ## License
 
 GNU Affero General Public License v3.0 (AGPL-3.0). See [LICENSE](LICENSE).


### PR DESCRIPTION
Prevention for the exact class of issue that broke #269 and #270 CI twice: commits landing with fmt drift, caught only after push.

## What it does

\`.githooks/pre-commit\` runs \`cargo fmt --all --check\` before a commit lands — but only when the commit stages at least one \`hallucinator-rs/**/*.rs\` file. Docs, config, and Python-legacy commits are unaffected.

On failure, the hook prints:
\`\`\`
rustfmt found formatting issues. Run:
    (cd hallucinator-rs && cargo fmt --all)
then \`git add -u\` the changes and commit again.
To bypass (not recommended), use \`git commit --no-verify\`.
\`\`\`

## Enabling

Opt-in per clone, one line:

\`\`\`bash
git config core.hooksPath .githooks
\`\`\`

Added to README under a new Contributing section. No automatic install; the hook is reviewable in diffs and can't surprise anyone.

## Scope

Deliberately **fmt only**. Clippy is tens of seconds in this workspace, and a slow pre-commit hook just trains people to bypass with \`--no-verify\`. CI still runs clippy + the full test suite; the hook just catches the one thing that's cheap enough to check locally every time.

## Test plan
- [x] Smoke-tested: hook exits 0 when no Rust files are staged.
- [ ] Manual: stage a Rust file with a formatting issue, confirm the hook blocks the commit with the expected error message.
- [ ] Manual: confirm CI still passes on this PR (meta-check — the hook changes aren't themselves Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)