### PR TITLE
HTML export: render url_check_skipped refs as Skipped, not Not Found

### DIFF
--- a/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
+++ b/hallucinator-rs/crates/hallucinator-reporting/src/export.rs
@@ -83,6 +83,13 @@ fn export_sort_key(r: &ValidationResult, fp: Option<FpReason>) -> u8 {
     if is_retracted(r) {
         return 0;
     }
+    // URL-gated NotFound refs are effectively skipped; group them with
+    // clean verified (5) rather than with the not-found bucket so they
+    // sort to the bottom of the per-paper section instead of cluttering
+    // the problems area with non-issues.
+    if r.url_check_skipped {
+        return 5;
+    }
     match r.status {
         Status::NotFound => 1,
         Status::Mismatch(_) => 2,
@@ -1022,6 +1029,7 @@ summary:hover { background: var(--card); border-radius: 8px; }
 .badge.not-found { background: var(--red); color: #fff; }
 .badge.mismatch { background: var(--yellow); color: #000; }
 .badge.retracted { background: var(--dark-red); color: #fff; }
+.badge.skipped { background: var(--dim); color: #fff; }
 .ref-detail {
   font-size: 0.9rem;
   color: var(--dim);
@@ -1261,6 +1269,15 @@ fn write_html_ref(out: &mut String, ref_num: usize, r: &ValidationResult, fp: Op
         ("verified".to_string(), "Verified".to_string())
     } else if retracted {
         ("retracted".to_string(), "RETRACTED".to_string())
+    } else if r.url_check_skipped {
+        // Mirror `effective_status_str`: a NotFound ref whose only
+        // remaining signal would have come from URL Check / Wayback was
+        // gated by `--url-match` and is effectively skipped, not a
+        // genuine "not found". The JSON export already collapses these
+        // to "skipped" via `effective_status`; the HTML must follow
+        // suit so users don't see hundreds of bogus "Not Found" badges
+        // for URL-only references they explicitly opted out of probing.
+        ("skipped".to_string(), "Skipped".to_string())
     } else {
         match &r.status {
             Status::Verified => ("verified".to_string(), "Verified".to_string()),
@@ -2035,6 +2052,85 @@ mod tests {
         assert!(out.contains("<!DOCTYPE html>"));
         assert!(out.contains("stat-card"));
         assert!(out.contains("</html>"));
+    }
+
+    #[test]
+    fn test_html_url_check_skipped_renders_as_skipped() {
+        // User report: "many references that are marked as safe still
+        // show as 'not found' in the report". Root cause: `write_html_ref`
+        // ignored `r.url_check_skipped` and rendered the underlying
+        // Status::NotFound, even though the JSON's `effective_status`
+        // collapses these to "skipped". Live in-memory state (a fresh
+        // PDF run with --url-match disabled) keeps Status=NotFound +
+        // url_check_skipped=true; HTML must follow the JSON convention
+        // and show these as Skipped, not Not Found.
+        let stats = CheckStats {
+            total: 2,
+            not_found: 1,
+            skipped: 1,
+            ..Default::default()
+        };
+        let mut url_gated = make_result("Github URL Ref", Status::NotFound);
+        url_gated.url_check_skipped = true;
+        let plain_nf = make_result("Real Hallucination", Status::NotFound);
+        let results = vec![Some(url_gated), Some(plain_nf)];
+        let paper = make_paper("test.pdf", &stats, &results);
+        let refs = vec![
+            make_ref(0, "Github URL Ref"),
+            make_ref(1, "Real Hallucination"),
+        ];
+        let ref_slices: &[&[ReportRef]] = &[&refs];
+        let out = export_html(&[paper], ref_slices, false);
+
+        // The url_check_skipped ref renders as "Skipped" badge.
+        let url_idx = out.find("Github URL Ref").expect("title in HTML");
+        let url_end = (url_idx + 800).min(out.len());
+        let url_card = &out[url_idx..url_end];
+        assert!(
+            url_card.contains("badge skipped\">Skipped</span>"),
+            "URL-gated ref should render as Skipped"
+        );
+        assert!(
+            !url_card.contains("badge not-found\">Not Found</span>"),
+            "URL-gated ref must NOT render as Not Found"
+        );
+
+        // The plain not-found ref still renders as Not Found.
+        let plain_idx = out.find("Real Hallucination").expect("title in HTML");
+        let plain_end = (plain_idx + 800).min(out.len());
+        let plain_card = &out[plain_idx..plain_end];
+        assert!(
+            plain_card.contains("badge not-found\">Not Found</span>"),
+            "Real not-found ref must still render Not Found"
+        );
+    }
+
+    #[test]
+    fn test_html_fp_marked_ref_shows_as_verified() {
+        // User reports: "many references that are marked as safe still
+        // show as 'not found' in the report". Reproduce by exporting a
+        // NotFound ref that has fp_reason set — the badge must show as
+        // "Verified", not "Not Found".
+        let stats = CheckStats {
+            total: 1,
+            not_found: 1,
+            ..Default::default()
+        };
+        let results = vec![Some(make_result("Marked Safe NF", Status::NotFound))];
+        let paper = make_paper("test.pdf", &stats, &results);
+        let refs = vec![make_ref_fp(0, "Marked Safe NF", FpReason::BrokenParse)];
+        let ref_slices: &[&[ReportRef]] = &[&refs];
+        let out = export_html(&[paper], ref_slices, false);
+
+        // The ref's badge should be "Verified" — NOT "Not Found".
+        assert!(
+            out.contains("Marked Safe NF"),
+            "ref title should appear in HTML"
+        );
+        assert!(
+            !out.contains("badge not-found\">Not Found</span>"),
+            "FP-marked ref must not render with the Not Found badge"
+        );
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-tui/src/load.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/load.rs
@@ -390,3 +390,173 @@ pub fn load_results_file(path: &Path) -> Result<Vec<(PaperState, Vec<RefState>)>
 
     Ok(loaded_files.into_iter().map(convert_loaded).collect())
 }
+
+#[cfg(test)]
+mod export_regression_tests {
+    use super::*;
+    use hallucinator_reporting::{ExportFormat, ReportPaper, ReportRef, SkipInfo, export_results};
+    use std::io::Write;
+
+    /// Synthetic-fixture version of the regression test for CI / fresh
+    /// checkouts that don't have the v3 JSON.
+    #[test]
+    fn html_export_after_json_load_marks_fp_refs_as_verified() {
+        // Minimal JSON in severity-sorted order (not_found ref first,
+        // even though its original_number is 3) — the same shape as
+        // usenix2026-v3.json.
+        let json = r#"[
+  {
+    "filename": "fixture.pdf",
+    "verdict": null,
+    "stats": {"total": 3, "skipped": 0},
+    "references": [
+      {
+        "index": 2,
+        "original_number": 3,
+        "title": "Marked Safe Paper",
+        "raw_citation": "Some Author. Marked Safe Paper. 2024",
+        "status": "not_found",
+        "effective_status": "not_found",
+        "url_check_skipped": false,
+        "fp_reason": "non_academic",
+        "source": null,
+        "ref_authors": ["Some Author"],
+        "found_authors": [],
+        "paper_url": null,
+        "failed_dbs": [],
+        "doi_info": null,
+        "arxiv_info": null,
+        "retraction_info": null,
+        "db_results": []
+      },
+      {
+        "index": 0,
+        "original_number": 1,
+        "title": "Verified Paper",
+        "raw_citation": "Author 1. Verified Paper. 2024",
+        "status": "verified",
+        "effective_status": "verified",
+        "url_check_skipped": false,
+        "fp_reason": null,
+        "source": "arxiv",
+        "ref_authors": ["Author 1"],
+        "found_authors": ["Author 1"],
+        "paper_url": "https://arxiv.org/abs/0001",
+        "failed_dbs": [],
+        "doi_info": null,
+        "arxiv_info": null,
+        "retraction_info": null,
+        "db_results": []
+      },
+      {
+        "index": 1,
+        "original_number": 2,
+        "title": "Plain Not Found",
+        "raw_citation": "Author 2. Plain Not Found. 2024",
+        "status": "not_found",
+        "effective_status": "not_found",
+        "url_check_skipped": false,
+        "fp_reason": null,
+        "source": null,
+        "ref_authors": ["Author 2"],
+        "found_authors": [],
+        "paper_url": null,
+        "failed_dbs": [],
+        "doi_info": null,
+        "arxiv_info": null,
+        "retraction_info": null,
+        "db_results": []
+      }
+    ]
+  }
+]"#;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let json_path = dir.path().join("fixture.json");
+        std::fs::File::create(&json_path)
+            .and_then(|mut f| f.write_all(json.as_bytes()))
+            .expect("write json");
+
+        let loaded = load_results_file(&json_path).expect("load");
+        assert_eq!(loaded.len(), 1);
+        let (paper, ref_states) = &loaded[0];
+
+        // Build the export structures EXACTLY the way app/update.rs does.
+        let results_vec: Vec<Option<hallucinator_core::ValidationResult>> =
+            ref_states.iter().map(|rs| rs.result.clone()).collect();
+        let report_paper = ReportPaper {
+            filename: &paper.filename,
+            stats: &paper.stats,
+            results: &results_vec,
+            verdict: paper.verdict,
+        };
+        let report_refs: Vec<ReportRef> = ref_states
+            .iter()
+            .map(|rs| ReportRef {
+                index: rs.index,
+                title: rs.title.clone(),
+                skip_info: if let RefPhase::Skipped(reason) = &rs.phase {
+                    Some(SkipInfo {
+                        reason: reason.clone(),
+                    })
+                } else {
+                    None
+                },
+                fp_reason: rs.fp_reason,
+            })
+            .collect();
+        let ref_slices: &[&[ReportRef]] = &[&report_refs];
+
+        let html_path = dir.path().join("fixture.html");
+        export_results(
+            &[report_paper],
+            ref_slices,
+            ExportFormat::Html,
+            &html_path,
+            false,
+        )
+        .expect("export html");
+
+        let html = std::fs::read_to_string(&html_path).expect("read html");
+
+        // The FP-marked ref ("Marked Safe Paper") MUST show as Verified
+        // — its badge cannot be "Not Found". The ref-card spans from
+        // an opening `<div class="ref-card" data-status="...">` through
+        // a closing `</div>` matched at the same depth. Slice between
+        // the title and the next ref-card to get this card's body.
+        let marked_idx = html
+            .find("Marked Safe Paper")
+            .expect("FP-marked ref title should appear in HTML");
+        let after_title = &html[marked_idx..];
+        // The next ref-card or the end of the papers block bounds us.
+        let card_end = after_title
+            .find("<div class=\"ref-card\"")
+            .or_else(|| after_title.find("</div>\n</details>"))
+            .unwrap_or(after_title.len());
+        let card = &after_title[..card_end];
+        assert!(
+            !card.contains("badge not-found"),
+            "FP-marked ref's badge is 'not-found' — bug reproduced. Card body:\n{card}"
+        );
+        assert!(
+            card.contains("badge verified"),
+            "FP-marked ref's badge should be 'verified'. Card body:\n{card}"
+        );
+
+        // Sanity: the unmarked NotFound ref ("Plain Not Found") MUST
+        // still render with the not-found badge — we shouldn't have
+        // accidentally promoted everything.
+        let plain_idx = html
+            .find("Plain Not Found")
+            .expect("Plain not-found title should appear in HTML");
+        let plain_after = &html[plain_idx..];
+        let plain_end = plain_after
+            .find("<div class=\"ref-card\"")
+            .or_else(|| plain_after.find("</div>\n</details>"))
+            .unwrap_or(plain_after.len());
+        let plain_card = &plain_after[..plain_end];
+        assert!(
+            plain_card.contains("badge not-found"),
+            "Unmarked NotFound ref must still render the not-found badge"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
User report: "many references that are marked as safe still show as 'not found' in the report" when exporting to HTML.

**Diagnostic comparing `hallucinator-results.json` against `hallucinator-results.html` (4 papers, generated together from a TUI export):**

| Metric | JSON | HTML | Expected |
|--------|------|------|----------|
| `status="not_found"` total | 13 | — | — |
| `not_found` WITH `fp_reason` (→ should render as Verified) | 11 | — | 0 Not Found badges |
| `not_found` plain (genuine hallucinations) | 2 | — | 2 Not Found badges |
| `url_check_skipped=true` (→ should render as Skipped) | 65 | — | 0 Not Found badges |
| `badge not-found">Not Found</span>` instances in HTML | — | **67** | 2 |

→ ~65 URL-gated refs leaked through with the Not Found badge.

## Root cause
`write_html_ref` reads `r.status` (the raw `Status` enum, which only has Verified/NotFound/Mismatch) and ignored `r.url_check_skipped`. The JSON export already collapses URL-gated refs to `"skipped"` via `effective_status_str`, but the HTML path skipped that step, so a NotFound ref the user explicitly opted out of probing (`--url-match` disabled, no DB hit) rendered as a genuine "Not Found" alongside actual hallucinations.

## Fix
Two coordinated changes in `hallucinator-reporting/src/export.rs`:

1. **`write_html_ref` badge**: insert a `r.url_check_skipped` branch between the retracted check and the status match, returning `("skipped", "Skipped")`. Mirrors the JSON's `effective_status_str` so both formats stay consistent. Added `.badge.skipped` CSS rule (dim-grey background) for the new badge class.

2. **`export_sort_key`**: bump `url_check_skipped` refs to the verified bucket (5) instead of leaving them at NotFound (1). They now sort to the bottom of the per-paper section alongside clean verified refs rather than cluttering the problems area.

The behavior change matches what `effective_status` already documents in JSON: URL-gated NotFound is *not* a hallucination, just a reference the user chose not to probe.

## Tests
- New `test_html_url_check_skipped_renders_as_skipped` in `export.rs`: asserts a `url_check_skipped + Status::NotFound` ref renders as Skipped (not Not Found) while a plain `Status::NotFound` ref still renders as Not Found.
- New synthetic load+export test in `load.rs`: walks the full TUI pipeline (`load_results_file` → `export_results(Html)`) on a fixture mimicking severity-sorted JSON, verifies FP-marked refs render with the Verified badge.
- `cargo test --workspace`: 0 failures across all crates.

## Test plan
- [ ] Re-export `hallucinator-results.html` from the TUI on the same data; the bad "Not Found" badges should drop from 67 to 2.
- [ ] Sanity: verified refs unchanged, FP-marked refs still show as Verified, retracted refs unchanged, real not-found refs still show as Not Found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)