### PR TITLE
Add --num-workers flag to the TUI binary

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -95,6 +95,12 @@ struct Cli {
     #[arg(long)]
     fps: Option<u32>,
 
+    /// Number of concurrent reference-validation workers (default: 4).
+    /// Raise for offline-heavy workloads; diminishing returns past
+    /// ~16 because SQLite mutexes on offline DBs become the ceiling.
+    #[arg(long)]
+    num_workers: Option<usize>,
+
     /// Enable SearxNG web search fallback for unverified citations.
     /// Uses SEARXNG_URL env var or defaults to http://localhost:8080
     #[arg(long)]
@@ -246,6 +252,9 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(fps) = cli.fps {
         config_state.fps = fps.clamp(1, 120);
+    }
+    if let Some(n) = cli.num_workers {
+        config_state.num_workers = n.max(1);
     }
 
     // SearxNG URL: only enabled if --searxng flag is set


### PR DESCRIPTION
Mirrors the pattern for \`--theme\` / \`--fps\` / \`--mouse\`: a per-session override that writes to \`config_state.num_workers\` before the \`ValidationPool\` is built. Persistent default still lives in \`[concurrency] num_workers\` in the config TOML or the TUI's live Config screen; \`--num-workers\` just overrides for that invocation.

Previously this knob was only reachable on the TUI via config file or \`,\` → Concurrency — adding the flag makes it symmetric with the CLI's existing \`check --num-workers\`.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` — 908 passed, 0 failed
- [x] \`./hallucinator-tui --help\` shows the flag with the expected description
- [ ] Manual: \`hallucinator-tui --num-workers 16 *.pdf\` and confirm the Config screen reflects the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)