### PR TITLE
Fix off-by-one reference numbering by propagating the real [N]

### DIFF
--- a/hallucinator-rs/crates/hallucinator-parsing/examples/debug_f1_zero.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/examples/debug_f1_zero.rs
@@ -69,6 +69,7 @@ fn check_paper(pdf_path: &Path, tarball_path: &Path, config: &ParsingConfig) -> 
             .references
             .iter()
             .filter_map(|r| {
+                let r = &r.text;
                 let (title, _) = hallucinator_parsing::title::extract_title_from_reference(r);
                 if title.is_empty() || title.split_whitespace().count() < config.min_title_words() {
                     None

--- a/hallucinator-rs/crates/hallucinator-parsing/examples/evaluate_extraction.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/examples/evaluate_extraction.rs
@@ -136,6 +136,7 @@ fn evaluate_paper(
         .references
         .iter()
         .filter_map(|r| {
+            let r = &r.text;
             let (title, _) = hallucinator_parsing::title::extract_title_from_reference(r);
             if title.is_empty() || title.split_whitespace().count() < config.min_title_words() {
                 None

--- a/hallucinator-rs/crates/hallucinator-parsing/examples/evaluate_per_ref.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/examples/evaluate_per_ref.rs
@@ -147,6 +147,7 @@ fn evaluate_paper(
         .references
         .iter()
         .filter_map(|r| {
+            let r = &r.text;
             let (title, from_quotes) = hallucinator_parsing::title::extract_title_from_reference(r);
             if title.is_empty() {
                 return None;

--- a/hallucinator-rs/crates/hallucinator-parsing/examples/evaluate_scoring.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/examples/evaluate_scoring.rs
@@ -123,7 +123,8 @@ fn evaluate_paper(pdf_path: &Path, tarball_path: &Path) -> Result<PaperEvaluatio
     let mut strategy_results = Vec::new();
     for result in all_results {
         let score = score_segmentation(&result, &ref_section, &config, &weights);
-        let (precision, recall, f1) = compute_f1(&result.references, &ground_truth, &config);
+        let ref_texts: Vec<String> = result.references.iter().map(|r| r.text.clone()).collect();
+        let (precision, recall, f1) = compute_f1(&ref_texts, &ground_truth, &config);
 
         strategy_results.push(StrategyEval {
             strategy: result.strategy,

--- a/hallucinator-rs/crates/hallucinator-parsing/examples/optimize_weights.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/examples/optimize_weights.rs
@@ -197,16 +197,17 @@ fn load_paper_data(
 
     let mut strategy_metrics = Vec::new();
     for result in all_results {
-        let (_, _, f1) = compute_f1(&result.references, &ground_truth, config);
+        let ref_texts: Vec<String> = result.references.iter().map(|r| r.text.clone()).collect();
+        let (_, _, f1) = compute_f1(&ref_texts, &ground_truth, config);
 
         // Compute raw metrics
-        let total_ref_len: usize = result.references.iter().map(|r| r.len()).sum();
+        let total_ref_len: usize = result.references.iter().map(|r| r.text.len()).sum();
         let coverage = (total_ref_len as f64 / ref_section.len().max(1) as f64).min(1.0);
 
         let complete_count = result
             .references
             .iter()
-            .filter(|r| has_extractable_content(r, config))
+            .filter(|r| has_extractable_content(&r.text, config))
             .count();
         let completeness = if result.references.is_empty() {
             0.0
@@ -214,7 +215,8 @@ fn load_paper_data(
             complete_count as f64 / result.references.len() as f64
         };
 
-        let consistency = 1.0 - coefficient_of_variation(result.references.iter().map(|r| r.len()));
+        let consistency =
+            1.0 - coefficient_of_variation(result.references.iter().map(|r| r.text.len()));
 
         strategy_metrics.push(StrategyMetrics {
             strategy: result.strategy,

--- a/hallucinator-rs/crates/hallucinator-parsing/examples/show_refs_section.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/examples/show_refs_section.rs
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
         if let Some(best) = results.iter().max_by_key(|r| r.references.len()) {
             println!("\n=== First 3 refs from {:?} ===", best.strategy);
             for (i, r) in best.references.iter().take(3).enumerate() {
-                println!("\n[{}] {}", i + 1, r);
+                println!("\n[{}] {}", r.number.unwrap_or(i + 1), r.text);
             }
         }
     } else {

--- a/hallucinator-rs/crates/hallucinator-parsing/src/extractor.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/extractor.rs
@@ -112,7 +112,7 @@ impl ReferenceExtractor {
             .find_references_section(&text)
             .ok_or(ParsingError::NoReferencesSection)?;
 
-        let raw_refs = self.segment_references(&ref_section);
+        let raw_refs = section::segment_references_numbered_with_config(&ref_section, &self.config);
 
         let mut stats = SkipStats {
             total_raw: raw_refs.len(),
@@ -122,7 +122,13 @@ impl ReferenceExtractor {
         let mut references = Vec::new();
         let mut previous_authors: Vec<String> = Vec::new();
 
-        for (raw_idx, ref_text) in raw_refs.iter().enumerate() {
+        for (raw_idx, segment) in raw_refs.iter().enumerate() {
+            let ref_text = &segment.text;
+            // Prefer the explicit list number (`[N]`/`N.`) parsed from the
+            // text; fall back to position only when the strategy didn't carry
+            // one. This keeps the reported number aligned with the paper even
+            // when an earlier segment is dropped or merged.
+            let original_number = segment.number.unwrap_or(raw_idx + 1);
             let parsed = parse_single_reference(
                 ref_text,
                 &previous_authors,
@@ -141,14 +147,14 @@ impl ReferenceExtractor {
                         doi: None,
                         arxiv_id: None,
                         urls: vec![],
-                        original_number: raw_idx + 1,
+                        original_number,
                         skip_reason: Some(match reason {
                             SkipReason::ShortTitle => "short_title".to_string(),
                         }),
                     });
                 }
                 ParsedRef::Ref(mut r) => {
-                    r.original_number = raw_idx + 1; // 1-based
+                    r.original_number = original_number;
                     if r.authors.is_empty() {
                         stats.no_authors += 1;
                     } else {

--- a/hallucinator-rs/crates/hallucinator-parsing/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/lib.rs
@@ -16,7 +16,7 @@ pub use config::{ListOverride, ParsingConfig, ParsingConfigBuilder};
 pub use dictionary::Dictionary;
 pub use extractor::ReferenceExtractor;
 pub use scoring::{ScoringWeights, score_segmentation, select_best_segmentation};
-pub use section::{SegmentationResult, SegmentationStrategy};
+pub use section::{Segment, SegmentationResult, SegmentationStrategy};
 // Re-export domain types from core (canonical definitions live there)
 pub use hallucinator_core::{BackendError, ExtractionResult, PdfBackend, Reference, SkipStats};
 

--- a/hallucinator-rs/crates/hallucinator-parsing/src/scoring.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/scoring.rs
@@ -57,18 +57,18 @@ pub fn score_segmentation(
     }
 
     // 1. Coverage: fraction of text captured
-    let total_ref_len: usize = refs.iter().map(|r| r.len()).sum();
+    let total_ref_len: usize = refs.iter().map(|r| r.text.len()).sum();
     let coverage = (total_ref_len as f64 / ref_section_text.len().max(1) as f64).min(1.0);
 
     // 2. Completeness: fraction with extractable title + authors
     let complete_count = refs
         .iter()
-        .filter(|r| has_extractable_content(r, config))
+        .filter(|r| has_extractable_content(&r.text, config))
         .count();
     let completeness = complete_count as f64 / refs.len() as f64;
 
     // 3. Consistency: inverse coefficient of variation of lengths
-    let consistency = 1.0 - coefficient_of_variation(refs.iter().map(|r| r.len()));
+    let consistency = 1.0 - coefficient_of_variation(refs.iter().map(|r| r.text.len()));
 
     // 4. Specificity: strategy-specific score
     let specificity = result.strategy.specificity_score();
@@ -150,7 +150,18 @@ pub fn select_best_segmentation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::section::SegmentationStrategy;
+    use crate::section::{Segment, SegmentationStrategy};
+
+    /// Wrap plain strings as unnumbered segments for test construction.
+    fn segs(items: &[&str]) -> Vec<Segment> {
+        items
+            .iter()
+            .map(|s| Segment {
+                text: s.to_string(),
+                number: None,
+            })
+            .collect()
+    }
 
     #[test]
     fn test_coefficient_of_variation_empty() {
@@ -204,10 +215,10 @@ mod tests {
         // Create a simple segmentation result
         let result = SegmentationResult {
             strategy: SegmentationStrategy::Ieee,
-            references: vec![
-                "Smith, J., Jones, A., \"A paper about something\", IEEE, 2023.".to_string(),
-                "Doe, J., \"Another paper here\", ACM, 2022.".to_string(),
-            ],
+            references: segs(&[
+                "Smith, J., Jones, A., \"A paper about something\", IEEE, 2023.",
+                "Doe, J., \"Another paper here\", ACM, 2022.",
+            ]),
         };
         let ref_text = concat!(
             "[1] Smith, J., Jones, A., \"A paper about something\", IEEE, 2023.\n",
@@ -225,14 +236,14 @@ mod tests {
         let results = vec![
             SegmentationResult {
                 strategy: SegmentationStrategy::Fallback,
-                references: vec!["short".to_string()],
+                references: segs(&["short"]),
             },
             SegmentationResult {
                 strategy: SegmentationStrategy::Ieee,
-                references: vec![
-                    "Smith, J., \"A proper paper title here\", IEEE, 2023.".to_string(),
-                    "Jones, A., \"Another paper title\", ACM, 2022.".to_string(),
-                ],
+                references: segs(&[
+                    "Smith, J., \"A proper paper title here\", IEEE, 2023.",
+                    "Jones, A., \"Another paper title\", ACM, 2022.",
+                ]),
             },
         ];
         let ref_text = "Some reference text here";

--- a/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/section.rs
@@ -30,11 +30,43 @@ impl SegmentationStrategy {
     }
 }
 
+/// A single segmented reference.
+///
+/// `number` carries the explicit list number the segmenter parsed from the
+/// text — the `N` in `[N]` for IEEE, or the `N` in `N.` for the numbered
+/// style. Strategies with no explicit marker (author-year, fallback) leave
+/// it `None`, and the caller falls back to a positional number.
+///
+/// Keeping the explicit number is what keeps the reported reference number
+/// aligned with the paper: if a later step drops or merges a segment, every
+/// surviving reference still reports its true `[N]` instead of drifting by
+/// one (the position-based off-by-one bug).
+#[derive(Debug, Clone)]
+pub struct Segment {
+    pub text: String,
+    pub number: Option<usize>,
+}
+
+impl Segment {
+    /// Segment whose list number is known from an explicit marker.
+    fn numbered(text: String, number: usize) -> Self {
+        Segment {
+            text,
+            number: Some(number),
+        }
+    }
+
+    /// Segment from a strategy with no explicit list marker.
+    fn unnumbered(text: String) -> Self {
+        Segment { text, number: None }
+    }
+}
+
 /// Result of a single segmentation strategy attempt
 #[derive(Debug, Clone)]
 pub struct SegmentationResult {
     pub strategy: SegmentationStrategy,
-    pub references: Vec<String>,
+    pub references: Vec<Segment>,
 }
 
 /// Locate the references section in the document text.
@@ -319,11 +351,14 @@ pub fn segment_references_all_strategies(
         });
     }
 
+    // Strategies 3-5 below have no explicit per-reference list marker, so
+    // their segments are unnumbered and fall back to positional numbering.
+
     // Strategy 3a: AAAI
     if let Some(refs) = try_aaai(ref_text) {
         results.push(SegmentationResult {
             strategy: SegmentationStrategy::Aaai,
-            references: refs,
+            references: refs.into_iter().map(Segment::unnumbered).collect(),
         });
     }
 
@@ -331,7 +366,7 @@ pub fn segment_references_all_strategies(
     if let Some(refs) = try_neurips(ref_text) {
         results.push(SegmentationResult {
             strategy: SegmentationStrategy::Neurips,
-            references: refs,
+            references: refs.into_iter().map(Segment::unnumbered).collect(),
         });
     }
 
@@ -339,7 +374,7 @@ pub fn segment_references_all_strategies(
     if let Some(refs) = try_ml_full_name(ref_text) {
         results.push(SegmentationResult {
             strategy: SegmentationStrategy::MlFullName,
-            references: refs,
+            references: refs.into_iter().map(Segment::unnumbered).collect(),
         });
     }
 
@@ -347,7 +382,7 @@ pub fn segment_references_all_strategies(
     if let Some(refs) = try_springer_nature(ref_text) {
         results.push(SegmentationResult {
             strategy: SegmentationStrategy::SpringerNature,
-            references: refs,
+            references: refs.into_iter().map(Segment::unnumbered).collect(),
         });
     }
 
@@ -356,7 +391,7 @@ pub fn segment_references_all_strategies(
     if !fallback_refs.is_empty() {
         results.push(SegmentationResult {
             strategy: SegmentationStrategy::Fallback,
-            references: fallback_refs,
+            references: fallback_refs.into_iter().map(Segment::unnumbered).collect(),
         });
     }
 
@@ -373,6 +408,22 @@ pub(crate) fn segment_references_with_config(
     ref_text: &str,
     config: &ParsingConfig,
 ) -> Vec<String> {
+    segment_references_numbered_with_config(ref_text, config)
+        .into_iter()
+        .map(|s| s.text)
+        .collect()
+}
+
+/// Like [`segment_references_with_config`], but preserves each segment's
+/// explicit list number (`[N]` / `N.`) when the winning strategy provides one.
+///
+/// Callers use the carried number as the reference's `original_number` so the
+/// reported number matches the paper rather than the segment's position — the
+/// latter drifts whenever a segment is dropped or merged.
+pub(crate) fn segment_references_numbered_with_config(
+    ref_text: &str,
+    config: &ParsingConfig,
+) -> Vec<Segment> {
     use crate::scoring::select_best_segmentation;
 
     let all_results = segment_references_all_strategies(ref_text, config);
@@ -387,12 +438,29 @@ pub(crate) fn segment_references_with_config(
     // Strip headers for scoring (same preprocessing as in segment_references_all_strategies)
     let preprocessed = strip_page_headers(ref_text);
 
-    let chosen = select_best_segmentation(all_results, &preprocessed, config, &weights)
-        .map(|r| r.references)
-        .unwrap_or_default();
+    let Some(chosen) = select_best_segmentation(all_results, &preprocessed, config, &weights)
+    else {
+        return Vec::new();
+    };
+
+    // The prose-drop filter (`looks_like_reference`) exists to discard appendix
+    // text that leaked past the section-end detector and got chunked by the
+    // double-newline fallback. Explicitly-numbered strategies (IEEE, Numbered)
+    // split on a sequential `[N]`/`N.` run, so every segment between two
+    // consecutive markers is a real reference by construction. Running the
+    // heuristic filter over them only risks false-drops — e.g. a URL-only
+    // citation whose link got space-mangled in PDF extraction — and a dropped
+    // segment used to shift every later reference's position-based number by
+    // one. So we trust numbered strategies and only filter the rest.
+    let skip_prose_filter = matches!(
+        chosen.strategy,
+        SegmentationStrategy::Ieee | SegmentationStrategy::Numbered
+    );
+
     chosen
+        .references
         .into_iter()
-        .filter(|s| looks_like_reference(s))
+        .filter(|s| skip_prose_filter || looks_like_reference(&s.text))
         .collect()
 }
 
@@ -458,7 +526,7 @@ fn looks_like_reference(seg: &str) -> bool {
     ACADEMIC_RE.is_match(trimmed)
 }
 
-fn try_ieee_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Vec<String>> {
+fn try_ieee_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Vec<Segment>> {
     // Match [1], [2], etc. at start of string, after newline, period, or closing bracket
     // - Start/newline: standard IEEE format
     // - Period: handles PDFs where text extraction doesn't preserve newlines
@@ -468,15 +536,16 @@ fn try_ieee_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Vec<St
         Lazy::new(|| Regex::new(r"(?m)(?:^|\n|[.\]0-9])\s*\[(\d+)\]\s*").unwrap());
 
     let re = config.ieee_segment_re.as_ref().unwrap_or(&RE);
-    let matches: Vec<_> = re.find_iter(ref_text).collect();
+    // Capture both the match span (for slicing) and group 1 (the `[N]` number,
+    // which we propagate so reported numbers track the paper, not list order).
+    let matches: Vec<_> = re.captures_iter(ref_text).collect();
     if matches.len() < 3 {
         return None;
     }
 
     // Extract the captured numbers to check sequentiality
     // This prevents matching years like [2017], [2020] in author-year citations
-    let caps: Vec<_> = re.captures_iter(ref_text).collect();
-    let first_nums: Vec<i64> = caps
+    let first_nums: Vec<i64> = matches
         .iter()
         .take(5)
         .filter_map(|c| c.get(1)?.as_str().parse().ok())
@@ -495,15 +564,16 @@ fn try_ieee_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Vec<St
 
     let mut refs = Vec::new();
     for i in 0..matches.len() {
-        let start = matches[i].end();
+        let cur = matches[i].get(0).unwrap();
+        let start = cur.end();
         let end = if i + 1 < matches.len() {
             // Check if the next match starts with a digit (from prev ref's DOI)
             // If so, include that digit in the current reference
-            let next_start = matches[i + 1].start();
-            let next_match_str = matches[i + 1].as_str();
+            let next = matches[i + 1].get(0).unwrap();
+            let next_start = next.start();
             // If match starts with a digit (e.g., "0[3]" from DOI ending in ...0),
             // the digit belongs to the current reference
-            if let Some(first_char) = next_match_str.chars().next() {
+            if let Some(first_char) = next.as_str().chars().next() {
                 if first_char.is_ascii_digit() {
                     next_start + 1 // Include the digit in current ref
                 } else {
@@ -517,27 +587,34 @@ fn try_ieee_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Vec<St
         };
         let content = ref_text[start..end].trim();
         if !content.is_empty() {
-            refs.push(content.to_string());
+            // Propagate the explicit `[N]` so the reference reports its true
+            // paper number even if it is later filtered or merged.
+            let number = matches[i].get(1).and_then(|m| m.as_str().parse().ok());
+            refs.push(match number {
+                Some(n) => Segment::numbered(content.to_string(), n),
+                None => Segment::unnumbered(content.to_string()),
+            });
         }
     }
     Some(refs)
 }
 
-fn try_numbered_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Vec<String>> {
+fn try_numbered_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Vec<Segment>> {
     // Match 1-3 digit numbers only (not 4-digit years like 2018, 2024)
     // Papers rarely have 1000+ references, so this is a safe constraint
     static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)(?:^|\n)\s*(\d{1,3})\.\s+").unwrap());
 
     let re = config.numbered_segment_re.as_ref().unwrap_or(&RE);
-    let matches: Vec<_> = re.find_iter(ref_text).collect();
+    // Capture both the match span and group 1 (the `N.` number) so we can
+    // propagate the explicit list number alongside each segment.
+    let matches: Vec<_> = re.captures_iter(ref_text).collect();
     if matches.len() < 3 {
         return None;
     }
 
     // Extract the captured numbers to check sequentiality
     // When using a custom regex, we still need capture group 1 for numbers
-    let caps: Vec<_> = re.captures_iter(ref_text).collect();
-    let first_nums: Vec<i64> = caps
+    let first_nums: Vec<i64> = matches
         .iter()
         .take(5)
         .filter_map(|c| c.get(1)?.as_str().parse().ok())
@@ -555,15 +632,20 @@ fn try_numbered_with_config(ref_text: &str, config: &ParsingConfig) -> Option<Ve
 
     let mut refs = Vec::new();
     for i in 0..matches.len() {
-        let start = matches[i].end();
+        let cur = matches[i].get(0).unwrap();
+        let start = cur.end();
         let end = if i + 1 < matches.len() {
-            matches[i + 1].start()
+            matches[i + 1].get(0).unwrap().start()
         } else {
             ref_text.len()
         };
         let content = ref_text[start..end].trim();
         if !content.is_empty() {
-            refs.push(content.to_string());
+            let number = matches[i].get(1).and_then(|m| m.as_str().parse().ok());
+            refs.push(match number {
+                Some(n) => Segment::numbered(content.to_string(), n),
+                None => Segment::unnumbered(content.to_string()),
+            });
         }
     }
     Some(refs)
@@ -818,6 +900,81 @@ fn fallback_double_newline_with_config(ref_text: &str, config: &ParsingConfig) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_ieee_segments_carry_their_bracket_number() {
+        // IEEE segments must report the `[N]` parsed from the text, so the
+        // number is correct even if the list isn't contiguous in our output.
+        let text = "[1] A. Author. First paper title here. 2021.\n\
+                    [2] B. Author. Second paper title here. 2022.\n\
+                    [3] C. Author. Third paper title here. 2023.";
+        let cfg = ParsingConfig::default();
+        let segs = segment_references_numbered_with_config(text, &cfg);
+        let nums: Vec<Option<usize>> = segs.iter().map(|s| s.number).collect();
+        assert_eq!(nums, vec![Some(1), Some(2), Some(3)]);
+    }
+
+    #[test]
+    fn test_ieee_offbyone_filter_does_not_renumber() {
+        // Regression for the TUI off-by-one bug. Reference [3] here is a
+        // URL-only citation whose link is space-mangled by PDF extraction, so
+        // the prose-drop heuristic (`looks_like_reference`) used to discard it.
+        // Dropping a middle segment then shifted every later reference's
+        // position-based number down by one ([4] reported as [3], etc.).
+        //
+        // Explicitly-numbered IEEE segments must (a) survive — the filter is
+        // skipped for numbered strategies — and (b) keep their true `[N]`.
+        let mangled_url_ref = "SecurityWeek. News Vulnerabilities. \
+            https : / / www . securityweek . com / category / vulnerabilities / \
+            with extra padding text to push this segment past one hundred chars.";
+        assert!(
+            mangled_url_ref.chars().count() >= 100 && !looks_like_reference(mangled_url_ref),
+            "test fixture must be a segment the prose filter would drop",
+        );
+
+        let text = format!(
+            "[1] A. Author. Some real paper title. In Proc. IEEE Conf., 2021.\n\
+             [2] B. Author. Another real paper title. In Proc. ACM Conf., 2022.\n\
+             [3] {mangled_url_ref}\n\
+             [4] D. Author. Fourth real paper title. In Proc. USENIX, 2024.\n\
+             [5] E. Author. Fifth real paper title. In Proc. NDSS, 2025."
+        );
+        let cfg = ParsingConfig::default();
+        let segs = segment_references_numbered_with_config(&text, &cfg);
+
+        // All five references kept, each reporting its true bracket number.
+        let nums: Vec<Option<usize>> = segs.iter().map(|s| s.number).collect();
+        assert_eq!(nums, vec![Some(1), Some(2), Some(3), Some(4), Some(5)]);
+    }
+
+    #[test]
+    fn test_ieee_merge_keeps_downstream_numbers_aligned() {
+        // When a boundary is missed and two refs merge into one segment, the
+        // merged segment keeps the first ref's number and every later segment
+        // still reports its true `[N]` — no cascading off-by-one. (The IEEE
+        // sequentiality guard only inspects the first five numbers, so the
+        // missed boundary must come later, exactly as it does in real PDFs.)
+        //
+        // Here the `[6]` boundary is preceded by a letter ("text [6]") so it
+        // lacks an accepted anchor char and merges into [5]; [7] must still
+        // report 7, not the segment count (6).
+        let text = "[1] A. Author. First paper title here, 2021.\n\
+                    [2] B. Author. Second paper title here, 2022.\n\
+                    [3] C. Author. Third paper title here, 2023.\n\
+                    [4] D. Author. Fourth paper title here, 2024.\n\
+                    [5] E. Author. Fifth paper title here, 2025 trailing text [6] F. Author. Sixth merged, 2025.\n\
+                    [7] G. Author. Seventh paper title here, 2026.";
+        let cfg = ParsingConfig::default();
+        let segs = segment_references_numbered_with_config(text, &cfg);
+        let nums: Vec<usize> = segs.iter().filter_map(|s| s.number).collect();
+        // The last reported number must be the real last bracket, [7],
+        // never the segment count (6 after the merge).
+        assert_eq!(segs.len(), 6, "expected one merged segment");
+        assert_eq!(nums.last(), Some(&7));
+        // Numbers strictly increasing and within the real bracket range.
+        assert!(nums.windows(2).all(|w| w[1] > w[0]));
+        assert!(nums.iter().all(|&n| n <= 7));
+    }
 
     #[test]
     fn test_find_references_section_basic() {


### PR DESCRIPTION
## Problem

Reference numbers shown in the TUI were sometimes **one off** from the actual references in the paper. The numbers were assigned by *list position* (`raw_idx + 1` in `extractor.rs`), not by the actual `[N]` bracket. Whenever the segmented list ended up shorter than the paper's reference count, every reference after the gap was renumbered one (or more) too low.

## Reproduction

A harness over `~/Data/arxiv-ground-truth` comparing each IEEE paper's real `[N]` brackets against the pipeline output found **12 of 83 IEEE papers drifting**, including the classic minus-one cases (80→79, 59→58, 170→169, 147→146, 138→137).

## Root cause

Traced on `2602.19606v1` (brackets `[1..=59]` but only 58 segments): the IEEE segmenter produced the correct 59 segments, but the post-segmentation `looks_like_reference` filter — meant to discard appendix prose that leaks past the fallback splitter — **false-dropped a legitimate reference** (a URL-only citation whose link was space-mangled during PDF extraction: `https : / / www . securityweek . com`). Dropping segment #17 then shifted refs [18]–[59] down by one.

A second pattern (e.g. `2602.19275`) was two refs *merging* when a `[N]` boundary lacked an accepted anchor character.

## Fix

1. **Propagate the real `[N]`/`N.` number.** A new `Segment { text, number }` type carries the explicit list number; the IEEE and Numbered segmenters capture it, and the extractor uses `segment.number` as `original_number`, falling back to position only for strategies with no explicit marker. Robust against both drops *and* merges — a surviving reference always reports its true paper number.
2. **Skip the prose-drop filter for explicitly-numbered strategies.** Segments between a sequential `[1..N]`/`N.` run are references by construction, so the heuristic only risks false-drops there. It still runs for the fallback/author-year strategies it was built for.

## Verification

- End-to-end re-run: the minus-one cascade is gone (`2602.19606` → 59 refs numbered 1–59; `2602.19275` → 80 refs numbered 1–80 despite a mid-list merge). Remaining flagged papers are not off-by-one — they're cases where the scorer picks the *fallback* strategy over IEEE (a pre-existing, separate issue) or harness bracket false-positives (a literal `[262144]` in body text).
- 3 new regression tests in `section.rs` (filter-false-drop, merge-stays-aligned, numbers-carried).
- Full workspace test suite passes; clean build, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)