### PR TITLE
Add PoPETs running-header regex (rebase of #229)

### DIFF
--- a/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
@@ -258,8 +258,9 @@ fn strip_page_headers(text: &str) -> String {
     //   • Even-page:   "Proceedings on Privacy Enhancing Technologies 2026(1)"  (no prefix)
     static POPETS_HEADER: Lazy<Regex> = Lazy::new(|| {
         Regex::new(
-            r"(?:[A-Z][^\[.]*?)?Proceedings on Privacy Enhancing Technologies\s+\d{4}\(\d+\)"
-        ).unwrap()
+            r"(?:[A-Z][^\[.]*?)?Proceedings on Privacy Enhancing Technologies\s+\d{4}\(\d+\)",
+        )
+        .unwrap()
     });
 
     let mut result = USENIX_HEADER.replace_all(text, "\n").to_string();

--- a/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
@@ -227,6 +227,41 @@ fn strip_page_headers(text: &str) -> String {
         ).unwrap()
     });
 
+    // PoPETs (Proceedings on Privacy Enhancing Technologies) running headers.
+    //
+    // PoPETs uses two running-header formats, one per page side:
+    //
+    //   Even page (left):  "Proceedings on Privacy Enhancing Technologies 2026(1)"
+    //                      (journal name + year/issue, no title, no page number)
+    //
+    //   Odd page (right):  "QUICstep: Evaluating … circumvention
+    //                       Proceedings on Privacy Enhancing Technologies 2026(1)"
+    //                      (paper title preceding the journal name + year/issue)
+    //
+    // The KEY distinguishing marker is that the year/issue follows the journal
+    // name with NO comma — i.e.:
+    //   Header:   "Proceedings on Privacy Enhancing Technologies 2026(1)"
+    //   Citation: "Proceedings on Privacy Enhancing Technologies, 2017(4)"
+    //                                                           ^--- comma
+    //
+    // Pattern: optionally consume a preceding capital-letter title fragment,
+    // then match the journal name followed by year(issue) with whitespace (not comma).
+    //
+    // `[^\[.]*?` allows the prefix to span newlines (for wrapped titles) while
+    // still stopping at:
+    //   - `.` (periods)  → prevents crossing sentence boundaries in citation text
+    //   - `[` (brackets) → prevents matching across IEEE reference markers like [1]
+    //
+    // This correctly handles:
+    //   • Same-line:   "QUICstep: … circumvention Proceedings on Privacy … 2026(1)"
+    //   • Multi-line:  "QUICstep: … circumvention\nProceedings on Privacy … 2026(1)"
+    //   • Even-page:   "Proceedings on Privacy Enhancing Technologies 2026(1)"  (no prefix)
+    static POPETS_HEADER: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?:[A-Z][^\[.]*?)?Proceedings on Privacy Enhancing Technologies\s+\d{4}\(\d+\)"
+        ).unwrap()
+    });
+
     let mut result = USENIX_HEADER.replace_all(text, "\n").to_string();
     result = USENIX_ASSOC_ONLY.replace_all(&result, "\n").to_string();
     result = IEEE_HEADER.replace_all(&result, "\n").to_string();
@@ -238,6 +273,7 @@ fn strip_page_headers(text: &str) -> String {
     result = ACM_PLACEHOLDER_HEADER
         .replace_all(&result, "\n")
         .to_string();
+    result = POPETS_HEADER.replace_all(&result, "\n").to_string();
 
     result
 }
