### PR TITLE
Wire IACR ePrint offline backend into the TUI

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "hallucinator-bbl",
  "hallucinator-core",
  "hallucinator-dblp",
+ "hallucinator-iacr-eprint",
  "hallucinator-ingest",
  "hallucinator-openalex",
  "hallucinator-reporting",

--- a/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-tui/Cargo.toml
@@ -17,6 +17,7 @@ hallucinator-bbl.workspace = true
 hallucinator-dblp.workspace = true
 hallucinator-acl.workspace = true
 hallucinator-arxiv-offline.workspace = true
+hallucinator-iacr-eprint.workspace = true
 hallucinator-openalex.workspace = true
 hallucinator-reporting.workspace = true
 reqwest.workspace = true

--- a/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
@@ -271,12 +271,14 @@ impl App {
                 ))
             },
             arxiv_offline_db: None, // Populated from main.rs
-            // IACR ePrint has no TUI config field yet — main.rs
-            // populates the path from the config file / env and
-            // opens the DB handle there. Mirrors how the TUI treats
-            // the other offline paths that don't yet have UI toggles.
-            iacr_eprint_offline_path: None,
-            iacr_eprint_offline_db: None,
+            iacr_eprint_offline_path: if self.config_state.iacr_eprint_offline_path.is_empty() {
+                None
+            } else {
+                Some(std::path::PathBuf::from(
+                    &self.config_state.iacr_eprint_offline_path,
+                ))
+            },
+            iacr_eprint_offline_db: None, // Populated from main.rs
             openalex_offline_path: if self.config_state.openalex_offline_path.is_empty() {
                 None
             } else {

--- a/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
@@ -378,6 +378,24 @@ pub fn open_arxiv_db(
     Ok(Arc::new(Mutex::new(db)))
 }
 
+/// Open offline IACR Cryptology ePrint Archive database, returning the
+/// `Arc<Mutex<..>>` handle. The archive has no online search API, so
+/// without this local index the IACR backend never registers.
+pub fn open_iacr_eprint_db(
+    path: &std::path::Path,
+) -> anyhow::Result<Arc<Mutex<hallucinator_iacr_eprint::IacrDatabase>>> {
+    if !path.exists() {
+        anyhow::bail!(
+            "Offline IACR ePrint database not found at {}. Build it with `hallucinator-cli update-iacr-eprint {}`.",
+            path.display(),
+            path.display(),
+        );
+    }
+    let db =
+        hallucinator_iacr_eprint::IacrDatabase::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
+    Ok(Arc::new(Mutex::new(db)))
+}
+
 /// Open offline OpenAlex Tantivy index if a path is configured, returning the Arc<Mutex<..>> handle.
 pub fn open_openalex_db(
     path: &std::path::Path,

--- a/hallucinator-rs/crates/hallucinator-tui/src/config_file.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/config_file.rs
@@ -43,6 +43,11 @@ pub fn apply_to_config_state(file_cfg: &ConfigFile, state: &mut ConfigState) {
         {
             state.acl_offline_path = path.clone();
         }
+        if let Some(ref path) = db.iacr_eprint_offline_path
+            && !path.is_empty()
+        {
+            state.iacr_eprint_offline_path = path.clone();
+        }
         if let Some(ref path) = db.openalex_offline_path
             && !path.is_empty()
         {
@@ -148,10 +153,11 @@ pub fn from_config_state(state: &ConfigState) -> ConfigFile {
             } else {
                 Some(state.arxiv_offline_path.clone())
             },
-            // TUI doesn't expose iacr_eprint yet — serialize `None`
-            // so round-tripping a TUI-saved config doesn't drop the
-            // field if main.rs loaded it from the file originally.
-            iacr_eprint_offline_path: None,
+            iacr_eprint_offline_path: if state.iacr_eprint_offline_path.is_empty() {
+                None
+            } else {
+                Some(state.iacr_eprint_offline_path.clone())
+            },
             openalex_offline_path: if state.openalex_offline_path.is_empty() {
                 None
             } else {
@@ -251,6 +257,34 @@ mod tests {
         let state = ConfigState::default();
         let file_cfg = from_config_state(&state);
         assert!(file_cfg.databases.unwrap().cache_path.is_none());
+    }
+
+    #[test]
+    fn iacr_eprint_offline_path_round_trip() {
+        // Round-trip: a path set in the file ends up on ConfigState,
+        // and a path set on ConfigState ends up in the serialized
+        // file. Locks down the previous "TUI doesn't expose
+        // iacr_eprint" behavior where saving the TUI config silently
+        // dropped this field — see issue #289 follow-up.
+        let file_cfg = ConfigFile {
+            databases: Some(DatabasesConfig {
+                iacr_eprint_offline_path: Some("/data/iacr.db".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut state = ConfigState::default();
+        apply_to_config_state(&file_cfg, &mut state);
+        assert_eq!(state.iacr_eprint_offline_path, "/data/iacr.db");
+
+        let written = from_config_state(&state);
+        assert_eq!(
+            written
+                .databases
+                .and_then(|d| d.iacr_eprint_offline_path)
+                .as_deref(),
+            Some("/data/iacr.db"),
+        );
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -67,6 +67,11 @@ struct Cli {
     #[arg(long)]
     arxiv_offline: Option<PathBuf>,
 
+    /// Path to offline IACR Cryptology ePrint Archive database
+    /// (build with `hallucinator-cli update-iacr-eprint`).
+    #[arg(long)]
+    iacr_eprint_offline: Option<PathBuf>,
+
     /// Path to offline OpenAlex Tantivy index
     #[arg(long)]
     openalex_offline: Option<PathBuf>,
@@ -209,6 +214,11 @@ async fn main() -> anyhow::Result<()> {
     {
         config_state.acl_offline_path = path;
     }
+    if let Ok(path) = std::env::var("IACR_EPRINT_OFFLINE_PATH")
+        && !path.is_empty()
+    {
+        config_state.iacr_eprint_offline_path = path;
+    }
     if let Ok(path) = std::env::var("OPENALEX_OFFLINE_PATH")
         && !path.is_empty()
     {
@@ -243,6 +253,9 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(ref path) = cli.arxiv_offline {
         config_state.arxiv_offline_path = path.display().to_string();
+    }
+    if let Some(ref path) = cli.iacr_eprint_offline {
+        config_state.iacr_eprint_offline_path = path.display().to_string();
     }
     if let Some(ref path) = cli.openalex_offline {
         config_state.openalex_offline_path = path.display().to_string();
@@ -319,6 +332,23 @@ async fn main() -> anyhow::Result<()> {
         for candidate in &candidates {
             if candidate.exists() {
                 config_state.arxiv_offline_path = candidate.display().to_string();
+                break;
+            }
+        }
+    }
+
+    // Auto-detect default IACR ePrint DB if no explicit path configured
+    if config_state.iacr_eprint_offline_path.is_empty() {
+        let candidates = [
+            PathBuf::from("iacr.db"),
+            dirs::data_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("hallucinator")
+                .join("iacr.db"),
+        ];
+        for candidate in &candidates {
+            if candidate.exists() {
+                config_state.iacr_eprint_offline_path = candidate.display().to_string();
                 break;
             }
         }
@@ -404,6 +434,33 @@ async fn main() -> anyhow::Result<()> {
             match backend::open_arxiv_db(path) {
                 Ok(db) => {
                     startup_info.push(format!("arXiv offline DB loaded: {}", path.display()));
+                    Some(db)
+                }
+                Err(e) => {
+                    startup_warnings.push(format!("{e}"));
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+    // Resolve IACR ePrint offline path from config state
+    let iacr_eprint_offline_path: Option<PathBuf> =
+        if config_state.iacr_eprint_offline_path.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(&config_state.iacr_eprint_offline_path))
+        };
+
+    // Open IACR ePrint database if configured. The archive has no
+    // online search API, so without a local index this backend never
+    // registers — non-fatal if missing or corrupt.
+    let iacr_eprint_offline_db: Option<Arc<Mutex<hallucinator_iacr_eprint::IacrDatabase>>> =
+        if let Some(ref path) = iacr_eprint_offline_path {
+            match backend::open_iacr_eprint_db(path) {
+                Ok(db) => {
+                    startup_info.push(format!("IACR ePrint offline DB loaded: {}", path.display()));
                     Some(db)
                 }
                 Err(e) => {
@@ -656,6 +713,8 @@ async fn main() -> anyhow::Result<()> {
     let mut cached_acl_db = acl_offline_db.clone();
     let mut cached_arxiv_path = arxiv_offline_path.clone();
     let mut cached_arxiv_db = arxiv_offline_db.clone();
+    let mut cached_iacr_eprint_path = iacr_eprint_offline_path.clone();
+    let mut cached_iacr_eprint_db = iacr_eprint_offline_db.clone();
     let mut cached_openalex_path = openalex_offline_path.clone();
     let mut cached_openalex_db = openalex_offline_db.clone();
     let check_openalex_authors = cli.check_openalex_authors;
@@ -703,6 +762,16 @@ async fn main() -> anyhow::Result<()> {
                         };
                     }
 
+                    // If user changed the IACR ePrint path in config, try to open the new DB
+                    if config.iacr_eprint_offline_path != cached_iacr_eprint_path {
+                        cached_iacr_eprint_path = config.iacr_eprint_offline_path.clone();
+                        cached_iacr_eprint_db = if let Some(ref path) = cached_iacr_eprint_path {
+                            backend::open_iacr_eprint_db(path).ok()
+                        } else {
+                            None
+                        };
+                    }
+
                     // If user changed the OpenAlex path in config, try to open the new index
                     if config.openalex_offline_path != cached_openalex_path {
                         cached_openalex_path = config.openalex_offline_path.clone();
@@ -719,6 +788,8 @@ async fn main() -> anyhow::Result<()> {
                     config.acl_offline_db = cached_acl_db.clone();
                     config.arxiv_offline_path = cached_arxiv_path.clone();
                     config.arxiv_offline_db = cached_arxiv_db.clone();
+                    config.iacr_eprint_offline_path = cached_iacr_eprint_path.clone();
+                    config.iacr_eprint_offline_db = cached_iacr_eprint_db.clone();
                     config.openalex_offline_path = cached_openalex_path.clone();
                     config.openalex_offline_db = cached_openalex_db.clone();
                     config.check_openalex_authors = check_openalex_authors;
@@ -743,6 +814,8 @@ async fn main() -> anyhow::Result<()> {
                     config.acl_offline_db = cached_acl_db.clone();
                     config.arxiv_offline_path = cached_arxiv_path.clone();
                     config.arxiv_offline_db = cached_arxiv_db.clone();
+                    config.iacr_eprint_offline_path = cached_iacr_eprint_path.clone();
+                    config.iacr_eprint_offline_db = cached_iacr_eprint_db.clone();
                     config.openalex_offline_path = cached_openalex_path.clone();
                     config.openalex_offline_db = cached_openalex_db.clone();
                     config.check_openalex_authors = check_openalex_authors;

--- a/hallucinator-rs/crates/hallucinator-tui/src/model/config.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/model/config.rs
@@ -75,6 +75,7 @@ pub struct ConfigState {
     pub dblp_offline_path: String,
     pub acl_offline_path: String,
     pub arxiv_offline_path: String,
+    pub iacr_eprint_offline_path: String,
     pub openalex_offline_path: String,
     pub cache_path: String,
     /// Inline status message for cache clear operation.
@@ -135,6 +136,7 @@ impl Default for ConfigState {
             dblp_offline_path: String::new(),
             acl_offline_path: String::new(),
             arxiv_offline_path: String::new(),
+            iacr_eprint_offline_path: String::new(),
             openalex_offline_path: String::new(),
             cache_path: String::new(),
             cache_clear_status: None,


### PR DESCRIPTION
## Summary
- Adds `--iacr-eprint-offline <PATH>` to the TUI binary.
- Wires the IACR ePrint backend through CLI flag → env var → config file → auto-detect, mirroring how arXiv / DBLP / ACL / OpenAlex already work.
- Until now the TUI silently ignored IACR ePrint: no flag, no Config-screen field, and `app/processing.rs::build_config` hard-coded `iacr_eprint_offline_path: None`. Setting `iacr_eprint_offline_path` in `.hallucinator.toml` was a no-op; saving the TUI config dropped the field.

## Changes
- `--iacr-eprint-offline` flag + `IACR_EPRINT_OFFLINE_PATH` env var.
- `ConfigState.iacr_eprint_offline_path` plus `apply_to_config_state` / `from_config_state` round-trip in `config_file.rs`.
- Auto-detect `iacr.db` in CWD or platform data dir.
- `backend::open_iacr_eprint_db` helper opens the SQLite DB; cached path + handle are injected into `Config` from the `ProcessFiles` and `RetryReferences` handlers in `main.rs`.
- `build_config` reads `iacr_eprint_offline_path` from `ConfigState`; the DB handle is populated by `main.rs` (same pattern as the other offline DBs).
- Building the index remains a CLI-only operation (`hallucinator-cli update-iacr-eprint <path>`), matching arXiv.

## Test plan
- [x] `cargo build -p hallucinator-tui` clean.
- [x] `cargo test --workspace` green (93 TUI tests, including new `iacr_eprint_offline_path_round_trip`).
- [x] `hallucinator-tui --help` shows the new flag with the right description.
- [ ] Manual: `hallucinator-cli update-iacr-eprint iacr.db` then `hallucinator-tui --iacr-eprint-offline iacr.db <pdf>` — confirm startup info "IACR ePrint offline DB loaded: …" appears and IACR queries fire on cryptology refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)