### PR TITLE
Phantom-author guard: drop "found.len() >= 3" floor to catch padded citations against incomplete DB records

### DIFF
--- a/hallucinator-rs/crates/hallucinator-core/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/authors.rs
@@ -149,20 +149,26 @@ pub fn validate_authors(ref_authors: &[String], found_authors: &[String]) -> boo
         }
         false
     } else {
-        // Phantom-author guard — when the DB returned a substantial
-        // author list and the citation lists noticeably more authors,
-        // count the surnames in the citation that don't appear in the
-        // DB record. A few unmatched names are tolerable (typos,
-        // unusual transliterations), but a citation that pads several
-        // unrelated names onto a real paper's author list — common
-        // for AI-hallucinated bibliographies that splice famous co-
-        // authors onto an existing title — should be flagged as a
-        // mismatch even though the genuine authors still overlap.
+        // Phantom-author guard — when the citation lists noticeably
+        // more authors than the DB record, count the surnames in the
+        // citation that don't appear in the DB record. A few unmatched
+        // names are tolerable (typos, unusual transliterations), but a
+        // citation that pads several unrelated names onto a real
+        // paper's author list — common for AI-hallucinated
+        // bibliographies that splice famous co-authors onto an existing
+        // title — should be flagged as a mismatch even though the
+        // genuine authors still overlap. Skipped when ref ≤ found (the
+        // et-al-truncation case is handled below).
         //
-        // Skip when found has <3 authors (some sources truncate, so
-        // "extra" doesn't necessarily mean "fabricated") or when ref
-        // ≤ found (the et-al-truncation case is handled below).
-        if found_authors.len() >= 3 && ref_authors.len() > found_authors.len() {
+        // We don't gate on `found.len() >= 3` like a more conservative
+        // guard would: some DB records are themselves incomplete
+        // (DBLP's StackGuard entry has just 1 author of the real 10,
+        // and citations with 9 phantoms vs that single hit are common
+        // padded-citation patterns). Trusting DB completeness here
+        // would hand a "verified" stamp to citations whose author list
+        // bears no resemblance to the indexed paper. Better to flag
+        // and let the user mark safe than to silently approve.
+        if ref_authors.len() > found_authors.len() {
             let found_surnames_for_phantom: HashSet<String> = found_authors
                 .iter()
                 .filter_map(|a| {
@@ -729,19 +735,31 @@ mod tests {
     }
 
     #[test]
-    fn test_phantom_authors_skipped_for_small_found() {
-        // When the DB returns only 1-2 authors, "extras" in the citation
-        // could just be a truncated DB response, not fabrication. The
-        // guard must not fire below the 3-author floor.
-        assert!(validate_authors(
+    fn test_phantom_authors_fires_even_with_small_found() {
+        // Real failure: DBLP's StackGuard (USENIX 1998) entry has only
+        // one author indexed (Crispan Cowan) although the actual paper
+        // has 10. A padded citation (10 ref authors, 1 DBLP author, 9
+        // surnames not matching the lone DB author) used to pass the
+        // standard intersection because the phantom guard was gated on
+        // `found.len() >= 3` — DB-completeness is too generous a
+        // benefit-of-the-doubt when the citation/DB skew is this
+        // extreme. The guard now fires regardless of DB size, so
+        // citations that don't match the indexed author list (whatever
+        // its size) are flagged as mismatches.
+        assert!(!validate_authors(
             &s(&[
-                "Alice Author",
-                "Bob Author",
-                "Carol Phantom",
-                "Dave Phantom",
-                "Eve Phantom",
+                "Crispan Cowan",
+                "Calton Pu",
+                "Dave Maier",
+                "Heather Hintony",
+                "Jonathan Walpole",
+                "Peat Bakke",
+                "Steve Beattie",
+                "Aaron Grier",
+                "Perry Wagle",
+                "Qian Zhang",
             ]),
-            &s(&["Alice Author", "Bob Author"]),
+            &s(&["Crispan Cowan"]),
         ));
     }
 


### PR DESCRIPTION
## Summary
User report: the StackGuard reference (Crump ref 16 in usenix2026 corpus) is now marked as **verified** after the recent search-side fixes (PR #282), but the citation has several fabricated authors and should be flagged as a mismatch.

## Diagnostic
DBLP's offline DB has just **one** author indexed for the paper (`Crispan Cowan`), though the real 1998 USENIX paper has ~10. The previous phantom-author guard (introduced in #280) explicitly skipped when DB had fewer than 3 authors, on the theory that "DB might be truncated and we can't tell extras from real":

```
ref:    [Cowan, Pu, Maier, Hintony, Walpole, Bakke, Beattie,
         Grier, Wagle, Zhang]                              (10 authors)
DBLP:   [Crispan Cowan]                                    ( 1 author)
phantoms: 9 (everyone except Cowan)

Old guard: found.len() < 3 → skip → standard intersection finds Cowan
           overlap → return true → "verified"
```

A 10-author citation overlapping a 1-author DB record on just the first surname slips through verification.

## Fix
Drop the `found.len() >= 3` floor. Let the existing absolute + percentage thresholds (`3+ phantom surnames AND >25% of citation`) fire regardless of DB size.

```
New guard: ref > found ✓
           phantoms = 9
           9 >= 3 ✓  AND  9*4 = 36 > 10 ✓
           → return false (mismatch)
```

The trade-off — false positives on legitimately-large-author papers when the DB has truncated data — is acceptable for an anti-hallucination tool. The user can mark the ref safe; silently approving a fabricated author list is the worse failure.

## Tests
- `test_phantom_authors_fires_even_with_small_found` (rewrite of the prior `_skipped_for_small_found` test that was documenting the now-removed floor): exercises the 10-vs-1 StackGuard shape, asserts `validate_authors` returns false.
- All other phantom-author tests still pass:
  - `test_phantom_authors_padded_citation_rejected` — 11 ref vs 5 DBLP, the kabir/ref-36 case
  - `test_phantom_authors_one_extra_still_passes` — one typo'd name, no false positive
- `cargo test --workspace`: 0 failures.

## Test plan
- [ ] Re-run on `sec26_prepub_crump.pdf`; ref 16 (StackGuard) should now flag as author mismatch instead of verified.
- [ ] Sanity: refs whose citations match the DB record's authors stay verified.
- [ ] No regression on the kabir/ref-36 phantom-author case (Are Your Sensitive Attributes Private?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)