### PR TITLE
Validation & parsing correctness fixes (special letters, JSON cache sync, phantom authors, body-text segments, system-name titles)

### DIFF
--- a/hallucinator-rs/crates/hallucinator-core/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/authors.rs
@@ -2,6 +2,8 @@ use once_cell::sync::Lazy;
 use std::collections::HashSet;
 use unicode_normalization::UnicodeNormalization;
 
+use crate::matching::fold_special_letters;
+
 /// Common surname prefixes (case-insensitive).
 static SURNAME_PREFIXES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     [
@@ -292,13 +294,17 @@ fn get_surname_from_parts(parts: &[&str]) -> String {
 }
 
 /// Strip diacritics and normalize typographic characters for comparison.
-/// "Müller" → "Muller", "Crépeau" → "Crepeau", "O'Brien" → "O'Brien"
+/// "Müller" → "Muller", "Crépeau" → "Crepeau", "Müßig" → "Mussig",
+/// "Adıgüzel" → "Adiguzel", "O'Brien" → "O'Brien"
 fn strip_diacritics(s: &str) -> String {
     // Normalize curly quotes/apostrophes to ASCII before NFKD
     // (NFKD doesn't decompose U+2019 RIGHT SINGLE QUOTATION MARK)
     let s = s
         .replace(['\u{2019}', '\u{2018}'], "'") // curly single quotes → apostrophe
         .replace(['\u{201C}', '\u{201D}'], "\""); // curly double quotes → straight
+    // Fold ß/ı/ø/… to their DBLP/arXiv-style ASCII transliteration; NFKD alone
+    // would leave these untouched and the ASCII filter would then drop them.
+    let s = fold_special_letters(&s);
     s.nfkd().filter(|c| c.is_ascii()).collect()
 }
 
@@ -563,6 +569,41 @@ mod tests {
         assert!(validate_authors(
             &s(&["Florian Tramèr"]),
             &s(&["Florian Tramer"]),
+        ));
+    }
+
+    #[test]
+    fn test_sharp_s_folds_to_ss() {
+        // PDF: "Müßig", DBLP/arXiv: "Mussig" (ß → ss).
+        // NFKD alone would drop ß and produce "Mig", which never matched.
+        assert!(validate_authors(&s(&["Hans Müßig"]), &s(&["Hans Mussig"]),));
+    }
+
+    #[test]
+    fn test_dotless_i_folds_to_i() {
+        // PDF: "Adıgüzel" (Turkish dotless i), DBLP: "Adiguzel".
+        // NFKD alone would drop ı and produce "Adgzel", which never matched.
+        assert!(validate_authors(
+            &s(&["Cemal Adıgüzel"]),
+            &s(&["Cemal Adiguzel"]),
+        ));
+    }
+
+    #[test]
+    fn test_slashed_o_folds_to_o() {
+        // PDF: "Bjørn Østergaard", DBLP: "Bjorn Ostergaard".
+        assert!(validate_authors(
+            &s(&["Bjørn Østergaard"]),
+            &s(&["Bjorn Ostergaard"]),
+        ));
+    }
+
+    #[test]
+    fn test_l_with_stroke_folds_to_l() {
+        // PDF: "Wojciech Łukasz", DBLP: "Wojciech Lukasz".
+        assert!(validate_authors(
+            &s(&["Wojciech Łukasz"]),
+            &s(&["Wojciech Lukasz"]),
         ));
     }
 

--- a/hallucinator-rs/crates/hallucinator-core/src/matching.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/matching.rs
@@ -3,6 +3,43 @@ use regex::Regex;
 use std::collections::HashMap;
 use unicode_normalization::UnicodeNormalization;
 
+/// Map non-decomposable Latin letters to their conventional ASCII transliteration.
+///
+/// NFKD only decomposes characters built from a base + combining mark (ä → a + ¨),
+/// so letters that are atomic codepoints (ß, ı, ø, æ, …) survive NFKD and then get
+/// dropped by an ASCII filter — turning "Müßig" into "Mig" and "Adıgüzel" into
+/// "Adgzel". DBLP, arXiv and OpenAlex all transliterate these the standard way
+/// (ß → "ss", ı → "i", ø → "o", …) before publishing metadata, so we replicate
+/// the mapping here to keep author and title comparisons aligned with backends.
+pub(crate) fn fold_special_letters(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            'ß' => out.push_str("ss"),
+            'ẞ' => out.push_str("SS"),
+            'ı' => out.push('i'),
+            'ø' => out.push('o'),
+            'Ø' => out.push('O'),
+            'æ' => out.push_str("ae"),
+            'Æ' => out.push_str("AE"),
+            'œ' => out.push_str("oe"),
+            'Œ' => out.push_str("OE"),
+            'ł' => out.push('l'),
+            'Ł' => out.push('L'),
+            'đ' => out.push('d'),
+            'Đ' => out.push('D'),
+            'ð' => out.push('d'),
+            'Ð' => out.push('D'),
+            'þ' => out.push_str("th"),
+            'Þ' => out.push_str("Th"),
+            'ħ' => out.push('h'),
+            'Ħ' => out.push('H'),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 /// Mapping of (diacritic, letter) pairs to precomposed characters.
 /// Used to fix separated diacritics from PDF extraction.
 static DIACRITIC_COMPOSITIONS: Lazy<HashMap<(&str, &str), &str>> = Lazy::new(|| {
@@ -202,7 +239,8 @@ pub fn normalize_title(title: &str) -> String {
         .replace('⇐', "impliedby")
         .replace('⇔', "iff");
 
-    // 5-6. NFKD normalization and strip to ASCII
+    // 5-6. Fold non-decomposable Latin letters, NFKD-normalize, strip to ASCII
+    let title = fold_special_letters(&title);
     let normalized: String = title.nfkd().filter(|c| c.is_ascii()).collect();
 
     // 7-8. Keep only alphanumeric, lowercase
@@ -293,6 +331,15 @@ mod tests {
     fn test_normalize_title_unicode() {
         // é decomposes to e + combining accent, accent gets stripped as non-alnum
         assert_eq!(normalize_title("résumé"), "resume");
+    }
+
+    #[test]
+    fn test_normalize_title_special_letters() {
+        // Letters that don't decompose under NFKD must still fold to ASCII
+        // the way DBLP/arXiv transliterate them.
+        assert_eq!(normalize_title("Außenseiter"), "aussenseiter");
+        assert_eq!(normalize_title("İstanbul Adıgüzel"), "istanbuladiguzel");
+        assert_eq!(normalize_title("Bjørn Ærø"), "bjornaero");
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
@@ -1,12 +1,53 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
+use hallucinator_core::QueryCache;
 use hallucinator_ingest::archive::ArchiveItem;
+use hallucinator_reporting::FpReason;
 
 use super::App;
-use crate::model::paper::RefPhase;
+use crate::model::paper::{RefPhase, RefState};
 use crate::model::queue::{PaperPhase, PaperState};
 use crate::tui_event::BackendCommand;
+
+/// Reconcile freshly-loaded refs with the query cache's `fp_overrides`
+/// table. PDF runs do this implicitly via `BackendEvent::ExtractionComplete`
+/// in `backend.rs`, which reads `get_fp_override` per ref before the user
+/// can interact. The JSON-load path never receives that event, so without
+/// this step Space-marks made on a loaded paper would persist to SQLite
+/// but be invisible the next time the JSON is reopened.
+///
+/// Per ref:
+/// - If the cache already has an entry for this identity, that value wins
+///   over the JSON's `fp_reason` and is stamped onto the `RefState`. This
+///   keeps the cache the live source of truth — re-loading a JSON whose
+///   `fp_reason` field is stale (e.g. the user toggled the mark in a
+///   previous session) restores the latest mark instead of clobbering it.
+/// - Otherwise, if the JSON carried an `fp_reason`, seed the cache with
+///   it so future sessions see the mark even when re-extracted from PDF.
+pub(crate) fn sync_fp_overrides_with_cache(refs: &mut [RefState], cache: &QueryCache) {
+    for rs in refs {
+        let Some(key) = hallucinator_core::cache::compute_fp_identity(&rs.title, &rs.authors)
+        else {
+            continue;
+        };
+        match cache.get_fp_override(&key) {
+            Some(reason_str) => {
+                // Cache wins. Parse and stamp; if the cache holds an
+                // unknown variant (forward-compat), leave rs.fp_reason
+                // untouched rather than silently dropping the mark.
+                if let Ok(reason) = reason_str.parse::<FpReason>() {
+                    rs.fp_reason = Some(reason);
+                }
+            }
+            None => {
+                if let Some(reason) = rs.fp_reason {
+                    cache.set_fp_override(&key, Some(reason.as_str()));
+                }
+            }
+        }
+    }
+}
 
 impl App {
     /// Send a start command to the backend if not already started.
@@ -65,6 +106,48 @@ impl App {
                 config: Box::new(config),
             });
             self.inflight_batches += 1;
+        }
+    }
+
+    /// Reconcile freshly-loaded papers (those at indices `first_paper_idx..`)
+    /// with the query cache. For each ref:
+    /// - Restore `fp_reason` from cache if present (cache wins over JSON).
+    /// - Otherwise seed cache from the JSON's `fp_reason`.
+    /// Then re-walk the papers' stats to apply the `apply_fp_delta`
+    /// adjustments for refs whose `fp_reason` flipped from None → Some
+    /// during the cache-restore step. This keeps the queue table's
+    /// "Safe" / "Problems" counts consistent with what the user sees
+    /// per-ref, just as `backend.rs` ExtractionComplete already does
+    /// for live PDF runs.
+    pub(crate) fn sync_loaded_fp_overrides(&mut self, first_paper_idx: usize) {
+        let cache = self.get_or_build_query_cache();
+        for paper_idx in first_paper_idx..self.ref_states.len() {
+            let refs = &mut self.ref_states[paper_idx];
+
+            // Snapshot pre-sync fp_reason to detect None → Some flips
+            // that need a stat adjustment (load.rs already credited
+            // the JSON's marks, so we only need to credit *new* ones
+            // restored from cache).
+            let pre: Vec<Option<FpReason>> = refs.iter().map(|rs| rs.fp_reason).collect();
+
+            sync_fp_overrides_with_cache(refs, &cache);
+
+            for (i, rs) in refs.iter().enumerate() {
+                let was_safe = pre[i].is_some();
+                let is_safe = rs.fp_reason.is_some();
+                if was_safe == is_safe {
+                    continue;
+                }
+                let Some(result) = &rs.result else { continue };
+                let is_retracted = result
+                    .retraction_info
+                    .as_ref()
+                    .is_some_and(|r| r.is_retracted);
+                let dir: i32 = if is_safe { 1 } else { -1 };
+                if let Some(paper) = self.papers.get_mut(paper_idx) {
+                    paper.apply_fp_delta(&result.status, is_retracted, dir);
+                }
+            }
         }
     }
 
@@ -240,11 +323,13 @@ impl App {
                 match crate::load::load_results_file(&path) {
                     Ok(loaded) => {
                         let count = loaded.len();
+                        let first_idx = self.papers.len();
                         for (paper, refs) in loaded {
                             self.papers.push(paper);
                             self.ref_states.push(refs);
                             self.file_paths.push(PathBuf::new()); // placeholder
                         }
+                        self.sync_loaded_fp_overrides(first_idx);
                         self.batch_complete = true;
                         self.processing_started = true;
                         self.activity.log(format!(
@@ -561,5 +646,125 @@ impl App {
                 config: Box::new(config),
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::paper::FpReason;
+
+    fn ref_with(title: &str, authors: &[&str], fp_reason: Option<FpReason>) -> RefState {
+        RefState {
+            index: 0,
+            title: title.into(),
+            phase: RefPhase::Done,
+            result: None,
+            fp_reason,
+            raw_citation: String::new(),
+            authors: authors.iter().map(|s| s.to_string()).collect(),
+            doi: None,
+            arxiv_id: None,
+            urls: vec![],
+        }
+    }
+
+    fn temp_cache() -> (tempfile::TempDir, std::sync::Arc<QueryCache>) {
+        // SQLite-backed cache; the in-memory fallback (`build_query_cache(None, …)`)
+        // silently drops fp_overrides since there's no persistence layer.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.db");
+        let cache = hallucinator_core::build_query_cache(Some(&path), 60, 60);
+        (dir, cache)
+    }
+
+    #[test]
+    fn sync_seeds_cache_from_json_fp_reasons() {
+        // Regression for case (A): pre-marked refs in JSON should land
+        // in the cache so future sessions (PDF or JSON) see the mark.
+        let (_dir, cache) = temp_cache();
+        let mut refs = vec![
+            ref_with(
+                "Marked Safe Paper",
+                &["Alice Author"],
+                Some(FpReason::KnownGood),
+            ),
+            ref_with("Untouched Paper", &["Bob Author"], None),
+        ];
+
+        sync_fp_overrides_with_cache(&mut refs, &cache);
+
+        let key_marked = hallucinator_core::cache::compute_fp_identity(
+            "Marked Safe Paper",
+            &["Alice Author".into()],
+        )
+        .unwrap();
+        let key_untouched = hallucinator_core::cache::compute_fp_identity(
+            "Untouched Paper",
+            &["Bob Author".into()],
+        )
+        .unwrap();
+        assert_eq!(
+            cache.get_fp_override(&key_marked).as_deref(),
+            Some("known_good")
+        );
+        assert!(cache.get_fp_override(&key_untouched).is_none());
+    }
+
+    #[test]
+    fn sync_restores_cache_marks_into_loaded_refs() {
+        // Regression for case (B): a Space-mark made in a previous JSON
+        // session writes to the cache, but reopening the JSON used to
+        // ignore the cache (only PDF extraction restored marks). Now
+        // the load path also reads `get_fp_override` and stamps the
+        // mark onto the freshly-loaded RefState.
+        let (_dir, cache) = temp_cache();
+        let key = hallucinator_core::cache::compute_fp_identity(
+            "Persisted Paper",
+            &["Carol Author".into()],
+        )
+        .unwrap();
+        cache.set_fp_override(&key, Some("broken_parse"));
+
+        let mut refs = vec![ref_with("Persisted Paper", &["Carol Author"], None)];
+        sync_fp_overrides_with_cache(&mut refs, &cache);
+
+        assert_eq!(refs[0].fp_reason, Some(FpReason::BrokenParse));
+    }
+
+    #[test]
+    fn sync_cache_wins_over_json_fp_reason() {
+        // If JSON and cache disagree, cache is the live source of truth
+        // (the user may have toggled the mark in a later session and
+        // the JSON on disk is stale).
+        let (_dir, cache) = temp_cache();
+        let key = hallucinator_core::cache::compute_fp_identity(
+            "Disagreeing Paper",
+            &["Dave Author".into()],
+        )
+        .unwrap();
+        cache.set_fp_override(&key, Some("non_academic"));
+
+        let mut refs = vec![ref_with(
+            "Disagreeing Paper",
+            &["Dave Author"],
+            Some(FpReason::KnownGood),
+        )];
+        sync_fp_overrides_with_cache(&mut refs, &cache);
+
+        assert_eq!(refs[0].fp_reason, Some(FpReason::NonAcademic));
+        // Cache stays untouched (we read, didn't write).
+        assert_eq!(cache.get_fp_override(&key).as_deref(), Some("non_academic"));
+    }
+
+    #[test]
+    fn sync_skips_refs_with_empty_authors() {
+        // compute_fp_identity returns None when authors are missing,
+        // so those refs cannot be cached — they were session-local
+        // even on the live path. Just confirm we don't panic and skip them.
+        let (_dir, cache) = temp_cache();
+        let mut refs = vec![ref_with("No Authors Paper", &[], Some(FpReason::KnownGood))];
+        sync_fp_overrides_with_cache(&mut refs, &cache);
+        // No identity key → nothing to assert beyond "did not crash".
     }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/update.rs
@@ -1699,4 +1699,156 @@ mod propagation_tests {
         assert_eq!(n, 0, "empty-authors ref is not a match");
         assert!(ref_states[1][0].fp_reason.is_none());
     }
+
+    /// End-to-end version of `space_after_json_load_writes_to_cache`:
+    /// constructs a real App, populates it from a loaded JSON report,
+    /// fires the actual `Action::ToggleSafe` via `app.update`, and asserts
+    /// the cache was written. The unit-level reproducer below tests the
+    /// inner helper in isolation; this one routes through the same Space
+    /// dispatch path the user hits, so any drift between the two paths
+    /// (cache not opened, screen-specific routing, propagation clobbers,
+    /// …) would surface here.
+    #[test]
+    fn space_via_app_after_json_load_writes_to_cache() {
+        use super::super::App;
+        use super::super::Screen;
+        use crate::action::Action;
+        use crate::load::load_results_file;
+        use crate::theme::Theme;
+        use std::io::Write;
+
+        let json = r#"[
+  {
+    "filename": "fixture.pdf",
+    "verdict": "safe",
+    "stats": {"total": 1, "skipped": 0},
+    "references": [
+      {
+        "index": 0,
+        "original_number": 1,
+        "title": "Attention Is All You Need",
+        "raw_citation": "Vaswani et al. 2017",
+        "status": "verified",
+        "effective_status": "verified",
+        "url_check_skipped": false,
+        "fp_reason": null,
+        "source": "arxiv",
+        "ref_authors": ["Ashish Vaswani", "Noam Shazeer"],
+        "found_authors": ["Ashish Vaswani", "Noam Shazeer"],
+        "paper_url": "https://arxiv.org/abs/1706.03762",
+        "failed_dbs": [],
+        "doi_info": null,
+        "arxiv_info": null,
+        "retraction_info": null,
+        "db_results": []
+      }
+    ]
+  }
+]"#;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let json_path = dir.path().join("fixture.json");
+        std::fs::File::create(&json_path)
+            .and_then(|mut f| f.write_all(json.as_bytes()))
+            .expect("write json");
+        let cache_path = dir.path().join("cache.db");
+
+        let mut app = App::new(vec![], Theme::hacker());
+        app.config_state.cache_path = cache_path.to_string_lossy().into_owned();
+        // Mirror main.rs:587-589 — eagerly open the cache so the Space
+        // handler finds it on the App.
+        app.get_or_build_query_cache();
+
+        let loaded = load_results_file(&json_path).expect("load");
+        let first_idx = app.papers.len();
+        for (paper, refs) in loaded {
+            app.papers.push(paper);
+            app.ref_states.push(refs);
+            app.file_paths.push(std::path::PathBuf::new());
+        }
+        app.sync_loaded_fp_overrides(first_idx);
+        app.recompute_sorted_indices();
+
+        // Simulate the user navigating to the paper and pressing Space.
+        app.screen = Screen::Paper(0);
+        app.paper_cursor = 0;
+        app.update(Action::ToggleSafe);
+
+        let cache = app.current_query_cache.as_ref().expect("cache opened");
+        let key = hallucinator_core::cache::compute_fp_identity(
+            "Attention Is All You Need",
+            &["Ashish Vaswani".into(), "Noam Shazeer".into()],
+        )
+        .expect("identity");
+        assert_eq!(
+            cache.get_fp_override(&key).as_deref(),
+            Some("broken_parse"),
+            "Space on a JSON-loaded ref must update the cache via the App's Action::ToggleSafe path",
+        );
+    }
+
+    /// Regression: refs loaded from a JSON report should persist Space-mark
+    /// updates to the cache the same way live PDF refs do. Previously the
+    /// cache write went through, but the identity key produced from the
+    /// loaded RefState diverged from the key the next live PDF run would
+    /// compute, so the persisted override was unreachable on reload.
+    #[test]
+    fn space_after_json_load_writes_to_cache() {
+        use crate::load::load_results_file;
+        use std::io::Write;
+
+        // Minimal export-format JSON with a verified ref carrying authors.
+        let json = r#"[
+  {
+    "filename": "fixture.pdf",
+    "verdict": "safe",
+    "stats": {"total": 1, "skipped": 0},
+    "references": [
+      {
+        "index": 0,
+        "original_number": 1,
+        "title": "Attention Is All You Need",
+        "raw_citation": "Vaswani et al. 2017",
+        "status": "verified",
+        "effective_status": "verified",
+        "url_check_skipped": false,
+        "fp_reason": null,
+        "source": "arxiv",
+        "ref_authors": ["Ashish Vaswani", "Noam Shazeer"],
+        "found_authors": ["Ashish Vaswani", "Noam Shazeer"],
+        "paper_url": "https://arxiv.org/abs/1706.03762",
+        "failed_dbs": [],
+        "doi_info": null,
+        "arxiv_info": null,
+        "retraction_info": null,
+        "db_results": []
+      }
+    ]
+  }
+]"#;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let json_path = dir.path().join("fixture.json");
+        let mut f = std::fs::File::create(&json_path).expect("create json");
+        f.write_all(json.as_bytes()).expect("write json");
+        drop(f);
+
+        let loaded = load_results_file(&json_path).expect("load");
+        let (paper, refs) = loaded.into_iter().next().expect("one paper");
+        let mut papers = vec![paper];
+        let mut ref_states = vec![refs];
+
+        let cache_path = dir.path().join("cache.db");
+        let cache = hallucinator_core::build_query_cache(Some(&cache_path), 60, 60);
+
+        // Simulate Space on the loaded ref.
+        let (origin_identity, new_fp) =
+            cycle_fp_reason_and_adjust_stats(&mut papers, &mut ref_states, 0, 0, Some(&cache));
+
+        let key = origin_identity.expect("identity key built from loaded title+authors");
+        assert_eq!(new_fp, Some(FpReason::BrokenParse));
+        assert_eq!(
+            cache.get_fp_override(&key).as_deref(),
+            Some("broken_parse"),
+            "Space-mark on a JSON-loaded ref must write through to the cache",
+        );
+    }
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -596,11 +596,13 @@ async fn main() -> anyhow::Result<()> {
         match load::load_results_file(load_path) {
             Ok(loaded) => {
                 let count = loaded.len();
+                let first_idx = app.papers.len();
                 for (paper, refs) in loaded {
                     app.papers.push(paper);
                     app.ref_states.push(refs);
                     app.file_paths.push(PathBuf::new()); // placeholder
                 }
+                app.sync_loaded_fp_overrides(first_idx);
                 app.batch_complete = true;
                 app.processing_started = true;
                 app.recompute_sorted_indices();


### PR DESCRIPTION
Seven independent validation/parsing-correctness fixes that surfaced while running the tool against the USENIX 2026 corpus and the user's marked-safe broken_parse audits. Each fix is in its own commit.

## 1. Fold non-decomposable Latin letters in author/title normalization (`c4c0709`)
`strip_diacritics` and `normalize_title` ran NFKD then filtered to ASCII. NFKD only decomposes base + combining-mark pairs (ä → a + ¨); atomic letters like **ß, ı, ø, æ, œ, ł, đ, ð, þ, ħ** survive NFKD and were dropped by the ASCII filter. "Müßig" became `"Mig"` and "Adıgüzel" became `"Adgzel"`. Fix: a `fold_special_letters` helper applied before NFKD in both paths.

## 2. Sync FP overrides between cache and JSON-loaded refs (`7bb783b`)
PDF runs reconcile both directions (`backend.rs` reads `cache.get_fp_override` per ref, Space handler writes back). The JSON-load path had no equivalent read, so:
- (A) Pre-marked refs in a JSON file never seeded the cache → marks were session-local.
- (B) Space-marks made on a JSON-loaded ref wrote to the cache, but reopening the JSON read `fp_reason: null` from disk → marks appeared lost.

Fix: `sync_fp_overrides_with_cache` reconciles each loaded ref. Cache wins over JSON when both have a value; cache miss + JSON has reason → seeds cache.

## 3. Reject author overlap when the citation pads in phantom co-authors (`4a7c4c7`)
`validate_authors` returned `true` whenever ref/found author lists intersected on at least one surname. Padded citations (e.g. AI-hallucinated bibliographies that take a real paper and add fake co-authors) still passed because the genuine authors overlap. Concrete failure: `sec26_prepub_kabir.pdf` ref 36 cites the real USENIX 2022 "Are Your Sensitive Attributes Private?" (5 authors) but lists 10+ authors, padding in 5 famous security researchers who never co-authored that paper.

Fix: phantom-author guard — when DB returns ≥3 authors and ref lists more, count surnames in ref not in DB record. Trip when 3+ phantom surnames AND >25% of citation. Skipped when DB has <3 authors or ref ≤ found.

## 4. Filter non-reference segments after segmentation (`727739f`)
The references-section detector ends at hardcoded appendix-title keywords. When papers have appendices titled differently (`Hy2`, `Theorem 4`, `Datasets.`, `KP-ABS with Type-III pairings`, `Figure 9 illustrates…`), the detector runs past them and the segmenter chunks the trailing body text into pseudo-references. 13/155 papers in the USENIX 2026 corpus affected, worst cases (`li-weihan`, `zhu-chengcheng`, `tu`) had 9–10 spurious "refs" each.

Fix: `looks_like_reference` filter applied after segmentation. Drops segments starting with punctuation (column-break artifacts) and segments ≥100 chars lacking any year, DOI, arXiv ID, URL, or venue keyword (body text). Short legitimate refs (RFC numbers, GitHub URLs, ISO standards) are exempt.

## 5. Recognise system-name-prefixed titles in sentence splitting (`c15b4cc`)
CS references commonly title their paper as `<system>: <subtitle>` where the system name is lowercase, mixed-case, or contains digits/hyphens — `eedtls:`, `mixup:`, `iSpy:`, `idlg:`, `vRAM:` — or wraps a BibTeX-protected acronym `{PRSA}:` / `{FLAME}:`. The sentence splitter required the next word after a period to start with an uppercase letter, dropping all of these and letting `clean_title` truncate at the last author surname's period (titles became `"Chandrakasan"`, `"Wang"`, `"Dragoni"`, `"Ji"`).

Fix: two coordinated regex tweaks — a lowercase-guard escape hatch for `system_token: title` shape, and an AUTHOR_AFTER pattern recognising `Surname. system_token: title` so the period after the initial isn't broken. Both accept plain CS tokens AND brace-wrapped acronyms.

## 6. Extend system-colon extraction to et-al and ACM-year-mid-cite (`563f790`)
Two follow-on shapes from the v3 broken_parse audit:
- `et al. {FLAME}:` — the "al." mid-sentence-abbrev path checked the *first character* after the period; with `{` as that char the boundary check failed. Switch to first *alphabetic* char.
- `Marco Casagrande et al. CTRAPS: ... Dec. 2024. DOI: ...` — `try_acm_year` matched the mid-citation date and extracted `"DOI:..."` as the title. `clean_title` emptied it but the format chain had already short-circuited. `try_acm_year` now bails on identifier-prefixed extractions so the chain falls through.

## 7. Dehyphenate PDF-line-break system-name titles (`4006701`)
Crump ref 16 (USENIX 2026): cited title is "Stack-guard: automatic adaptive detection..." but the real paper is **StackGuard** (NDSS 1998), single-token. PDF typesetter broke the line at `Stack-\nguard`. `fix_hyphenation` is dictionary-based and conservative — "stackguard" isn't a standard English word, so the hyphen stays. The FTS5 unicode61 tokenizer (DBLP / arXiv / IACR offline indexes) splits the cited form into `["stack", "guard"]`, neither of which matches the indexed `stackguard` token. Validator returns `not_found` against a real, well-known paper.

Fix: targeted dehyphenation in `clean_title_with_config` for titles matching `[A-Z][a-z]+-[a-z]+:` (capital + lowercase + colon — system-name shape), guarded by an English-compound-prefix exclusion list (`Pre-`, `Post-`, `Multi-`, `Anti-`, `Sub-`, `Non-`, `Pseudo-`, `Meta-`, …) so legitimate compounds aren't clobbered. Bonus: a pre-existing test on `"Sanc-tuary:"` was documenting broken behavior — that's also a PDF line break of "Sanctuary" (NDSS 2019). Test updated.

## Verification

| Check | Result |
|-------|--------|
| `cargo test --workspace` | 0 failures, 0 panics. New tests: 5 special-letter, 4 JSON-sync, 3 phantom-author, 10 segment-filter, 9 system-colon, 2 system-name-dehyphenation |
| 13 v3 system-colon broken_parse refs | 13/13 extract correctly |
| Compound-prefix titles (Pre-training, Multi-modal, Post-quantum) | Hyphens preserved |
| Mid-title hyphens (`buffer-overflow`) | Untouched |

## Test plan
- [ ] Author matching: load any PDF whose refs include authors with ß / ı / ø — confirm previously-mismatched entries now verify.
- [ ] JSON cache round-trip: load JSON → press Space on a ref → quit. Reopen the same JSON → mark appears automatically.
- [ ] Phantom-author guard: `sec26_prepub_kabir.pdf` ref 36 should now flag as author mismatch.
- [ ] Segment filter: `li-weihan`, `zhu-chengcheng`, `tu`, `fan`, `chen-liqun`, `jia`, `dellepere`, `baweja` from USENIX 2026 — body-text "refs" should no longer appear.
- [ ] System-colon titles: refs like `mixup:`, `iSpy:`, `eedtls:`, `{PRSA}:` should now extract the full title.
- [ ] Stack-guard: `sec26_prepub_crump.pdf` ref 16 should now verify against DBLP (title sent as "Stackguard" matches indexed `stackguard` token).
- [ ] No false-negatives on legitimate edges: `EUROCRYPT '24`, GitHub URLs, RFC numbers, `Pre-training:` compounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)