@@ -1105,6 +1141,121 @@ mod tests {
         let stripped2 = strip_page_headers(text2);
         assert!(!stripped2.contains("Conference '24"));
         assert!(!stripped2.contains("Some Paper Title"));
+    }
+
+    #[test]
+    fn test_strip_page_headers_popets_odd_page() {
+        // Odd page header: title line + journal-name line (two lines, as extracted from the PDF)
+        // MuPDF extracts each printed text line separately, so the title and journal
+        // are on adjacent lines:
+        //   "QUICstep: Evaluating connection migration based QUIC censorship circumvention"
+        //   "Proceedings on Privacy Enhancing Technologies 2026(1)"
+        let header = "QUICstep: Evaluating connection migration based QUIC censorship circumvention\nProceedings on Privacy Enhancing Technologies 2026(1)";
+        let text = format!("some text before\n{header}\nsome text after");
+        let stripped = strip_page_headers(&text);
+        assert!(
+            !stripped.contains("QUICstep: Evaluating"),
+            "Should strip PoPETs title fragment from odd-page header: {stripped}"
+        );
+        assert!(
+            !stripped.contains("Proceedings on Privacy Enhancing Technologies 2026"),
+            "Should strip PoPETs journal+year from odd-page header: {stripped}"
+        );
+        assert!(stripped.contains("some text before"));
+        assert!(stripped.contains("some text after"));
+    }
+
+    #[test]
+    fn test_strip_page_headers_popets_odd_page_same_line() {
+        // Odd page header: title and journal name on the SAME line
+        // (also valid — some PDF layouts produce this)
+        let header = "QUICstep: Evaluating connection migration based QUIC censorship circumvention Proceedings on Privacy Enhancing Technologies 2026(1)";
+        let text = format!("some text before\n{header}\nsome text after");
+        let stripped = strip_page_headers(&text);
+        assert!(
+            !stripped.contains("QUICstep: Evaluating"),
+            "Should strip same-line PoPETs header: {stripped}"
+        );
+        assert!(
+            !stripped.contains("Proceedings on Privacy Enhancing Technologies 2026"),
+            "Should strip journal+year from same-line PoPETs header: {stripped}"
+        );
+        assert!(stripped.contains("some text before"));
+        assert!(stripped.contains("some text after"));
+    }
+
+    #[test]
+    fn test_strip_page_headers_popets_even_page() {
+        // Even page header: just "Proceedings on Privacy Enhancing Technologies <year>(<issue>)"
+        // (no page number, no title — appears as a standalone fragment between references)
+        let text = "...USENIX, 2020. Proceedings on Privacy Enhancing Technologies 2026(1) Next author et al.";
+        let stripped = strip_page_headers(text);
+        assert!(
+            !stripped.contains("Proceedings on Privacy Enhancing Technologies 2026"),
+            "Should strip PoPETs journal+year from even-page header: {stripped}"
+        );
+        assert!(stripped.contains("USENIX, 2020."));
+        assert!(stripped.contains("Next author et al."));
+    }
+
+    #[test]
+    fn test_strip_page_headers_popets_preserves_references() {
+        // Citations to PoPETs papers use a comma after the journal name — must NOT be stripped.
+        let text = concat!(
+            "Barradas et al. DeltaShaper: Enabling unobservable TCP tunneling. ",
+            "Proceedings on Privacy Enhancing Technologies, 2017(4):1–20.\n",
+            "Fifield et al. Blocking-resistant communication through domain fronting. ",
+            "Proceedings on Privacy Enhancing Technologies, 2015(2).\n",
+        );
+        let stripped = strip_page_headers(text);
+        assert!(
+            stripped.contains("DeltaShaper"),
+            "Should preserve citations to PoPETs papers: {stripped}"
+        );
+        assert!(
+            stripped.contains("Blocking-resistant communication"),
+            "Should preserve citations to PoPETs papers: {stripped}"
+        );
+        assert!(
+            stripped.contains("Proceedings on Privacy Enhancing Technologies, 2017"),
+            "Journal name in citations must be preserved: {stripped}"
+        );
+    }
+
+    #[test]
+    fn test_segment_ieee_with_popets_page_header() {
+        // Simulates a PoPETs paper where the running page header appears between references.
+        // Odd-page format: "<paper_title> Proceedings on Privacy Enhancing Technologies <year>(<issue>)"
+        // (no leading page number — confirmed by inspecting popets-2026-0014.pdf)
+        let text = concat!(
+            "[1] First reference with a long enough title here.\n",
+            "[2] Second reference also with sufficient content.\n",
+            "[3] Third reference ends before the page break.\n",
+            "QUICstep: Evaluating connection migration based QUIC censorship circumvention ",
+            "Proceedings on Privacy Enhancing Technologies 2026(1)\n",
+            "[4] Fourth reference starts new page content here.\n",
+            "[5] Fifth reference continues normally with text.\n",
+            "[6] Sixth reference completes the section here.\n",
+        );
+        let refs = segment_references(text);
+        assert_eq!(
+            refs.len(),
+            6,
+            "Should find 6 IEEE refs after stripping PoPETs header: {:?}",
+            refs
+        );
+        assert!(refs[0].contains("First reference"));
+        assert!(refs[3].contains("Fourth reference"));
+        assert!(
+            !refs.iter().any(|r| r.contains("QUICstep")),
+            "PoPETs page-number+title must not appear in any reference"
+        );
+        assert!(
+            !refs
+                .iter()
+                .any(|r| r.contains("Proceedings on Privacy Enhancing Technologies 2026")),
+            "PoPETs journal+year header must not appear in any reference"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #229 (author: @weinshel). Two commits preserved from the original; merge conflicts resolved against current main.

## Summary

Adds a `POPETS_HEADER` regex to `strip_page_headers` in `hallucinator-parsing/src/section.rs` plus 5 tests. Handles three PoPETs header shapes:

1. **Odd page, wrapped**: title on one line, journal + year/issue on the next.
2. **Odd page, single line**: title + journal + year/issue on one line.
3. **Even page**: just `Proceedings on Privacy Enhancing Technologies YYYY(N)` as a standalone fragment.

The distinguishing marker from a real PoPETs citation is the absence of a comma between the journal name and the year — citations always have the comma (`"Proceedings on Privacy Enhancing Technologies, 2017(4)"`), page headers never do. That's what makes the regex safe to apply without stripping citations.

## Conflict resolution

The original PR branched off an older main; it's been rebased onto current main. The conflicts were:

- `strip_page_headers` body: main picked up `THESIS_RUNNING_HEADER` and `ACM_PLACEHOLDER_HEADER` after the PR was written. Resolved by keeping **all four** new regexes and appending `POPETS_HEADER.replace_all(...)` after the existing chain.
- Test module: main added `test_strip_page_headers_thesis_running_header` and `test_strip_page_headers_acm_placeholder`. The 5 new PoPETs tests from #229 were appended after those.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --test-threads=1` — 908 passed, 0 failed (+5 PoPETs tests from #229)
- [ ] Manual smoke: run against a real PoPETs PDF and confirm the running header is stripped from each page, but PoPETs citations in other papers' bibliographies are preserved.

## Credit
@weinshel for the regex + tests in the original PR #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)