### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The tool queries these databases simultaneously:
 | **OpenAlex** | 250M+ works (online with free API key, or offline) |
 | **Open Library** | Books, technical reports, and non-academic publications |
 | **GovInfo** | US federal laws, regulations, court opinions (optional, needs free API key) |
+| **IACR ePrint** | Cryptology ePrint Archive (offline-only — no public search API) |
 | **URL Checker** | Liveness check for non-academic URLs like GitHub repos (fallback) |
 | **Web Search** | SearxNG metasearch fallback for unindexed papers (optional, see below) |
 
@@ -116,19 +117,21 @@ GovInfo covers Public Laws, Congressional Bills, Code of Federal Regulations (CF
 
 ## Offline Databases
 
-Four databases can be downloaded for local querying. Offline databases are faster than online APIs and avoid rate limits.
+Five databases can be downloaded for local querying. Offline databases are faster than online APIs and avoid rate limits.
 
 ```bash
-# Build all four (run once, refresh periodically)
+# Build all five (run once, refresh periodically)
 hallucinator-cli update-dblp dblp.db
 hallucinator-cli update-acl acl.db
 hallucinator-cli update-arxiv arxiv.db
+hallucinator-cli update-iacr-eprint iacr.db
 hallucinator-cli update-openalex openalex.idx
 
 # Use them
 hallucinator-cli check \
     --dblp-offline=dblp.db --acl-offline=acl.db \
-    --arxiv-offline=arxiv.db --openalex-offline=openalex.idx \
+    --arxiv-offline=arxiv.db --iacr-eprint-offline=iacr.db \
+    --openalex-offline=openalex.idx \
     paper.pdf
 ```
 
@@ -166,6 +169,22 @@ hallucinator-cli update-arxiv arxiv.db --dump /path/to/arxiv-metadata-oai-snapsh
 ```
 
 When `--arxiv-offline` is configured, the online arXiv backend is **replaced entirely** (same pattern as DBLP and ACL). The Kaggle snapshot carries only each paper's latest-version title — the rare retitled-paper edge case (reference cites an old title, paper was renamed in a later version) is not caught. Clear the offline DB config and re-run if you need that coverage.
+
+### IACR ePrint (cryptology papers)
+
+The [IACR Cryptology ePrint Archive](https://eprint.iacr.org/) has no public search API, so this backend is **offline-only** — without a local index it never registers. Build the index once (~25–30k records, takes a few minutes) and refresh periodically; subsequent runs are incremental and only fetch records newer than the stored `last_harvest` timestamp.
+
+```bash
+hallucinator-cli update-iacr-eprint iacr.db
+
+# CLI
+hallucinator-cli check --iacr-eprint-offline=iacr.db paper.pdf
+
+# TUI — same flag, or set `iacr_eprint_offline_path` in the config file
+hallucinator-tui --iacr-eprint-offline=iacr.db paper.pdf
+```
+
+Auto-detected at `iacr.db` in the current directory or `~/.local/share/hallucinator/iacr.db`. IACR's metadata is published under CC0.
 
 ### ACL Anthology
 

--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-acl"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-arxiv-offline"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "dirs",
  "flate2",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-bbl"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "biblatex",
  "hallucinator-core",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-dblp"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-grobid"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "hallucinator-core",
  "quick-xml",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-iacr-eprint"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "once_cell",
  "quick-xml",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-ingest"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "flate2",
  "hallucinator-bbl",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-openalex"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-compression",
  "flate2",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-parsing"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-pdf-mupdf"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "hallucinator-core",
  "mupdf",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-reporting"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "hallucinator-core",
 ]
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-tui"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/hallucinator-rs/Cargo.toml
+++ b/hallucinator-rs/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/gianlucasb/hallucinator"

--- a/hallucinator-rs/README.md
+++ b/hallucinator-rs/README.md
@@ -2,7 +2,7 @@
 
 Rust implementation of the Hallucinated Reference Detector. Includes a CLI and an interactive terminal UI (TUI) for batch-processing PDFs and archives.
 
-Same validation engine as the Python version — queries 13 databases in parallel (academic APIs, DOI resolution, book catalogs, government documents, and web search fallback), fuzzy-matches titles, checks for retractions — but with a native async runtime and a full-screen TUI for working through large batches interactively.
+Same validation engine as the Python version — queries 14 databases in parallel (academic APIs, DOI resolution, book catalogs, government documents, cryptology ePrint, and web search fallback), fuzzy-matches titles, checks for retractions — but with a native async runtime and a full-screen TUI for working through large batches interactively.
 
 ---
 
@@ -79,6 +79,8 @@ hallucinator-cli check --no-color paper.pdf
 | `--dblp-offline=PATH` | Path to offline DBLP database |
 | `--acl-offline=PATH` | Path to offline ACL Anthology database |
 | `--arxiv-offline=PATH` | Path to offline arXiv database (Kaggle snapshot) |
+| `--iacr-eprint-offline=PATH` | Path to offline IACR Cryptology ePrint Archive database |
+| `--openalex-offline=PATH` | Path to offline OpenAlex Tantivy index |
 | `--output=PATH` | Write output to file |
 | `--no-color` | Disable colored output |
 | `--disable-dbs=CSV` | Comma-separated database names to skip |
@@ -103,9 +105,16 @@ hallucinator-cli update-arxiv arxiv.db
 # Alternative: skip the download and point at an already-downloaded
 # Kaggle zip / JSON dump (useful for retries)
 hallucinator-cli update-arxiv arxiv.db --dump /path/to/arxiv-metadata-oai-snapshot.json
+
+# IACR Cryptology ePrint Archive — offline-only (no public search API).
+# Initial harvest is ~25-30k records; subsequent runs are incremental.
+hallucinator-cli update-iacr-eprint iacr.db
+
+# OpenAlex (Tantivy index — large; consider `--min-year` to limit scope)
+hallucinator-cli update-openalex openalex.idx
 ```
 
-When `--arxiv-offline` is configured, the online arXiv backend is replaced entirely (same pattern as DBLP / ACL / OpenAlex).
+When `--arxiv-offline` is configured, the online arXiv backend is replaced entirely (same pattern as DBLP / ACL / OpenAlex). The IACR ePrint backend has no online counterpart — it only registers when a local index is provided.
 
 ---
 
@@ -121,7 +130,8 @@ hallucinator-tui
 hallucinator-tui paper1.pdf paper2.pdf proceedings.zip
 
 # With options
-hallucinator-tui --dblp-offline=dblp.db --acl-offline=acl.db --arxiv-offline=arxiv.db --theme=modern
+hallucinator-tui --dblp-offline=dblp.db --acl-offline=acl.db \
+    --arxiv-offline=arxiv.db --iacr-eprint-offline=iacr.db --theme=modern
 ```
 
 ### TUI Options
@@ -134,7 +144,7 @@ All CLI options above, plus:
 | `--mouse` | Enable mouse support |
 | `--fps N` | Target framerate, 1-120 (default: 30) |
 
-The TUI also has `update-dblp`, `update-acl`, and `update-arxiv` subcommands, same as the CLI.
+The TUI has `update-dblp`, `update-acl`, and `update-openalex` subcommands. `update-arxiv` and `update-iacr-eprint` are CLI-only — build those indexes with `hallucinator-cli` and point the TUI at them via `--arxiv-offline` / `--iacr-eprint-offline` (or the config file).
 
 ### Screens
 
@@ -173,7 +183,7 @@ The TUI also has `update-dblp`, `update-acl`, and `update-arxiv` subcommands, sa
 Settings are loaded from (highest to lowest priority):
 
 1. CLI arguments
-2. Environment variables (`OPENALEX_KEY`, `S2_API_KEY`, `GOVINFO_KEY`, `DBLP_OFFLINE_PATH`, `ACL_OFFLINE_PATH`, `SEARXNG_URL`, `DB_TIMEOUT`, `DB_TIMEOUT_SHORT`)
+2. Environment variables (`OPENALEX_KEY`, `S2_API_KEY`, `GOVINFO_KEY`, `DBLP_OFFLINE_PATH`, `ACL_OFFLINE_PATH`, `IACR_EPRINT_OFFLINE_PATH`, `OPENALEX_OFFLINE_PATH`, `SEARXNG_URL`, `DB_TIMEOUT`, `DB_TIMEOUT_SHORT`)
 3. Config file
 4. Defaults
 
@@ -196,6 +206,8 @@ govinfo_key = "..."  # Free from api.data.gov
 dblp_offline_path = "/path/to/dblp.db"
 acl_offline_path = "/path/to/acl.db"
 arxiv_offline_path = "/path/to/arxiv.db"
+iacr_eprint_offline_path = "/path/to/iacr.db"
+openalex_offline_path = "/path/to/openalex.idx"
 disabled = ["OpenAlex", "PubMed"]
 
 [concurrency]
@@ -213,8 +225,8 @@ fps = 30
 ### Offline Database Auto-Detection
 
 If no path is specified, the tool checks:
-1. `dblp.db` / `acl.db` / `arxiv.db` in the current directory
-2. `~/.local/share/hallucinator/dblp.db` (or platform equivalent)
+1. `dblp.db` / `acl.db` / `arxiv.db` / `iacr.db` / `openalex.idx` in the current directory
+2. `~/.local/share/hallucinator/<filename>` (or platform equivalent)
 
 ---
 
@@ -233,6 +245,7 @@ If no path is specified, the tool checks:
 | OpenAlex | 250M+ works | Online (needs API key) or offline SQLite |
 | Open Library | Books, technical reports, and non-academic publications | |
 | GovInfo | US federal laws, regulations, court opinions | Optional, needs free API key from api.data.gov |
+| IACR ePrint | Cryptology ePrint Archive | Offline-only — build the local index with `update-iacr-eprint` |
 | URL Checker | Liveness check for non-academic URLs (GitHub, blogs, etc.) | Weaker verification — confirms URL is reachable |
 | Web Search | SearxNG metasearch fallback (Google, Bing, Google Scholar) | Optional, self-hosted, no author verification |
 
@@ -338,6 +351,13 @@ GovInfo indexes:
 | `hallucinator-dblp` | Offline DBLP database builder and querier (SQLite + FTS5) |
 | `hallucinator-acl` | Offline ACL Anthology database builder and querier |
 | `hallucinator-arxiv-offline` | Offline arXiv database builder (Kaggle snapshot ingester) and querier |
+| `hallucinator-iacr-eprint` | Offline IACR Cryptology ePrint Archive harvester and querier |
+| `hallucinator-openalex` | Offline OpenAlex Tantivy index builder and querier |
+| `hallucinator-ingest` | PDF / archive / BBL / GROBID ingestion glue |
+| `hallucinator-bbl` | BBL (LaTeX bibliography) parser |
+| `hallucinator-grobid` | GROBID TEI XML reference parser |
+| `hallucinator-reporting` | Output formatters (HTML / JSON / Markdown / CSV / text) |
+| `hallucinator-scowl` | SCOWL-based English dictionary helper |
 | `hallucinator-cli` | CLI binary |
 | `hallucinator-tui` | Terminal UI (Ratatui) |
 | `hallucinator-web` | Web interface |

--- a/hallucinator-rs/crates/hallucinator-python/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hallucinator-python"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 description = "Python bindings for hallucinator reference extraction"
@@ -20,6 +20,8 @@ hallucinator-ingest = { path = "../hallucinator-ingest" }
 hallucinator-core = { path = "../hallucinator-core" }
 hallucinator-dblp = { path = "../hallucinator-dblp" }
 hallucinator-acl = { path = "../hallucinator-acl" }
+hallucinator-arxiv-offline = { path = "../hallucinator-arxiv-offline" }
+hallucinator-iacr-eprint = { path = "../hallucinator-iacr-eprint" }
 hallucinator-openalex = { path = "../hallucinator-openalex" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-util = "0.7"

--- a/hallucinator-rs/crates/hallucinator-python/src/config.rs
+++ b/hallucinator-rs/crates/hallucinator-python/src/config.rs
@@ -22,6 +22,8 @@ pub struct PyValidatorConfig {
     pub(crate) s2_api_key: Option<String>,
     pub(crate) dblp_offline_path: Option<String>,
     pub(crate) acl_offline_path: Option<String>,
+    pub(crate) arxiv_offline_path: Option<String>,
+    pub(crate) iacr_eprint_offline_path: Option<String>,
     pub(crate) openalex_offline_path: Option<String>,
     pub(crate) cache_path: Option<String>,
     pub(crate) cache_positive_ttl_secs: u64,
@@ -34,6 +36,7 @@ pub struct PyValidatorConfig {
     pub(crate) disabled_dbs: Vec<String>,
     pub(crate) check_openalex_authors: bool,
     pub(crate) crossref_mailto: Option<String>,
+    pub(crate) url_match: bool,
 }
 
 impl PyValidatorConfig {
@@ -57,6 +60,33 @@ impl PyValidatorConfig {
                 let db = hallucinator_acl::AclDatabase::open(std::path::Path::new(path)).map_err(
                     |e| PyRuntimeError::new_err(format!("Failed to open ACL database: {}", e)),
                 )?;
+                Some(Arc::new(Mutex::new(db)))
+            }
+            None => None,
+        };
+
+        let arxiv_offline_db = match &self.arxiv_offline_path {
+            Some(path) => {
+                let db = hallucinator_arxiv_offline::ArxivDatabase::open(std::path::Path::new(
+                    path,
+                ))
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to open arXiv database: {}", e))
+                })?;
+                Some(Arc::new(Mutex::new(db)))
+            }
+            None => None,
+        };
+
+        let iacr_eprint_offline_db = match &self.iacr_eprint_offline_path {
+            Some(path) => {
+                let db = hallucinator_iacr_eprint::IacrDatabase::open(std::path::Path::new(path))
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!(
+                            "Failed to open IACR ePrint database: {}",
+                            e
+                        ))
+                    })?;
                 Some(Arc::new(Mutex::new(db)))
             }
             None => None,
@@ -88,6 +118,10 @@ impl PyValidatorConfig {
             dblp_offline_db,
             acl_offline_path: self.acl_offline_path.as_ref().map(PathBuf::from),
             acl_offline_db,
+            arxiv_offline_path: self.arxiv_offline_path.as_ref().map(PathBuf::from),
+            arxiv_offline_db,
+            iacr_eprint_offline_path: self.iacr_eprint_offline_path.as_ref().map(PathBuf::from),
+            iacr_eprint_offline_db,
             openalex_offline_path: self.openalex_offline_path.as_ref().map(PathBuf::from),
             openalex_offline_db,
             num_workers: self.num_workers,
@@ -109,6 +143,7 @@ impl PyValidatorConfig {
                 self.cache_positive_ttl_secs,
                 self.cache_negative_ttl_secs,
             )),
+            url_match: self.url_match,
         })
     }
 }
@@ -122,6 +157,8 @@ impl PyValidatorConfig {
             s2_api_key: None,
             dblp_offline_path: None,
             acl_offline_path: None,
+            arxiv_offline_path: None,
+            iacr_eprint_offline_path: None,
             openalex_offline_path: None,
             cache_path: None,
             cache_positive_ttl_secs: hallucinator_core::DEFAULT_POSITIVE_TTL.as_secs(),
@@ -134,6 +171,7 @@ impl PyValidatorConfig {
             disabled_dbs: vec![],
             check_openalex_authors: false,
             crossref_mailto: None,
+            url_match: false,
         }
     }
 
@@ -179,6 +217,29 @@ impl PyValidatorConfig {
     #[setter]
     fn set_acl_offline_path(&mut self, value: Option<String>) {
         self.acl_offline_path = value;
+    }
+
+    /// Path to offline arXiv SQLite database (Kaggle snapshot, optional).
+    #[getter]
+    fn get_arxiv_offline_path(&self) -> Option<&str> {
+        self.arxiv_offline_path.as_deref()
+    }
+
+    #[setter]
+    fn set_arxiv_offline_path(&mut self, value: Option<String>) {
+        self.arxiv_offline_path = value;
+    }
+
+    /// Path to offline IACR Cryptology ePrint Archive SQLite database
+    /// (optional, no online counterpart — the backend is offline-only).
+    #[getter]
+    fn get_iacr_eprint_offline_path(&self) -> Option<&str> {
+        self.iacr_eprint_offline_path.as_deref()
+    }
+
+    #[setter]
+    fn set_iacr_eprint_offline_path(&mut self, value: Option<String>) {
+        self.iacr_eprint_offline_path = value;
     }
 
     /// Path to offline OpenAlex index directory (optional).
@@ -311,6 +372,20 @@ impl PyValidatorConfig {
     #[setter]
     fn set_crossref_mailto(&mut self, value: Option<String>) {
         self.crossref_mailto = value;
+    }
+
+    /// Cross-check unverified references against their raw URLs via URL
+    /// liveness checks and the Wayback Machine. When False (default),
+    /// non-academic-URL refs that miss every database land as "skipped"
+    /// rather than "not_found".
+    #[getter]
+    fn get_url_match(&self) -> bool {
+        self.url_match
+    }
+
+    #[setter]
+    fn set_url_match(&mut self, value: bool) {
+        self.url_match = value;
     }
 
     fn __repr__(&self) -> String {


### PR DESCRIPTION
## Summary
- Bumps workspace + `hallucinator-python` versions to 0.2.0.
- Brings README + Python bindings in line with everything that landed since 0.1.2 (HTML stats cleanup, async cache writer, IACR ePrint offline backend, URL-match flag, arXiv offline backend).

## Changes
- **Versions:** `hallucinator-rs/Cargo.toml` workspace `0.1.2` → `0.2.0`. `hallucinator-python/Cargo.toml` `0.1.2` → `0.2.0`.
- **README (top-level):** IACR ePrint row in the database table, "Five databases" instead of four in the offline section, `update-iacr-eprint` in the build commands, new IACR ePrint subsection.
- **README (workspace):** `--iacr-eprint-offline` / `--openalex-offline` flags in the CLI options table, `update-iacr-eprint` + `update-openalex` in the offline-build section, IACR row in the workspace databases table, `iacr_eprint_offline_path` / `openalex_offline_path` in the config-file example, autodetect path, env-var list, workspace crates table now lists `iacr-eprint` / `openalex` / `ingest` / `bbl` / `grobid` / `reporting` / `scowl`.
- **Python bindings:** `ValidatorConfig` grows `arxiv_offline_path`, `iacr_eprint_offline_path`, and `url_match` (with getter/setter pairs); `to_core_config` opens the new offline DBs and fills the new struct fields. Adds workspace deps on `hallucinator-arxiv-offline` and `hallucinator-iacr-eprint`. Without this fix, the 0.2.0 wheel build would fail with `missing fields ... in initializer of Config`.

## Test plan
- [x] `cargo test --workspace` green.
- [x] `cargo fmt --all --check` green.
- [x] Wheel build locally with the CI version override (`maturin build --release -i 3.12`) → `hallucinator-0.2.0-cp312-cp312-macosx_11_0_arm64.whl`.
- [x] Wheel installed into a fresh venv, `pytest hallucinator-rs/tests/ -m "not network"` → **76 passed**.
- [x] Smoke-tested new `ValidatorConfig` setters (`iacr_eprint_offline_path`, `arxiv_offline_path`, `url_match`).
- [ ] Tag `v0.2.0` after this lands → `release.yml` and `python-wheels.yml` build + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)