### PR TITLE
Add --url-match flag; fix URL/title extraction on NDSS 2026 corpus

### DIFF
--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -98,6 +98,18 @@ enum Command {
         #[arg(long)]
         searxng: bool,
 
+        /// Cross-check references that fail all DB lookups against their
+        /// raw URL via URL Check (live HTTP) and the Wayback Machine.
+        /// Without this flag, a NotFound ref that still carries a
+        /// non-academic URL is reported as "skipped" rather than
+        /// "not_found" — URL liveness is the only extra signal we'd
+        /// have had, and the URL-check/Wayback layer is noisy (bot
+        /// walls, 404s, slow hosts). Refs with fake arXiv/DOI
+        /// identifiers remain NotFound because `extract_urls` filters
+        /// academic domains, leaving their url list empty.
+        #[arg(long)]
+        url_match: bool,
+
         /// Path to persistent query cache database (SQLite)
         #[arg(long)]
         cache_path: Option<PathBuf>,
@@ -244,6 +256,7 @@ async fn main() -> anyhow::Result<()> {
             max_rate_limit_retries,
             dry_run,
             searxng,
+            url_match,
             cache_path,
             clear_cache,
             clear_not_found,
@@ -315,6 +328,7 @@ async fn main() -> anyhow::Result<()> {
                     num_workers,
                     max_rate_limit_retries,
                     searxng,
+                    url_match,
                     cache_path,
                     file_config,
                     config_source,
@@ -385,6 +399,15 @@ fn build_report_data(
         ..Default::default()
     };
     for result in results_vec.iter().flatten() {
+        // A NotFound ref with `url_check_skipped = true` was URL-bearing
+        // but `--url-match` was off, so reporting classifies it as
+        // skipped rather than not_found. Without this branch the count
+        // would double-bucket into "potential hallucination" despite
+        // the flag.
+        if result.url_check_skipped {
+            stats.skipped += 1;
+            continue;
+        }
         match &result.status {
             hallucinator_core::Status::Verified => stats.verified += 1,
             hallucinator_core::Status::NotFound => stats.not_found += 1,
@@ -431,6 +454,7 @@ async fn check(
     num_workers: Option<usize>,
     max_rate_limit_retries: Option<u32>,
     searxng: bool,
+    url_match: bool,
     cache_path: Option<PathBuf>,
     file_config: hallucinator_core::config_file::ConfigFile,
     config_source: Option<PathBuf>,
@@ -823,6 +847,7 @@ async fn check(
         cache_path,
         cache_positive_ttl_secs: positive_ttl,
         cache_negative_ttl_secs: negative_ttl,
+        url_match,
     };
 
     // Handle archives: extract each file and run check on each independently

--- a/hallucinator-rs/crates/hallucinator-cli/src/output.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/output.rs
@@ -115,7 +115,24 @@ pub fn print_progress(
                     }
                 }
                 Status::NotFound => {
-                    if color.enabled() {
+                    // If URL matching was disabled and the ref still
+                    // carried a (non-academic) URL, report it as
+                    // skipped — the red "NOT FOUND" would over-alarm
+                    // the user for a citation they chose not to
+                    // URL-verify.
+                    if result.url_check_skipped {
+                        if color.enabled() {
+                            writeln!(
+                                w,
+                                "[{}/{}] -> {} (URL check disabled)",
+                                idx,
+                                total,
+                                "SKIPPED".yellow()
+                            )?;
+                        } else {
+                            writeln!(w, "[{}/{}] -> SKIPPED (URL check disabled)", idx, total)?;
+                        }
+                    } else if color.enabled() {
                         writeln!(w, "[{}/{}] -> {}", idx, total, "NOT FOUND".red())?;
                     } else {
                         writeln!(w, "[{}/{}] -> NOT FOUND", idx, total)?;
@@ -156,6 +173,15 @@ pub fn print_hallucination_report(
     color: ColorMode,
 ) -> std::io::Result<()> {
     for result in results {
+        // Suppress the full "POTENTIAL HALLUCINATION" block for refs
+        // whose NotFound outcome was demoted to "skipped" by the
+        // `--url-match` gate. The ref is already accounted for in
+        // CheckStats.skipped; the verbose hallucination block would
+        // falsely flag a URL-bearing citation the user explicitly
+        // chose not to verify via URL Check.
+        if result.url_check_skipped {
+            continue;
+        }
         match &result.status {
             Status::NotFound => {
                 print_not_found_block(w, result, searched_openalex, color)?;

--- a/hallucinator-rs/crates/hallucinator-cli/src/output.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/output.rs
@@ -519,10 +519,16 @@ pub fn print_summary(
         .iter()
         .filter(|r| r.status == Status::Verified)
         .count();
+    // A NotFound ref with `url_check_skipped` is bucketed under
+    // "skipped (URL check disabled)" below and MUST NOT also count
+    // toward the hallucination total — otherwise the summary would
+    // double-count URL-bearing misses against the user who explicitly
+    // chose not to URL-verify them.
     let not_found = results
         .iter()
-        .filter(|r| r.status == Status::NotFound)
+        .filter(|r| r.status == Status::NotFound && !r.url_check_skipped)
         .count();
+    let skipped_url_match_gate = results.iter().filter(|r| r.url_check_skipped).count();
     let mismatched = results.iter().filter(|r| r.status.is_mismatch()).count();
     // Count specific mismatch types
     let author_mismatches = results
@@ -574,6 +580,17 @@ pub fn print_summary(
             "Skipped: {} (URLs: {}, short titles: {})",
             total_skipped, skip_stats.url_only, skip_stats.short_title
         );
+        if color.enabled() {
+            writeln!(w, "  {}", msg.dimmed())?;
+        } else {
+            writeln!(w, "  {}", msg)?;
+        }
+    }
+    // Separate bucket so the user can tell a URL-gate skip from a
+    // parse-time skip. Shown only when `--url-match` was off and at
+    // least one ref got demoted — otherwise the line is noise.
+    if skipped_url_match_gate > 0 {
+        let msg = format!("Skipped (URL check disabled): {}", skipped_url_match_gate);
         if color.enabled() {
             writeln!(w, "  {}", msg.dimmed())?;
         } else {

--- a/hallucinator-rs/crates/hallucinator-core/src/checker.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/checker.rs
@@ -188,6 +188,7 @@ pub async fn check_single_reference(
                     doi_info,
                     arxiv_info: None,
                     retraction_info,
+                    url_check_skipped: false,
                 };
             }
             DoiMatchResult::AuthorMismatch {
@@ -214,6 +215,7 @@ pub async fn check_single_reference(
                     doi_info,
                     arxiv_info: None,
                     retraction_info: None,
+                    url_check_skipped: false,
                 };
             }
             _ => {
@@ -451,6 +453,10 @@ pub async fn check_single_reference(
         doi_info,
         arxiv_info: None, // TODO(#124): implement arXiv ID validation
         retraction_info,
+        // `check_single_reference` (this function) is only used for
+        // non-pool call sites that don't run the URL/Wayback fallbacks,
+        // so there's nothing for the reporting layer to reclassify.
+        url_check_skipped: false,
     }
 }
 
@@ -488,5 +494,7 @@ pub async fn check_single_reference_retry(
         doi_info: None,
         arxiv_info: None,
         retraction_info: None,
+        // Retry path also doesn't exercise the URL/Wayback fallbacks.
+        url_check_skipped: false,
     }
 }

--- a/hallucinator-rs/crates/hallucinator-core/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/lib.rs
@@ -200,6 +200,14 @@ pub struct ValidationResult {
     pub doi_info: Option<DoiInfo>,
     pub arxiv_info: Option<ArxivInfo>,
     pub retraction_info: Option<RetractionInfo>,
+    /// True iff this ref finished as `Status::NotFound` with a non-academic
+    /// URL still in hand, but URL Check / Wayback were not run because
+    /// `Config::url_match` was disabled. Reporting layers treat this as
+    /// "skipped" (incrementing `CheckStats.skipped`, emitting
+    /// `"status": "skipped"` in JSON, suppressing the hallucination
+    /// banner) so the absence of URL matching doesn't inflate the
+    /// not-found / potential-hallucination count.
+    pub url_check_skipped: bool,
 }
 
 /// Progress events emitted during validation.
@@ -304,6 +312,19 @@ pub struct Config {
     pub cache_positive_ttl_secs: u64,
     /// TTL in seconds for negative (not-found) cache entries. Default: 24 hours.
     pub cache_negative_ttl_secs: u64,
+    /// Cross-check references that fail all DB lookups against their raw
+    /// URL via URL Check (live HTTP) and the Wayback Machine. When false
+    /// (the default), neither check runs and a NotFound ref that still
+    /// carries a non-academic URL is reported as "skipped" rather than
+    /// "not_found" — the URL's liveness is the only signal we'd have had,
+    /// and without it we can't justify flagging the ref as a potential
+    /// hallucination. Refs whose only URL is an academic domain
+    /// (arxiv.org, doi.org, …) are unaffected because
+    /// `text_utils::extract_urls` filters those out at parse time, so
+    /// they carry `urls = []` and stay `NotFound` regardless of this
+    /// flag — preserving the fake-arXiv-ID / fake-DOI hallucination
+    /// signal.
+    pub url_match: bool,
 }
 
 impl std::fmt::Debug for Config {
@@ -354,6 +375,7 @@ impl std::fmt::Debug for Config {
             .field("cache_path", &self.cache_path)
             .field("cache_positive_ttl_secs", &self.cache_positive_ttl_secs)
             .field("cache_negative_ttl_secs", &self.cache_negative_ttl_secs)
+            .field("url_match", &self.url_match)
             .finish()
     }
 }
@@ -386,6 +408,7 @@ impl Default for Config {
             cache_path: None,
             cache_positive_ttl_secs: DEFAULT_POSITIVE_TTL.as_secs(),
             cache_negative_ttl_secs: DEFAULT_NEGATIVE_TTL.as_secs(),
+            url_match: false,
         }
     }
 }

--- a/hallucinator-rs/crates/hallucinator-core/src/pool.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/pool.rs
@@ -534,12 +534,18 @@ async fn apply_fallbacks(
     client: &reqwest::Client,
     progress: &(dyn Fn(ProgressEvent) + Send + Sync),
     ref_index: usize,
+    // The trailing `bool` is `url_check_skipped`: true iff the ref finishes
+    // NotFound with a non-academic URL that would have been checked
+    // (URL Check / Wayback) if `config.url_match` were enabled. Propagated
+    // onto `ValidationResult.url_check_skipped` so reporting can render
+    // these as "skipped" instead of "not_found".
 ) -> (
     Status,
     Option<String>,
     Vec<String>,
     Option<String>,
     Vec<DbResult>,
+    bool,
 ) {
     // Expand URL separator variants (see `expand_url_variants` docs).
     // URL Check and Wayback both operate on this expanded list so that
@@ -552,7 +558,10 @@ async fn apply_fallbacks(
     };
 
     // ── URL liveness check ─────────────────────────────────────────────
-    if status == Status::NotFound && !candidate_urls.is_empty() {
+    // Gated on `config.url_match`: when off, the ref will finish with
+    // `url_check_skipped = true` (computed below) and reporting will
+    // treat it as skipped rather than as a potential hallucination.
+    if config.url_match && status == Status::NotFound && !candidate_urls.is_empty() {
         let timeout = Duration::from_secs(config.db_timeout_secs);
         let start = std::time::Instant::now();
         let url_result = UrlChecker::check_first_live(&candidate_urls, client, timeout).await;
@@ -581,6 +590,7 @@ async fn apply_fallbacks(
                 vec![],
                 Some(url),
                 db_results,
+                false,
             );
         }
         progress(ProgressEvent::DatabaseQueryComplete {
@@ -615,7 +625,10 @@ async fn apply_fallbacks(
     // since 404'd (link rot). If the Internet Archive has a valid
     // snapshot, that's strong evidence the citation was real; report the
     // archived URL so the user can read the captured content.
-    if status == Status::NotFound && !candidate_urls.is_empty() {
+    //
+    // Gated on `config.url_match` alongside URL Check — the user's
+    // "URL checking (including wayback machine)" covers both.
+    if config.url_match && status == Status::NotFound && !candidate_urls.is_empty() {
         let timeout = Duration::from_secs(config.db_timeout_secs);
         let start = std::time::Instant::now();
         let wayback_result = wayback::check_first_snapshot(&candidate_urls, client, timeout).await;
@@ -643,6 +656,7 @@ async fn apply_fallbacks(
                 vec![],
                 Some(result.snapshot_url),
                 db_results,
+                false,
             );
         }
         progress(ProgressEvent::DatabaseQueryComplete {
@@ -700,6 +714,7 @@ async fn apply_fallbacks(
                 vec![],
                 url,
                 db_results,
+                false,
             );
         }
         progress(ProgressEvent::DatabaseQueryComplete {
@@ -719,7 +734,24 @@ async fn apply_fallbacks(
         });
     }
 
-    (status, source, found_authors, paper_url, db_results)
+    // Compute the url_check_skipped marker for the return path. True
+    // iff the ref would have been URL-checked / Wayback-checked had
+    // `config.url_match` been on — that is: NotFound with non-academic
+    // URLs still on hand. Academic URLs (arxiv.org, doi.org, …) never
+    // reach `candidate_urls` because `text_utils::extract_urls` filters
+    // them at parse time, so fake-arXiv-ID / fake-DOI refs stay
+    // NotFound here regardless of the flag.
+    let url_check_skipped =
+        !config.url_match && status == Status::NotFound && !candidate_urls.is_empty();
+
+    (
+        status,
+        source,
+        found_authors,
+        paper_url,
+        db_results,
+        url_check_skipped,
+    )
 }
 
 /// Build the final result and send it on the oneshot channel.
@@ -771,20 +803,21 @@ async fn finalize_collector(collector: &RefCollector) {
     };
 
     // URL liveness + SearxNG fallbacks (shared helper)
-    let (status, source, found_authors, paper_url, remote_db_results) = apply_fallbacks(
-        status,
-        source,
-        found_authors,
-        paper_url,
-        remote_db_results,
-        &collector.reference.urls,
-        &collector.title,
-        &collector.config,
-        &collector.client,
-        collector.progress.as_ref(),
-        collector.ref_index,
-    )
-    .await;
+    let (status, source, found_authors, paper_url, remote_db_results, url_check_skipped) =
+        apply_fallbacks(
+            status,
+            source,
+            found_authors,
+            paper_url,
+            remote_db_results,
+            &collector.reference.urls,
+            &collector.title,
+            &collector.config,
+            &collector.client,
+            collector.progress.as_ref(),
+            collector.ref_index,
+        )
+        .await;
 
     // Merge local + remote results
     let mut all_db_results = collector.local_result.db_results.clone();
@@ -875,6 +908,7 @@ async fn finalize_collector(collector: &RefCollector) {
         doi_info,
         arxiv_info,
         retraction_info,
+        url_check_skipped,
     };
 
     emit_final_events(
@@ -1119,20 +1153,21 @@ async fn coordinator_loop(
             // No remote DBs enabled — URL-check + SearxNG fallbacks only
             // (on NotFound). The helper is a no-op when status is already
             // Verified or Mismatch, so we always pass through it.
-            let (status, source, found_authors, paper_url, db_results) = apply_fallbacks(
-                local_result.status.clone(),
-                local_result.source.clone(),
-                local_result.found_authors.clone(),
-                local_result.paper_url.clone(),
-                local_result.db_results.clone(),
-                &reference.urls,
-                &title,
-                &config,
-                &client,
-                progress.as_ref(),
-                ref_index,
-            )
-            .await;
+            let (status, source, found_authors, paper_url, db_results, url_check_skipped) =
+                apply_fallbacks(
+                    local_result.status.clone(),
+                    local_result.source.clone(),
+                    local_result.found_authors.clone(),
+                    local_result.paper_url.clone(),
+                    local_result.db_results.clone(),
+                    &reference.urls,
+                    &title,
+                    &config,
+                    &client,
+                    progress.as_ref(),
+                    ref_index,
+                )
+                .await;
             let result = ValidationResult {
                 title: title.clone(),
                 raw_citation: reference.raw_citation.clone(),
@@ -1146,6 +1181,7 @@ async fn coordinator_loop(
                 doi_info: None,
                 arxiv_info: None,
                 retraction_info: None,
+                url_check_skipped,
             };
             emit_final_events(progress.as_ref(), &result, ref_index, total, &title);
             let _ = result_tx.send(result);
@@ -1247,6 +1283,9 @@ async fn coordinator_loop(
                 doi_info,
                 arxiv_info: None, // TODO(#124): implement arXiv ID validation
                 retraction_info,
+                // Verified from cache → never reaches apply_fallbacks,
+                // so the URL-check-skipped marker is vacuously false.
+                url_check_skipped: false,
             };
 
             emit_final_events(progress.as_ref(), &result, ref_index, total, &title);
@@ -1286,20 +1325,21 @@ async fn coordinator_loop(
             // every DB was a cache hit — this is the path where a
             // reference that was previously URL-verified would otherwise
             // regress to NotFound on the second run.
-            let (status, source, found_authors, paper_url, all_db_results) = apply_fallbacks(
-                status,
-                source,
-                found_authors,
-                paper_url,
-                all_db_results,
-                &reference.urls,
-                &title,
-                &config,
-                &client,
-                progress.as_ref(),
-                ref_index,
-            )
-            .await;
+            let (status, source, found_authors, paper_url, all_db_results, url_check_skipped) =
+                apply_fallbacks(
+                    status,
+                    source,
+                    found_authors,
+                    paper_url,
+                    all_db_results,
+                    &reference.urls,
+                    &title,
+                    &config,
+                    &client,
+                    progress.as_ref(),
+                    ref_index,
+                )
+                .await;
 
             let result = ValidationResult {
                 title: title.clone(),
@@ -1318,6 +1358,7 @@ async fn coordinator_loop(
                 }),
                 arxiv_info: None, // TODO(#124): implement arXiv ID validation
                 retraction_info: None,
+                url_check_skipped,
             };
 
             emit_final_events(progress.as_ref(), &result, ref_index, total, &title);
@@ -1455,5 +1496,8 @@ fn build_validation_result(
         doi_info: None,
         arxiv_info: None, // TODO(#124): implement arXiv ID validation
         retraction_info,
+        // Callers that reach this helper feed pre-fallback status,
+        // so they haven't made a URL-check decision yet.
+        url_check_skipped: false,
     }
 }

--- a/hallucinator-rs/crates/hallucinator-core/tests/pool_integration.rs
+++ b/hallucinator-rs/crates/hallucinator-core/tests/pool_integration.rs
@@ -206,3 +206,125 @@ async fn progress_events_emitted() {
         "should emit Result event, got: {collected:?}"
     );
 }
+
+// ── --url-match gate ─────────────────────────────────────────────────
+
+/// Build a reference that carries a non-academic URL (the shape that
+/// triggers the `--url-match` gate when all DBs return NotFound).
+fn url_bearing_ref(title: &str, url: &str) -> Reference {
+    Reference {
+        raw_citation: format!("[1] {title}, {url}"),
+        title: Some(title.to_string()),
+        authors: vec![],
+        doi: None,
+        arxiv_id: None,
+        urls: vec![url.to_string()],
+        original_number: 1,
+        skip_reason: None,
+    }
+}
+
+#[tokio::test]
+async fn url_match_off_demotes_notfound_with_url_to_skipped() {
+    // Core regression guard for the `--url-match` gate. With every DB
+    // disabled (so all queries return NotFound) and `url_match = false`
+    // (default), a ref that still carries a non-academic URL must come
+    // back with `url_check_skipped = true` — the reporting layer uses
+    // this to render the ref as "skipped" instead of bucketing it with
+    // potential hallucinations.
+    let config = Arc::new(config_no_network());
+    assert!(
+        !config.url_match,
+        "test expects default Config with url_match=false"
+    );
+    let cancel = CancellationToken::new();
+    let pool = ValidationPool::new(config, cancel, 2);
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let job = RefJob {
+        reference: url_bearing_ref("A URL-bearing citation", "https://github.com/owner/repo"),
+        result_tx: tx,
+        ref_index: 0,
+        total: 1,
+        progress: Arc::new(|_| {}),
+    };
+
+    pool.submit(job).await;
+    let result: ValidationResult = rx.await.expect("should receive result");
+    assert_eq!(result.status, Status::NotFound);
+    assert!(
+        result.url_check_skipped,
+        "url_match=false + NotFound + non-empty urls must set url_check_skipped"
+    );
+
+    pool.shutdown().await;
+}
+
+#[tokio::test]
+async fn url_match_off_without_urls_stays_not_found() {
+    // Companion guard: a NotFound ref with NO URLs must NOT be demoted
+    // — this is the fake-arXiv-ID / fake-DOI case where
+    // `extract_urls` filtered academic domains and left `urls = []`,
+    // and the full hallucination signal should still fire.
+    let config = Arc::new(config_no_network());
+    let cancel = CancellationToken::new();
+    let pool = ValidationPool::new(config, cancel, 2);
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let job = RefJob {
+        reference: dummy_ref("A ref with no URLs"),
+        result_tx: tx,
+        ref_index: 0,
+        total: 1,
+        progress: Arc::new(|_| {}),
+    };
+
+    pool.submit(job).await;
+    let result: ValidationResult = rx.await.expect("should receive result");
+    assert_eq!(result.status, Status::NotFound);
+    assert!(
+        !result.url_check_skipped,
+        "NotFound with no URLs must stay not_found regardless of url_match"
+    );
+
+    pool.shutdown().await;
+}
+
+#[tokio::test]
+async fn url_match_on_runs_url_check_without_demoting() {
+    // Mirror guard: with `url_match = true`, the gate stays open. The
+    // URL lookup will still return no_match for `https://example.invalid`
+    // (DNS failure), so the ref stays NotFound — but crucially,
+    // `url_check_skipped` must be false because the user opted in to
+    // URL matching.
+    let mut cfg = config_no_network();
+    cfg.url_match = true;
+    let config = Arc::new(cfg);
+    let cancel = CancellationToken::new();
+    let pool = ValidationPool::new(config, cancel, 2);
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let job = RefJob {
+        reference: url_bearing_ref(
+            "A URL-bearing citation",
+            "https://this-domain-definitely-does-not-exist-12345.invalid/path",
+        ),
+        result_tx: tx,
+        ref_index: 0,
+        total: 1,
+        progress: Arc::new(|_| {}),
+    };
+
+    pool.submit(job).await;
+    let result: ValidationResult = rx.await.expect("should receive result");
+    // URL Check runs but fails (DNS miss). With Wayback also returning
+    // no snapshot for a fabricated domain, status stays NotFound and
+    // the gate is inactive.
+    assert_eq!(result.status, Status::NotFound);
+    assert!(
+        !result.url_check_skipped,
+        "url_match=true must NEVER set url_check_skipped"
+    );
+
+    pool.shutdown().await;
+}

--- a/hallucinator-rs/crates/hallucinator-python/src/validation_types.rs
+++ b/hallucinator-rs/crates/hallucinator-python/src/validation_types.rs
@@ -121,6 +121,16 @@ impl PyValidationResult {
             .map(PyRetractionInfo::from)
     }
 
+    /// True iff this ref finished NotFound with a non-academic URL in
+    /// hand, but URL Check / Wayback were not run because
+    /// `--url-match` was off. Python callers can use this to render
+    /// the ref as "skipped" in their own UI rather than counting it
+    /// as a potential hallucination.
+    #[getter]
+    fn url_check_skipped(&self) -> bool {
+        self.inner.url_check_skipped
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "ValidationResult(title={:?}, status={:?}, source={:?})",

--- a/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
+++ b/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
@@ -39,6 +39,19 @@ fn status_str(s: &Status) -> &'static str {
     }
 }
 
+/// Effective status string used for the per-ref JSON field, taking into
+/// account the `--url-match` gate. A NotFound ref whose only remaining
+/// signal would have come from URL Check / Wayback (marked
+/// `url_check_skipped`) is serialized as `"skipped"` so JSON consumers
+/// and the TUI load path don't treat the run as having a potential
+/// hallucination the user chose not to verify.
+fn effective_status_str(r: &ValidationResult) -> &'static str {
+    if r.url_check_skipped {
+        return "skipped";
+    }
+    status_str(&r.status)
+}
+
 fn verdict_str(v: Option<PaperVerdict>) -> &'static str {
     match v {
         Some(PaperVerdict::Safe) => "safe",
@@ -234,6 +247,11 @@ pub fn export_json(
             let orig_num = sref.ref_num;
             let effective = if sref.fp.is_some() {
                 "\"verified\""
+            } else if r.url_check_skipped {
+                // `--url-match` gate demotes URL-bearing NotFound refs
+                // to "skipped" in the effective view, matching the
+                // "status" field.
+                "\"skipped\""
             } else {
                 match &r.status {
                     Status::Verified => "\"verified\"",
@@ -252,9 +270,16 @@ pub fn export_json(
             ));
             entry.push_str(&format!(
                 "        \"status\": {},\n",
-                json_str(status_str(&r.status))
+                json_str(effective_status_str(r))
             ));
             entry.push_str(&format!("        \"effective_status\": {},\n", effective));
+            // Emit the raw gate signal too so consumers (and round-trip
+            // loaders) can tell a `--url-match`-suppressed ref apart
+            // from a real parse-time skip.
+            entry.push_str(&format!(
+                "        \"url_check_skipped\": {},\n",
+                r.url_check_skipped
+            ));
             entry.push_str(&format!("        \"fp_reason\": {},\n", fp_json));
             entry.push_str(&format!(
                 "        \"source\": {},\n",
@@ -419,10 +444,13 @@ fn export_csv(
             let r = sref.result;
             let retracted = is_retracted(r);
             let fp = sref.fp.map(|fp| fp.as_str()).unwrap_or("");
+            // CSV path mirrors JSON: `--url-match`-suppressed refs
+            // render as "skipped" so CSV consumers see the same
+            // bucketing as the CLI summary.
             let effective = if sref.fp.is_some() {
                 "verified"
             } else {
-                status_str(&r.status)
+                effective_status_str(r)
             };
             let authors = r.ref_authors.join("; ");
             let found = r.found_authors.join("; ");
@@ -1414,6 +1442,7 @@ mod tests {
             doi_info: None,
             arxiv_info: None,
             retraction_info: None,
+            url_check_skipped: false,
         }
     }
 
@@ -1470,6 +1499,71 @@ mod tests {
     }
 
     // ── P1: pure helper functions ───────────────────────────────────
+
+    #[test]
+    fn test_url_match_gate_renders_notfound_as_skipped_in_json() {
+        // Regression guard for the `--url-match` gate: a ValidationResult
+        // that finished as `Status::NotFound` but carried
+        // `url_check_skipped = true` must render as `"status": "skipped"`
+        // in the exported JSON. Without this, URL-bearing refs that the
+        // user opted not to URL-verify would still show up as potential
+        // hallucinations in downstream consumers.
+        let mut r = make_result("Some URL-bearing citation", Status::NotFound);
+        r.url_check_skipped = true;
+        let results = vec![Some(r)];
+        let stats = CheckStats {
+            total: 1,
+            skipped: 1,
+            ..Default::default()
+        };
+        let paper = make_paper("test.pdf", &stats, &results);
+        let ref_states: Vec<&[ReportRef]> = vec![&[]];
+        let json = export_json(&[paper], &ref_states, false);
+        assert!(
+            json.contains("\"status\": \"skipped\""),
+            "expected status=skipped in JSON, got:\n{}",
+            json
+        );
+        // Effective status should follow the same demotion.
+        assert!(
+            json.contains("\"effective_status\": \"skipped\""),
+            "expected effective_status=skipped in JSON, got:\n{}",
+            json
+        );
+        // The raw marker is still emitted for round-trip callers.
+        assert!(
+            json.contains("\"url_check_skipped\": true"),
+            "expected url_check_skipped=true in JSON, got:\n{}",
+            json
+        );
+    }
+
+    #[test]
+    fn test_url_match_gate_notfound_without_url_still_not_found() {
+        // A NotFound ref with `url_check_skipped = false` (the case
+        // where the ref had no non-academic URL, or the flag was on) must
+        // still serialize as `"status": "not_found"`. This protects the
+        // hallucination signal for fake arXiv / DOI identifiers: those
+        // refs carry `urls = []` after `extract_urls` filters academic
+        // domains, so they never set `url_check_skipped` in the pool
+        // even with `--url-match` off.
+        let r = make_result("Fake arXiv ID citation", Status::NotFound);
+        assert!(!r.url_check_skipped);
+        let results = vec![Some(r)];
+        let stats = CheckStats {
+            total: 1,
+            not_found: 1,
+            ..Default::default()
+        };
+        let paper = make_paper("test.pdf", &stats, &results);
+        let ref_states: Vec<&[ReportRef]> = vec![&[]];
+        let json = export_json(&[paper], &ref_states, false);
+        assert!(
+            json.contains("\"status\": \"not_found\""),
+            "expected status=not_found in JSON, got:\n{}",
+            json
+        );
+    }
 
     #[test]
     fn test_json_escape_special_chars() {

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
@@ -33,6 +33,13 @@ impl App {
                         .count();
                     paper.stats.total = references.len();
                     paper.stats.skipped = skipped;
+                    // `parse_skipped` is the count of refs that never
+                    // entered validation (empty/short title + no strong
+                    // signal). The gauge uses this — NOT stats.skipped
+                    // — as the denominator adjustment, because
+                    // stats.skipped later grows with URL-gated refs
+                    // that DID enter validation.
+                    paper.parse_skipped = skipped;
                     // Allocate result slots for ALL refs (including skipped) so
                     // that remapped indices from the backend fit.
                     paper.init_results(references.len());

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/backend.rs
@@ -267,7 +267,12 @@ impl App {
                     if paper.phase == PaperPhase::Retrying {
                         paper.retry_done += 1;
                     }
-                    paper.record_status(index, result.status.clone(), is_retracted);
+                    paper.record_status(
+                        index,
+                        result.status.clone(),
+                        result.url_check_skipped,
+                        is_retracted,
+                    );
                     if fp_preexisting {
                         paper.apply_fp_delta(&result.status, is_retracted, 1);
                     }

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
@@ -501,10 +501,15 @@ impl App {
         let mut indices: Vec<usize> = (0..refs.len()).collect();
 
         if self.paper_filter == PaperFilter::ProblemsOnly {
+            // A URL-gated NotFound (`url_check_skipped`) is not a
+            // problem — it was demoted to skipped because the user
+            // opted out of URL Check. Keep the rest of the filter
+            // (non-verified statuses + retractions) intact.
             indices.retain(|&i| {
                 refs[i].result.as_ref().is_some_and(|r| {
-                    r.status != hallucinator_core::Status::Verified
-                        || r.retraction_info.as_ref().is_some_and(|ri| ri.is_retracted)
+                    let has_real_problem =
+                        r.status != hallucinator_core::Status::Verified && !r.url_check_skipped;
+                    has_real_problem || r.retraction_info.as_ref().is_some_and(|ri| ri.is_retracted)
                 })
             });
         }

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
@@ -206,6 +206,10 @@ impl App {
             cache_positive_ttl_secs: hallucinator_core::DEFAULT_POSITIVE_TTL.as_secs(),
             cache_negative_ttl_secs: hallucinator_core::DEFAULT_NEGATIVE_TTL.as_secs(),
             query_cache: Some(self.get_or_build_query_cache()),
+            // TUI doesn't expose --url-match yet; default to off so the
+            // NotFound-with-URL refs surface as "skipped" in the same
+            // way as the CLI default.
+            url_match: false,
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -1308,6 +1308,7 @@ mod propagation_tests {
             doi_info: None,
             arxiv_info: None,
             retraction_info: None,
+            url_check_skipped: false,
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -1345,7 +1345,7 @@ mod propagation_tests {
         for i in 0..n_papers {
             let mut p = PaperState::new(format!("paper{i}.pdf"));
             p.init_results(1);
-            p.record_status(0, status.clone(), false);
+            p.record_status(0, status.clone(), false, false);
             papers.push(p);
             ref_states.push(vec![refs(title, authors, Some(status.clone()), None)]);
         }
@@ -1390,9 +1390,9 @@ mod propagation_tests {
             PaperState::new("b.pdf".into()),
         ];
         papers[0].init_results(1);
-        papers[0].record_status(0, Status::NotFound, false);
+        papers[0].record_status(0, Status::NotFound, false, false);
         papers[1].init_results(1);
-        papers[1].record_status(0, Status::NotFound, false);
+        papers[1].record_status(0, Status::NotFound, false, false);
         let mut ref_states = vec![
             vec![refs(
                 "Some Paper",
@@ -1443,8 +1443,8 @@ mod propagation_tests {
     fn propagate_handles_same_paper_siblings() {
         let mut paper = PaperState::new("p.pdf".into());
         paper.init_results(2);
-        paper.record_status(0, Status::NotFound, false);
-        paper.record_status(1, Status::NotFound, false);
+        paper.record_status(0, Status::NotFound, false, false);
+        paper.record_status(1, Status::NotFound, false, false);
         assert_eq!(paper.stats.not_found, 2);
 
         let mut papers = vec![paper];
@@ -1502,7 +1502,7 @@ mod propagation_tests {
         let p0 = {
             let mut p = PaperState::new("a.pdf".into());
             p.init_results(1);
-            p.record_status(0, Status::NotFound, false);
+            p.record_status(0, Status::NotFound, false, false);
             p
         };
         let p1 = PaperState::new("b.pdf".into()); // no results recorded
@@ -1539,13 +1539,13 @@ mod propagation_tests {
             {
                 let mut p = PaperState::new("real.pdf".into());
                 p.init_results(1);
-                p.record_status(0, Status::NotFound, false);
+                p.record_status(0, Status::NotFound, false, false);
                 p
             },
             {
                 let mut p = PaperState::new("fake.pdf".into());
                 p.init_results(1);
-                p.record_status(0, Status::NotFound, false);
+                p.record_status(0, Status::NotFound, false, false);
                 p
             },
         ];
@@ -1673,13 +1673,13 @@ mod propagation_tests {
             {
                 let mut p = PaperState::new("a.pdf".into());
                 p.init_results(1);
-                p.record_status(0, Status::NotFound, false);
+                p.record_status(0, Status::NotFound, false, false);
                 p
             },
             {
                 let mut p = PaperState::new("b.pdf".into());
                 p.init_results(1);
-                p.record_status(0, Status::NotFound, false);
+                p.record_status(0, Status::NotFound, false, false);
                 p
             },
         ];

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/util.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/util.rs
@@ -356,7 +356,7 @@ pub(super) fn format_bytes(bytes: u64) -> String {
 
 pub(super) fn verdict_sort_key(rs: &RefState) -> u8 {
     if matches!(rs.phase, RefPhase::Skipped(_)) {
-        return 5; // sort skipped refs last
+        return 6; // parse-time skipped: sort last
     }
     match &rs.result {
         Some(r) => {
@@ -364,13 +364,21 @@ pub(super) fn verdict_sort_key(rs: &RefState) -> u8 {
                 0
             } else {
                 match &r.status {
+                    // URL-gated NotFound (`--url-match` was off) slots
+                    // between verified refs and parse-time-skipped
+                    // refs so the paper's verdict sort reads
+                    // "problems → verified → URL-skipped → skipped".
+                    // Same visual bucket as parse-time skips, but kept
+                    // as a distinct sort tier so the reader can still
+                    // tell them apart.
+                    hallucinator_core::Status::NotFound if r.url_check_skipped => 4,
                     hallucinator_core::Status::NotFound => 1,
                     hallucinator_core::Status::Mismatch(_) => 2,
                     hallucinator_core::Status::Verified => 3,
                 }
             }
         }
-        None => 4,
+        None => 5,
     }
 }
 
@@ -486,5 +494,77 @@ pub(super) fn get_rss_bytes() -> Option<usize> {
     #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
     {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::paper::FpReason;
+    use hallucinator_core::{MismatchKind, Status, ValidationResult};
+
+    fn result_with(status: Status, url_check_skipped: bool) -> ValidationResult {
+        ValidationResult {
+            title: String::new(),
+            raw_citation: String::new(),
+            ref_authors: Vec::new(),
+            status,
+            source: None,
+            found_authors: Vec::new(),
+            paper_url: None,
+            failed_dbs: Vec::new(),
+            db_results: Vec::new(),
+            doi_info: None,
+            arxiv_info: None,
+            retraction_info: None,
+            url_check_skipped,
+        }
+    }
+
+    fn rs_with(phase: RefPhase, result: Option<ValidationResult>) -> RefState {
+        RefState {
+            index: 0,
+            title: String::new(),
+            phase,
+            result,
+            fp_reason: Option::<FpReason>::None,
+            raw_citation: String::new(),
+            authors: Vec::new(),
+            doi: None,
+            arxiv_id: None,
+            urls: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn verdict_sort_places_url_gated_between_verified_and_skipped() {
+        // Verdict sort ordering the user asked for:
+        //   problems (retracted → not_found → mismatch) → verified
+        //   → URL-gated skip → parse-time skip.
+        // Concrete sort keys must preserve that partial order; the
+        // absolute values don't matter as long as the bucketing holds.
+        let retracted = {
+            let mut r = result_with(Status::Verified, false);
+            r.retraction_info = Some(hallucinator_core::RetractionInfo {
+                is_retracted: true,
+                retraction_doi: None,
+                retraction_source: None,
+            });
+            rs_with(RefPhase::Done, Some(r))
+        };
+        let not_found = rs_with(RefPhase::Done, Some(result_with(Status::NotFound, false)));
+        let mismatch = rs_with(
+            RefPhase::Done,
+            Some(result_with(Status::Mismatch(MismatchKind::AUTHOR), false)),
+        );
+        let verified = rs_with(RefPhase::Done, Some(result_with(Status::Verified, false)));
+        let url_gated = rs_with(RefPhase::Done, Some(result_with(Status::NotFound, true)));
+        let parse_skip = rs_with(RefPhase::Skipped("short_title".into()), None);
+
+        assert!(verdict_sort_key(&retracted) < verdict_sort_key(&not_found));
+        assert!(verdict_sort_key(&not_found) < verdict_sort_key(&mismatch));
+        assert!(verdict_sort_key(&mismatch) < verdict_sort_key(&verified));
+        assert!(verdict_sort_key(&verified) < verdict_sort_key(&url_gated));
+        assert!(verdict_sort_key(&url_gated) < verdict_sort_key(&parse_skip));
     }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -298,7 +298,12 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>) {
             .retraction_info
             .as_ref()
             .is_some_and(|r| r.is_retracted);
-        paper.record_status(loaded_ref.index, result.status.clone(), is_retracted);
+        paper.record_status(
+            loaded_ref.index,
+            result.status.clone(),
+            result.url_check_skipped,
+            is_retracted,
+        );
         // If this ref was persisted with an fp_reason, carry the
         // mark-safe adjustment into the paper stats so the queue table
         // and totals line reflect the prior user decision on load.

--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -56,6 +56,12 @@ struct LoadedRef {
     marked_safe: Option<bool>,
     /// Skip reason (e.g. "url_only", "short_title") — present when status is "skipped".
     skip_reason: Option<String>,
+    /// True iff the ref was rendered as "skipped" because the run had
+    /// `--url-match` disabled and the ref was a NotFound with a
+    /// non-academic URL still on hand. Present in exports from
+    /// sessions where URL matching was opt-in.
+    #[serde(default)]
+    url_check_skipped: bool,
 }
 
 #[derive(Deserialize)]
@@ -285,6 +291,7 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>) {
             doi_info: doi_info.clone(),
             arxiv_info: arxiv_info.clone(),
             retraction_info,
+            url_check_skipped: loaded_ref.url_check_skipped,
         };
 
         let is_retracted = result

--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -345,6 +345,17 @@ fn convert_loaded(loaded: LoadedFile) -> (PaperState, Vec<RefState>) {
         paper.total_refs = ref_count;
     }
 
+    // `parse_skipped` is only the parse-time subset of skipped refs —
+    // those that were marked "skipped" AND did NOT carry the URL-gate
+    // marker. Needed by the gauge denominator; must NOT include URL-
+    // gated refs because those would have entered validation on a
+    // live run and contribute to `done`.
+    paper.parse_skipped = loaded
+        .references
+        .iter()
+        .filter(|r| r.status == "skipped" && !r.url_check_skipped)
+        .count();
+
     (paper, ref_states)
 }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
@@ -300,6 +300,39 @@ mod tests {
     }
 
     #[test]
+    fn url_gated_notfound_is_not_an_unresolved_problem() {
+        // `--url-match` demotes URL-bearing NotFound refs: the user
+        // opted not to URL-verify them, so they must drop out of the
+        // paper-level problematic count.
+        let mut result = empty_val_result(Status::NotFound);
+        result.url_check_skipped = true;
+        let rs = ref_state(RefPhase::Done, Some(result), None);
+        assert!(!rs.is_unresolved_problem());
+    }
+
+    #[test]
+    fn url_gated_notfound_verdict_label_reads_as_skipped() {
+        // Paper table row's verdict cell: URL-gated refs must read as
+        // skipped (same visual bucket as parse-time skips), not as
+        // the red "✗ Not Found" glyph that flags a real
+        // hallucination candidate.
+        let mut result = empty_val_result(Status::NotFound);
+        result.url_check_skipped = true;
+        let rs = ref_state(RefPhase::Done, Some(result), None);
+        let label = rs.verdict_label();
+        assert!(
+            label.contains("skipped"),
+            "expected 'skipped' in verdict label, got {:?}",
+            label
+        );
+        assert!(
+            !label.contains("Not Found"),
+            "URL-gated ref must not render as Not Found: {:?}",
+            label
+        );
+    }
+
+    #[test]
     fn unresolved_problem_retracted_counts_even_if_verified() {
         let mut result = empty_val_result(Status::Verified);
         result.retraction_info = Some(RetractionInfo {

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
@@ -82,7 +82,13 @@ impl RefState {
         let Some(result) = &self.result else {
             return false;
         };
-        let status_problem = matches!(result.status, Status::NotFound)
+        // A `url_check_skipped` NotFound is intentionally not an
+        // unresolved problem — the user opted not to URL-verify that
+        // ref, so it's bucketed under "skipped" and must not inflate
+        // the paper-level problem count.
+        let is_real_not_found =
+            matches!(result.status, Status::NotFound) && !result.url_check_skipped;
+        let status_problem = is_real_not_found
             || matches!(result.status, Status::Mismatch(kind) if kind.contains(MismatchKind::AUTHOR));
         let retracted = result
             .retraction_info
@@ -118,6 +124,13 @@ impl RefState {
                     } else {
                         "\u{2713} Verified".to_string()
                     }
+                }
+                // URL-gated NotFound renders as "skipped (URL check
+                // disabled)" so the ref visually sits alongside the
+                // parse-time skips and doesn't look like a
+                // hallucination candidate.
+                Status::NotFound if r.url_check_skipped => {
+                    "(skipped: URL check disabled)".to_string()
                 }
                 Status::NotFound => "\u{2717} Not Found".to_string(),
                 Status::Mismatch(_) => "\u{26A0} Mismatch".to_string(),

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/paper.rs
@@ -219,6 +219,7 @@ mod tests {
             doi_info: None,
             arxiv_info: None,
             retraction_info: None,
+            url_check_skipped: false,
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
@@ -8,6 +8,13 @@ pub use hallucinator_reporting::PaperVerdict;
 pub struct ResultSummary {
     pub status: Status,
     pub is_retracted: bool,
+    /// Mirrors `ValidationResult.url_check_skipped`: when true, the ref
+    /// finished `Status::NotFound` but its URL would only have been
+    /// verified by URL Check / Wayback, which were disabled via the
+    /// `--url-match` gate. Paper-level stats treat these as "skipped"
+    /// rather than "not_found"; the display layer renders them the
+    /// same way.
+    pub url_check_skipped: bool,
 }
 
 /// Processing phase of a paper in the queue.
@@ -81,17 +88,31 @@ impl PaperState {
     /// If the slot already contains a result (retry pass), the old status
     /// counters are decremented before the new ones are incremented, preventing
     /// double-counting.
-    pub fn record_status(&mut self, index: usize, status: Status, is_retracted: bool) {
+    pub fn record_status(
+        &mut self,
+        index: usize,
+        status: Status,
+        url_check_skipped: bool,
+        is_retracted: bool,
+    ) {
         // Grow if needed (shouldn't happen after init_results, but be safe)
         if index >= self.results.len() {
             self.results.resize(index + 1, None);
         }
 
-        // Decrement old counters if replacing
+        // Decrement old counters if replacing. A URL-gated NotFound was
+        // counted under `skipped`, not `not_found`, so its decrement has
+        // to match the bucket it was incremented into.
         if let Some(old) = &self.results[index] {
             match &old.status {
                 Status::Verified => self.stats.verified = self.stats.verified.saturating_sub(1),
-                Status::NotFound => self.stats.not_found = self.stats.not_found.saturating_sub(1),
+                Status::NotFound => {
+                    if old.url_check_skipped {
+                        self.stats.skipped = self.stats.skipped.saturating_sub(1);
+                    } else {
+                        self.stats.not_found = self.stats.not_found.saturating_sub(1);
+                    }
+                }
                 Status::Mismatch(kind) => {
                     self.stats.mismatch = self.stats.mismatch.saturating_sub(1);
                     if kind.contains(MismatchKind::AUTHOR) {
@@ -110,10 +131,19 @@ impl PaperState {
             }
         }
 
-        // Increment new counters
+        // Increment new counters. A URL-gated NotFound goes into
+        // `skipped` so the paper-level problematic count stays aligned
+        // with the CLI summary and JSON export (which already exclude
+        // `url_check_skipped` refs from the hallucination bucket).
         match &status {
             Status::Verified => self.stats.verified += 1,
-            Status::NotFound => self.stats.not_found += 1,
+            Status::NotFound => {
+                if url_check_skipped {
+                    self.stats.skipped += 1;
+                } else {
+                    self.stats.not_found += 1;
+                }
+            }
             Status::Mismatch(kind) => {
                 self.stats.mismatch += 1;
                 if kind.contains(MismatchKind::AUTHOR) {
@@ -134,6 +164,7 @@ impl PaperState {
         self.results[index] = Some(ResultSummary {
             status,
             is_retracted,
+            url_check_skipped,
         });
     }
 
@@ -338,7 +369,10 @@ mod tests {
         let mut p = PaperState::new("t".into());
         p.init_results(statuses.len());
         for (i, (status, is_retracted)) in statuses.iter().enumerate() {
-            p.record_status(i, status.clone(), *is_retracted);
+            // Test helper leaves url_check_skipped=false because the
+            // existing cases exercise the pre-flag NotFound path. URL-
+            // gated cases have their own dedicated test below.
+            p.record_status(i, status.clone(), false, *is_retracted);
         }
         p.stats.total = statuses.len();
         p.total_refs = statuses.len();
@@ -405,6 +439,41 @@ mod tests {
         assert_eq!(p.stats.verified, before.verified);
         assert_eq!(p.stats.not_found, before.not_found);
         assert_eq!(p.stats.mismatch, before.mismatch);
+    }
+
+    #[test]
+    fn record_status_url_gated_not_found_goes_to_skipped_bucket() {
+        // Regression guard for the TUI `--url-match` gap (NDSS 2026
+        // f605 regression: TUI surfaced 15 not-found while the CLI
+        // showed 2, because `record_status` counted every NotFound
+        // into `stats.not_found` regardless of `url_check_skipped`).
+        // With the flag threaded through, a URL-gated NotFound must
+        // bump `stats.skipped` and leave `stats.not_found` at zero.
+        let mut p = PaperState::new("t".into());
+        p.init_results(2);
+        // Real NotFound (no URL in the ref) — the hallucination bucket.
+        p.record_status(0, Status::NotFound, false, false);
+        // URL-gated NotFound — was URL-bearing, `--url-match` was off.
+        p.record_status(1, Status::NotFound, true, false);
+        assert_eq!(p.stats.not_found, 1, "got {:?}", p.stats);
+        assert_eq!(p.stats.skipped, 1, "got {:?}", p.stats);
+    }
+
+    #[test]
+    fn record_status_replacement_preserves_bucket_symmetry() {
+        // The decrement path has to mirror the increment path: a URL-
+        // gated NotFound that's later replaced by a regular NotFound
+        // (e.g. after a retry with `--url-match` on) must drop the
+        // `skipped` count and add to `not_found`.
+        let mut p = PaperState::new("t".into());
+        p.init_results(1);
+        p.record_status(0, Status::NotFound, true, false);
+        assert_eq!(p.stats.skipped, 1);
+        assert_eq!(p.stats.not_found, 0);
+        // Retry: URL check now ran, still NotFound (dead link).
+        p.record_status(0, Status::NotFound, false, false);
+        assert_eq!(p.stats.skipped, 0, "got {:?}", p.stats);
+        assert_eq!(p.stats.not_found, 1, "got {:?}", p.stats);
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/queue.rs
@@ -61,6 +61,15 @@ pub struct PaperState {
     pub retry_done: usize,
     /// User-assigned verdict for the entire paper.
     pub verdict: Option<PaperVerdict>,
+    /// Count of refs that the parser skipped before validation ever
+    /// ran (empty title with no strong signal). These never enter the
+    /// pool, so the gauge denominator must exclude them. Kept
+    /// separate from `stats.skipped` because `stats.skipped` is the
+    /// combined display bucket (parse-time + URL-gated) that mirrors
+    /// the CLI summary and JSON export; mixing the two would inflate
+    /// the "already accounted for" part of the progress formula and
+    /// push the gauge ratio above 1 (ratatui panics on that).
+    pub parse_skipped: usize,
 }
 
 impl PaperState {
@@ -75,6 +84,7 @@ impl PaperState {
             retry_total: 0,
             retry_done: 0,
             verdict: None,
+            parse_skipped: 0,
         }
     }
 
@@ -234,8 +244,12 @@ impl PaperState {
 
     /// Percentage of references that are problematic (0.0 - 100.0).
     ///
-    /// Uses checkable refs (total minus skipped) as the denominator so the
-    /// percentage reflects only refs that actually entered the validation pipeline.
+    /// Mirrors `hallucinator_reporting::export::problematic_pct`:
+    /// denominator is `total - stats.skipped` (the combined skipped
+    /// bucket — parse-time + URL-gated), numerator is `problems()`
+    /// which already excludes URL-gated refs. This keeps the TUI's
+    /// sort-by-problematic column aligned with the number JSON and
+    /// CLI reports emit.
     pub fn problematic_pct(&self) -> f64 {
         let checkable = self.total_refs.saturating_sub(self.stats.skipped);
         if checkable == 0 {
@@ -457,6 +471,49 @@ mod tests {
         p.record_status(1, Status::NotFound, true, false);
         assert_eq!(p.stats.not_found, 1, "got {:?}", p.stats);
         assert_eq!(p.stats.skipped, 1, "got {:?}", p.stats);
+    }
+
+    #[test]
+    fn gauge_ratio_invariant_holds_with_url_gated_refs() {
+        // Regression guard for the ratatui gauge panic (NDSS 2026 f605:
+        // `Ratio should be between 0 and 1 inclusively` at
+        // `ratatui/src/widgets/gauge.rs:95`). The gauge uses
+        // `completed / (total - parse_skipped)` so URL-gated refs
+        // (which DO go through the pool and show up in `completed`)
+        // must not be subtracted from the denominator. If the
+        // formula accidentally used `stats.skipped` the ratio would
+        // go above 1 as soon as any URL-gated ref landed.
+        let mut p = PaperState::new("t".into());
+        p.total_refs = 53;
+        p.parse_skipped = 1;
+        // In the live flow, backend.rs sets stats.skipped = parse_skipped
+        // at ExtractionComplete, BEFORE any record_status calls.
+        // Mirror that seeding here so the combined count ends at 12.
+        p.stats.skipped = 1;
+        p.init_results(53);
+        // Simulate validation for the 52 non-parse-skipped refs:
+        // 40 verified, 11 URL-gated skips, 1 real not_found.
+        for i in 0..40 {
+            p.record_status(i, Status::Verified, false, false);
+        }
+        for i in 40..51 {
+            p.record_status(i, Status::NotFound, /*url_gated=*/ true, false);
+        }
+        p.record_status(51, Status::NotFound, false, false);
+        // `stats.skipped` reflects combined (parse + URL-gated) = 12,
+        // but `parse_skipped` stays at 1 so `checkable` stays at 52.
+        assert_eq!(p.stats.skipped, 12);
+        assert_eq!(p.parse_skipped, 1);
+        let completed = p.completed_count();
+        assert_eq!(completed, 52);
+        let checkable = p.total_refs.saturating_sub(p.parse_skipped);
+        assert_eq!(checkable, 52);
+        assert!(
+            completed <= checkable,
+            "completed ({}) must be <= checkable ({}) so gauge ratio stays in [0,1]",
+            completed,
+            checkable
+        );
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
@@ -118,6 +118,11 @@ pub fn render_in(
             .is_some_and(|ri| ri.is_retracted)
         {
             ("\u{2620} RETRACTED".to_string(), theme.retracted)
+        } else if result.url_check_skipped {
+            // URL-gated NotFound: render with the skipped palette so
+            // the detail view doesn't contradict the row-level
+            // "(skipped: URL check disabled)" verdict in the table.
+            ("Skipped (URL check disabled)".to_string(), theme.skipped)
         } else {
             match &result.status {
                 Status::Verified => ("\u{2713} Verified".to_string(), theme.verified),

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
@@ -595,6 +595,7 @@ mod tests {
             doi_info: None,
             arxiv_info: None,
             retraction_info: None,
+            url_check_skipped: false,
         }
     }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
@@ -157,8 +157,18 @@ fn render_ref_table(f: &mut Frame, area: Rect, app: &App, paper_index: usize) {
             let phase_style = theme.ref_phase_style(&rs.phase);
 
             let verdict = rs.verdict_label();
-            let verdict_style = if matches!(rs.phase, RefPhase::Skipped(_)) {
-                phase_style
+            // URL-gated NotFound (`--url-match` was off) renders with
+            // the same `skipped` color as parse-time skips: the user
+            // explicitly opted not to verify these, so they should
+            // visually blend with the other non-problematic skipped
+            // rows instead of glowing red alongside real hallucination
+            // candidates. Phase is still `Done` (they went through
+            // validation) — we dispatch on `result.url_check_skipped`.
+            let is_url_gated_skip = rs.result.as_ref().is_some_and(|r| r.url_check_skipped);
+            let verdict_style = if matches!(rs.phase, RefPhase::Skipped(_)) || is_url_gated_skip {
+                Style::default()
+                    .fg(theme.skipped)
+                    .add_modifier(Modifier::ITALIC)
             } else if rs.is_marked_safe() {
                 Style::default()
                     .fg(theme.verified)

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/paper.rs
@@ -74,9 +74,15 @@ fn render_progress(
     theme: &Theme,
 ) {
     let done = paper.completed_count();
-    let checkable = paper.total_refs.saturating_sub(paper.stats.skipped);
+    // Denominator is the count of refs that ENTERED validation — i.e.
+    // total minus parse-time skips. `stats.skipped` isn't safe here:
+    // it also contains URL-gated refs (demoted by the `--url-match`
+    // gate) which DO go through the pool and contribute to `done`.
+    // Using the combined `stats.skipped` pushed `done > checkable` and
+    // panicked the ratatui gauge.
+    let checkable = paper.total_refs.saturating_sub(paper.parse_skipped);
     let ratio = if checkable > 0 {
-        done as f64 / checkable as f64
+        (done as f64 / checkable as f64).clamp(0.0, 1.0)
     } else {
         0.0
     };

--- a/hallucinator-rs/crates/hallucinator-web/src/models.rs
+++ b/hallucinator-rs/crates/hallucinator-web/src/models.rs
@@ -21,6 +21,12 @@ pub struct ResultJson {
     pub arxiv_info: Option<ArxivInfoJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retraction_info: Option<RetractionInfoJson>,
+    /// True iff the ref finished NotFound with a non-academic URL but
+    /// `--url-match` was off. The `status` field is already demoted to
+    /// "skipped" in that case; this boolean lets web consumers tell the
+    /// URL-gated skip apart from a parse-time skip.
+    #[serde(default)]
+    pub url_check_skipped: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -50,16 +56,29 @@ pub struct RetractionInfoJson {
 
 impl From<&ValidationResult> for ResultJson {
     fn from(r: &ValidationResult) -> Self {
-        let status_str = match &r.status {
-            Status::Verified => "verified",
-            Status::NotFound => "not_found",
-            Status::Mismatch(_) => "mismatch",
+        // Demote URL-bearing NotFound refs to "skipped" when
+        // `--url-match` was off, so the web consumer's status bucket
+        // matches the CLI/JSON export behavior. `error_type` is
+        // cleared too — no hallucination banner should fire for a
+        // citation the user chose not to URL-verify.
+        let status_str = if r.url_check_skipped {
+            "skipped"
+        } else {
+            match &r.status {
+                Status::Verified => "verified",
+                Status::NotFound => "not_found",
+                Status::Mismatch(_) => "mismatch",
+            }
         };
 
-        let error_type = match &r.status {
-            Status::NotFound => Some("not_found".to_string()),
-            Status::Mismatch(kind) => Some(format!("mismatch_{}", kind.description())),
-            Status::Verified => None,
+        let error_type = if r.url_check_skipped {
+            None
+        } else {
+            match &r.status {
+                Status::NotFound => Some("not_found".to_string()),
+                Status::Mismatch(kind) => Some(format!("mismatch_{}", kind.description())),
+                Status::Verified => None,
+            }
         };
 
         let doi_info = r.doi_info.as_ref().map(|d| DoiInfoJson {
@@ -93,6 +112,7 @@ impl From<&ValidationResult> for ResultJson {
             doi_info,
             arxiv_info,
             retraction_info,
+            url_check_skipped: r.url_check_skipped,
         }
     }
 }
@@ -118,11 +138,15 @@ impl SummaryJson {
             .iter()
             .filter(|r| r.status == Status::Verified)
             .count();
+        // Exclude `url_check_skipped` refs from the not_found bucket —
+        // they're counted under `skipped` below, matching the CLI
+        // CheckStats treatment.
         let not_found = results
             .iter()
-            .filter(|r| r.status == Status::NotFound)
+            .filter(|r| r.status == Status::NotFound && !r.url_check_skipped)
             .count();
         let mismatched = results.iter().filter(|r| r.status.is_mismatch()).count();
+        let skipped_url_match_gate = results.iter().filter(|r| r.url_check_skipped).count();
 
         SummaryJson {
             total_raw: skip_stats.total_raw,
@@ -130,7 +154,9 @@ impl SummaryJson {
             verified,
             not_found,
             mismatched,
-            skipped: skip_stats.url_only + skip_stats.short_title,
+            skipped: skip_stats.url_only
+                + skip_stats.short_title
+                + skipped_url_match_gate,
             skipped_url: skip_stats.url_only,
             skipped_short_title: skip_stats.short_title,
             title_only: skip_stats.no_authors,


### PR DESCRIPTION
## Summary

Two independent lines of work, both surfaced by surveying the NDSS 2026
papers against the existing validator.

- **URL Check coverage and reference parsing fixes** (commits 1–3).
  Improves URL liveness detection and title extraction for references
  the existing pipeline was missing or mis-parsing on multiple NDSS 2026
  papers (f106, f182, f468, f1059, f2008, f93, ...).
- **New \`--url-match\` flag** (commits 4–8). URL Check + Wayback are
  now opt-in. With the flag off (the default), NotFound refs that
  still carry a non-academic URL are reported as \`skipped\` rather
  than \`not_found\`, so dead links and bot-walled hosts stop
  contaminating the hallucination list. Refs with fake arXiv/DOI
  identifiers still flag as \`not_found\` because academic URLs are
  already filtered out of \`Reference.urls\` at parse time.

### URL Check + parsing improvements

\`9ea5f5c\` — Broaden URL Check: polite UA, HEAD→GET on any 4xx (not
just 405). Fixes NXP-style anti-bot filters that serve 404 to HEAD
and 200 to GET.

\`01c1acf\` — Improve reference parsing on NDSS 2026 corpus.

- Title extraction: curly-quote greedy \`IEEE\` pattern, month-year
  cutoff now requires \`[.,]\` punctuation, \`[Online]\` annotation
  markers rejected as titles, 1-word IEEE-comma-terminated quoted
  titles accepted (\`"Zcash,"\`, \`"Pytorch,"\`, \`"Hashcat,"\`),
  new \`try_web_citation\` extractor for
  \`[Author,] Title, Month Year, URL\`.
- URL extraction: trailing typographic quotes (\`\u{201C}\u{201D}\u{2018}\u{2019}\`)
  stripped, \`HOST_SPACE_FIX\` collapses host-internal whitespace
  (\`https://multim edia.3m.com\` → \`multimedia.3m.com\`).
- Reporting: URL Check / Wayback / Web Search now push a \`no_match\`
  DbResult entry — \"fallback ran, didn't verify\" is no longer
  indistinguishable from \"fallback never ran\" in JSON.

\`c85533f\` — Recover URL paths with spaced slashes + f93 web citations.
\`SPACE_BEFORE_SLASH\` rule lets multi-slash paths like
\`https://example.com/a / b / c / d\` collapse fully in a single pass.
\`try_web_citation\` broadened to handle the \`ORG. Title., Month.
Year. [Online]. Available: URL\` shape common in NDSS 2026 f93 — drops
f93's empty-title count from 27 → 7.

### \`--url-match\` flag

\`f666c42\` — Add the flag. \`Config.url_match: bool\` (default
\`false\`); \`apply_fallbacks\` gates URL Check + Wayback on the
flag; a new \`ValidationResult.url_check_skipped: bool\` marker
flows through every reporting layer so \`NotFound + url_check_skipped\`
renders as \"skipped\" in CLI summary, JSON, CSV, web bindings, and
Python bindings. Keeps the \`Status\` enum unchanged (248 match-site
blast radius avoided).

\`479b744\` — Fix CLI summary to bucket URL-gated refs as skipped. The
JSON export already demoted them; the text summary still counted
them as \"potential hallucinations\". New \"Skipped (URL check
disabled): N\" line prints separately from parse-time skips.

\`c0cfe67\` — Fix TUI stats to bucket URL-gated refs as skipped.
\`PaperState::record_status\` now takes \`url_check_skipped\`;
URL-gated NotFounds bump \`stats.skipped\`, not \`stats.not_found\`.
\`verdict_label\` reads \"(skipped: URL check disabled)\";
\`is_unresolved_problem\` returns \`false\` for URL-gated refs.

\`0489ce0\` — Fix TUI gauge ratio panic. The previous commit's
\`stats.skipped\` bump broke \`view/paper.rs\`'s progress gauge
(\`ratio = done / (total - stats.skipped)\` went above 1 and
\`ratatui\` panicked). Separated \`PaperState.parse_skipped\` (gauge
denominator, set once at ExtractionComplete) from \`stats.skipped\`
(combined display bucket).

\`a31a815\` — Cosmetic: URL-gated refs render in the skipped palette
and sort between verified and parse-time skipped. Matches the
user's requested \"problems → verified → URL-skipped → skipped\"
order in the Verdict sort.

### Default

Opt-in. With no flag, URL Check + Wayback do not run and URL-bearing
NotFounds are reported as skipped. This is a visible behavior change
— in the 67-paper NDSS 2026 survey, 621 of 970 URL-bearing refs
currently verify via URL Check and flip to \"skipped\" without the
flag. The intent is \"less noise by default\"; users who want the
older strong-verification behavior add \`--url-match\`.

### Verified on NDSS 2026 corpus

| paper | before | after (default) | after (--url-match) |
|---|---|---|---|
| f106 (108 refs) | 68 potential-hallucinations | 9 not_found + 59 skipped | 93 verified + 15 not_found |
| f605 (53 refs) | 15 not_found (TUI) | 1 not_found + 11 URL-skipped + 1 parse-skip | — |
| f93 (64 refs, parsing only) | 27 empty titles | 7 empty titles | — |

## Test plan

- [ ] \`cargo test --workspace\` green (32 suites, 0 failures; includes
  7 new hermetic tests for \`try_web_citation\`, 3 for URL-extraction
  fixes, 3 integration tests for the URL-match gate in
  \`pool_integration.rs\`, 2 for reporting JSON status demotion,
  and 5 for the TUI stats / gauge / sort / verdict-label behavior).
- [ ] \`cargo fmt --all --check\` clean.
- [ ] End-to-end: \`hallucinator-cli check ~/Data/hallucinator-data/ndss-2026/2026-f106-paper.pdf\`
  without \`--url-match\` should report \"Not found: 9\" + \"Skipped
  (URL check disabled): 59\", not 68.
- [ ] End-to-end: same paper with \`--url-match\` should report 93
  verified + 15 not_found.
- [ ] End-to-end: \`hallucinator-cli check ~/Data/hallucinator-data/ndss-2026/2026-f93-paper.pdf --dry-run\`
  shows 7 empty titles, not 27.
- [ ] TUI: open f605 without \`--url-match\`; hit \`s\` to sort by
  verdict; confirm the 11 URL-bearing refs appear between verified
  and parse-time skipped, rendered in the skipped color with
  \"(skipped: URL check disabled)\" verdict.
- [ ] TUI: no ratatui gauge panic on f605 / f106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)