### PR TITLE
Preserve compound-word hyphens in parsing + FTS query sanitizer

### DIFF
--- a/hallucinator-rs/crates/hallucinator-arxiv-offline/src/db.rs
+++ b/hallucinator-rs/crates/hallucinator-arxiv-offline/src/db.rs
@@ -461,9 +461,18 @@ fn strip_version_suffix(arxiv_id: &str) -> &str {
 /// support quoted phrases or column filters — but safe for
 /// library-caller input.
 fn sanitize_fts_query(q: &str) -> String {
+    // Every char outside [a-zA-Z0-9 _] becomes a space. Hyphens in
+    // particular must NOT survive: FTS5 parses `fine-tuned` as the
+    // NOT/column-filter operator (`tuned` is mis-read as a column
+    // reference, yielding "no such column: tuned") — and even when
+    // FTS5 is lenient, indexed titles tokenise `-` as a separator,
+    // so a query containing `fine-tuned` will never match a stored
+    // "Fine-tuned" that was already split into `fine` + `tuned`.
+    // Converting `-` to space unifies both sides: `fine tuned` →
+    // implicit AND, matches the same two tokens in the index.
     q.chars()
         .map(|c| {
-            if c.is_ascii_alphanumeric() || c == ' ' || c == '-' || c == '_' {
+            if c.is_ascii_alphanumeric() || c == ' ' || c == '_' {
                 c
             } else {
                 ' '

--- a/hallucinator-rs/crates/hallucinator-parsing/src/text_processing.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/text_processing.rs
@@ -286,8 +286,19 @@ pub fn fix_hyphenation_with_dict<D: Dictionary + ?Sized>(text: &str, dict: &D) -
 
     // Pass 2: Fix "word-word" patterns (no space) using dictionary lookup.
     // This handles cases where the PDF removed the space (e.g., "Chal-lenges").
-    // If the merged word is in the dictionary, it's a real word split by a
-    // line break. If not, it's likely an intentional compound (e.g., "co-located").
+    //
+    // Rule: merge only when the merged form is a real word AND at least one
+    // of the halves is NOT a standalone word on its own. The "both halves
+    // are real words" case is almost always an author-written compound
+    // (e.g., "fine-tuned", "pre-trained", "open-source") — keep the hyphen
+    // even if the merged form happens to be in the dictionary too. This
+    // matters because the arXiv offline FTS index tokenises on `-`, so
+    // "Pre-trained" stored as `pre`/`trained` fails to match a de-
+    // hyphenated citation that was merged into a single `pretrained`
+    // token. (We learned this the hard way on NDSS 2026 f168 ref 5 and
+    // f2361 ref 2, where `pretrained` and `finetuned` are present as
+    // academic terms and caused the old "merge if merged is in dict"
+    // rule to silently strip the author's hyphen.)
     static RE_NO_SPACE: Lazy<Regex> = Lazy::new(|| Regex::new(r"([a-zA-Z]+)-([a-zA-Z]+)").unwrap());
 
     RE_NO_SPACE
@@ -300,12 +311,21 @@ pub fn fix_hyphenation_with_dict<D: Dictionary + ?Sized>(text: &str, dict: &D) -
                 return format!("{}-{}", before, after);
             }
 
-            // Check if merged word is in dictionary
             let merged = format!("{}{}", before, after);
-            if dict.contains(&merged.to_lowercase()) {
-                merged
-            } else {
+            if !dict.contains(&merged.to_lowercase()) {
+                // Merged form isn't a word — must be a compound.
+                return format!("{}-{}", before, after);
+            }
+
+            // Merged form IS a word. Only merge when the halves by
+            // themselves don't both look like real words — otherwise
+            // treat it as an author-written compound.
+            let before_is_word = dict.contains(&before.to_lowercase());
+            let after_is_word = dict.contains(&after.to_lowercase());
+            if before_is_word && after_is_word {
                 format!("{}-{}", before, after)
+            } else {
+                merged
             }
         })
         .into_owned()
@@ -527,6 +547,62 @@ mod tests {
         fn contains(&self, word: &str) -> bool {
             self.words.contains(&word.to_lowercase())
         }
+    }
+
+    #[test]
+    fn test_dict_keeps_compound_when_both_halves_are_words() {
+        // Regression for NDSS 2026 f168 ref 5 / f2361 ref 2: the
+        // scowl academic-terms list contains `finetuned` and
+        // `pretrained` as single words, and the old rule "merge if
+        // the merged form is in the dict" silently stripped the
+        // hyphen the author actually wrote. That broke arXiv-offline
+        // FTS matching (the index tokenises on `-`, storing `pre`
+        // and `trained` separately; a de-hyphenated `pretrained`
+        // query is a different token). Keep the hyphen whenever
+        // both halves are valid standalone words — treat those as
+        // author-written compounds.
+        let dict = MockDict::new(&[
+            "fine",
+            "tuned",
+            "finetuned",
+            "pre",
+            "trained",
+            "pretrained",
+            "open",
+            "source",
+            "opensource",
+        ]);
+        assert_eq!(
+            fix_hyphenation_with_dict("fine-tuned models", &dict),
+            "fine-tuned models",
+        );
+        assert_eq!(
+            fix_hyphenation_with_dict("pre-trained transformer", &dict),
+            "pre-trained transformer",
+        );
+        assert_eq!(
+            fix_hyphenation_with_dict("open-source project", &dict),
+            "open-source project",
+        );
+        // Line-break artifact — whitespace-separated form — still merges.
+        assert_eq!(fix_hyphenation_with_dict("fine- tuned", &dict), "finetuned",);
+    }
+
+    #[test]
+    fn test_dict_still_merges_word_fragment_artifacts() {
+        // The other side of the coin: when one half isn't a word,
+        // the hyphen is almost certainly a PDF line-break. Keep the
+        // old merging behaviour for those.
+        let dict = MockDict::new(&["bidirectional", "challenges", "privacy"]);
+        assert_eq!(
+            fix_hyphenation_with_dict("bidirec-tional", &dict),
+            "bidirectional",
+        );
+        assert_eq!(
+            fix_hyphenation_with_dict("Chal-lenges", &dict),
+            "Challenges",
+        );
+        assert_eq!(fix_hyphenation_with_dict("pri-vacy", &dict), "privacy",);
     }
 
     #[test]


### PR DESCRIPTION
Fixes NDSS 2026 f168 ref 5 ("Lora land: 310 fine-tuned llms…" / arXiv 2405.00732) and f2361 ref 2 ("OPT: Open pre-trained transformer…" / arXiv 2205.01068). Both carry arXiv IDs, both papers are in the offline arXiv snapshot, both came back NotFound.

## Two bugs

1. **Parsing: over-eager hyphen merging.** \`hallucinator-parsing::text_processing::fix_hyphenation_with_dict\` Pass 2 merged \`word-word\` whenever the merged form was in the dict. The scowl \`academic-terms.txt\` list has \`pretrained\` and \`finetuned\` as first-class entries, so the old rule silently stripped the author's hyphen: \`fine-tuned\` → \`finetuned\`. New rule: merge only when merged is a word AND *at least one half* is not — treats \`bidirec-tional\` (halves aren't words) as a line-break artifact but \`fine-tuned\` / \`pre-trained\` / \`open-source\` (both halves are words) as author-written compounds.

2. **FTS query: hyphen passed through.** \`hallucinator-arxiv-offline::db::sanitize_fts_query\` let \`-\` through, and FTS5 parses \`fine-tuned\` as the NOT / column-filter operator (yielding \`no such column: tuned\`). Replace \`-\` with space in the sanitiser so \`fine-tuned\` → \`fine tuned\` queries both tokens — matching the index, which stored \`Fine-tuned\` as the same two tokens (unicode61 tokenises on \`-\`).

## Impact

Both failing refs now resolve via arXiv offline in <100 ms. The fix is general — any citation with a hyphenated compound word that happens to appear un-hyphenated in the scowl academic-terms list (likely many in ML / systems papers) benefits.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` — 913 passed, 0 failed (2 new tests in \`text_processing\`)
- [x] Manual verification against f168 and f2361 — both Verified via arXiv after the fix
- [ ] Broader corpus run to check for regressions on genuine line-break artifacts

## Regression tests
- \`test_dict_keeps_compound_when_both_halves_are_words\` — covers f168 / f2361 shapes + \`open-source\`.
- \`test_dict_still_merges_word_fragment_artifacts\` — pins the old \`bidirec-tional\` / \`Chal-lenges\` / \`pri-vacy\` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)