### PR TITLE
Strip DBLP 4-digit homonym suffix from author names

### DIFF
--- a/hallucinator-rs/crates/hallucinator-core/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/authors.rs
@@ -316,14 +316,27 @@ fn first_token_lower(name: &str) -> Option<String> {
     }
 }
 
+/// Drop a trailing DBLP-style 4-digit disambiguation suffix
+/// (`"Wenbo Guo 0001"` → `["Wenbo", "Guo"]`). Without this, downstream
+/// surname extraction would treat `0001` as the surname.
+fn strip_dblp_suffix<'a>(parts: &[&'a str]) -> Vec<&'a str> {
+    if parts.len() >= 2 {
+        let last = *parts.last().unwrap();
+        if last.len() == 4 && last.bytes().all(|b| b.is_ascii_digit()) {
+            return parts[..parts.len() - 1].to_vec();
+        }
+    }
+    parts.to_vec()
+}
+
 /// Extract surname from name parts, handling multi-word surnames and suffixes.
 fn get_surname_from_parts(parts: &[&str]) -> String {
     if parts.is_empty() {
         return String::new();
     }
 
-    // Strip name suffixes
-    let mut parts = parts.to_vec();
+    // Strip DBLP disambiguation suffix and name suffixes
+    let mut parts = strip_dblp_suffix(parts);
     while parts.len() >= 2
         && NAME_SUFFIXES.contains(parts.last().unwrap().to_lowercase().trim_end_matches('.'))
     {
@@ -381,7 +394,11 @@ fn normalize_author(name: &str) -> String {
         return format!("{} {}", first_initial, surname.to_lowercase());
     }
 
-    let parts: Vec<&str> = name.split_whitespace().collect();
+    let raw_parts: Vec<&str> = name.split_whitespace().collect();
+    if raw_parts.is_empty() {
+        return String::new();
+    }
+    let parts = strip_dblp_suffix(&raw_parts);
     if parts.is_empty() {
         return String::new();
     }
@@ -544,6 +561,19 @@ mod tests {
     #[test]
     fn test_get_last_name_multi_word() {
         assert_eq!(get_last_name("Jay Van Bavel"), "van bavel");
+    }
+
+    #[test]
+    fn test_dblp_homonym_suffix_stripped() {
+        // DBLP appends 4-digit homonym suffixes ("Wenbo Guo 0001") to
+        // disambiguate same-named authors. The suffix must not leak
+        // into surname extraction or normalization.
+        assert_eq!(get_last_name("Wenbo Guo 0001"), "guo");
+        assert_eq!(normalize_author("Wenbo Guo 0001"), "W guo");
+        assert!(validate_authors(
+            &s(&["Wenbo Guo"]),
+            &s(&["Wenbo Guo 0001", "Alice Jones"]),
+        ));
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-core/src/cache.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/cache.rs
@@ -1049,9 +1049,18 @@ pub(crate) fn author_fingerprint(raw: &str) -> Option<String> {
         (first, surname.trim())
     } else {
         // "John Smith" form — last whitespace token is the surname.
-        let parts: Vec<&str> = s.split_whitespace().collect();
+        let mut parts: Vec<&str> = s.split_whitespace().collect();
         if parts.is_empty() {
             return None;
+        }
+        // Drop a trailing DBLP 4-digit disambiguation suffix
+        // ("Wenbo Guo 0001" → "Wenbo Guo") so it doesn't get read
+        // as the surname.
+        if parts.len() >= 2 {
+            let last = *parts.last().unwrap();
+            if last.len() == 4 && last.bytes().all(|b| b.is_ascii_digit()) {
+                parts.pop();
+            }
         }
         if parts.len() == 1 {
             // Single name — treat it as surname; no initial.
@@ -1119,6 +1128,21 @@ impl std::fmt::Debug for QueryCache {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn author_fingerprint_strips_dblp_homonym_suffix() {
+        // DBLP appends 4-digit suffixes ("Wenbo Guo 0001"); the fingerprint
+        // is used in the phantom-author guard, so the surname must come
+        // from "Guo", not "0001".
+        assert_eq!(
+            author_fingerprint("Wenbo Guo 0001"),
+            Some("w:guo".to_string())
+        );
+        assert_eq!(
+            author_fingerprint("Wenbo Guo"),
+            author_fingerprint("Wenbo Guo 0001")
+        );
+    }
 
     #[test]
     fn cache_miss_on_empty() {

--- a/hallucinator-rs/crates/hallucinator-dblp/src/db.rs
+++ b/hallucinator-rs/crates/hallucinator-dblp/src/db.rs
@@ -159,6 +159,10 @@ pub fn get_counts(conn: &Connection) -> Result<(i64, i64, i64), DblpError> {
 }
 
 /// Get author names for a publication by its integer ID.
+///
+/// Strips DBLP's trailing 4-digit homonym disambiguation suffix
+/// (`"Wenbo Guo 0001"` → `"Wenbo Guo"`) so callers compare against
+/// citation-style names. See <https://dblp.org/faq/1474704.html>.
 pub fn get_authors_for_publication(
     conn: &Connection,
     pub_id: i64,
@@ -171,8 +175,22 @@ pub fn get_authors_for_publication(
     let authors = stmt
         .query_map(params![pub_id], |row| row.get::<_, String>(0))?
         .filter_map(|r| r.ok())
+        .map(|name| strip_homonym_suffix(&name))
         .collect();
     Ok(authors)
+}
+
+/// Drop a trailing 4-digit DBLP homonym suffix from an author name.
+fn strip_homonym_suffix(name: &str) -> String {
+    let trimmed = name.trim_end();
+    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    if tokens.len() >= 2 {
+        let last = *tokens.last().unwrap();
+        if last.len() == 4 && last.bytes().all(|b| b.is_ascii_digit()) {
+            return tokens[..tokens.len() - 1].join(" ");
+        }
+    }
+    trimmed.to_string()
 }
 
 #[cfg(test)]
@@ -258,6 +276,36 @@ mod tests {
         let mut authors = get_authors_for_publication(&conn, pub_id).unwrap();
         authors.sort();
         assert_eq!(authors, vec!["Alice", "Bob"]);
+    }
+
+    #[test]
+    fn test_get_authors_strips_homonym_suffix() {
+        // DBLP appends a 4-digit suffix to disambiguate same-named authors
+        // ("Wenbo Guo 0001"). The suffix is internal bookkeeping and must
+        // not leak into author comparison; strip at the boundary.
+        let conn = setup_db();
+        let a = insert_or_get_author(&conn, "Wenbo Guo 0001").unwrap();
+        let b = insert_or_get_author(&conn, "Alice Smith").unwrap();
+        let pub_id = insert_or_get_publication(&conn, "rec/x", "Paper").unwrap();
+        let mut batch = InsertBatch::new();
+        batch.publication_authors.push((pub_id, a));
+        batch.publication_authors.push((pub_id, b));
+        insert_batch(&conn, &batch).unwrap();
+
+        let mut authors = get_authors_for_publication(&conn, pub_id).unwrap();
+        authors.sort();
+        assert_eq!(authors, vec!["Alice Smith", "Wenbo Guo"]);
+    }
+
+    #[test]
+    fn test_strip_homonym_suffix_unit() {
+        assert_eq!(strip_homonym_suffix("Wenbo Guo 0001"), "Wenbo Guo");
+        assert_eq!(strip_homonym_suffix("Alice Smith"), "Alice Smith");
+        // Don't strip non-4-digit trailing tokens.
+        assert_eq!(strip_homonym_suffix("Smith 12345"), "Smith 12345");
+        assert_eq!(strip_homonym_suffix("Smith 123"), "Smith 123");
+        // Single-token name with a 4-digit string stays put (no surname to keep).
+        assert_eq!(strip_homonym_suffix("0001"), "0001");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- DBLP appends a 4-digit disambiguation suffix to authors who share a name (`Wenbo Guo 0001`). The suffix was reaching `validate_authors` unmodified, so `get_last_name` read `0001` as the surname — false `Author Mismatch` results on otherwise correct DBLP hits, and the phantom-author guard misfired because every DBLP-side fingerprint hashed to `<initial>:<digits>`.
- Fix at the DBLP boundary: `get_authors_for_publication` now strips the suffix so the orchestrator never sees it.
- Defense in depth in core: `get_surname_from_parts`, `normalize_author`, and `author_fingerprint` also drop a trailing 4-digit token, covering any other source (e.g. Semantic Scholar) that surfaces DBLP-style names.

## Test plan
- [x] `cargo test -p hallucinator-core --lib` (348 passed)
- [x] `cargo test -p hallucinator-dblp --lib` (49 passed)
- [x] `cargo build --workspace`
- [ ] Run a real PDF through the CLI against an offline DBLP DB containing a homonym-suffixed author and confirm the reference now verifies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)