### PR TITLE
Fix IACR ePrint date math so fresh harvests aren't flagged stale

### DIFF
--- a/hallucinator-rs/crates/hallucinator-iacr-eprint/src/builder.rs
+++ b/hallucinator-rs/crates/hallucinator-iacr-eprint/src/builder.rs
@@ -374,9 +374,11 @@ fn today_iso_date() -> Option<String> {
         .ok()?
         .as_secs();
     let days = now_secs / 86_400;
-    // Inverse of ymd_to_days in lib.rs. Epoch days from year 0 to
-    // 1970 is 719_162. Add that and convert back.
-    let mut z = days as i64 + 719_162 - 60; // shift origin to 0000-03-01
+    // Howard Hinnant's civil_from_days: shift the Unix-epoch day count by
+    // 719_468 (days from 0000-03-01 to 1970-01-01) before the era math.
+    // This is the exact inverse of ymd_to_days in lib.rs, which returns
+    // era*146097 + doe (i.e. days-since-1970 + 719_468).
+    let mut z = days as i64 + 719_468;
     let era = if z >= 0 { z } else { z - 146096 } / 146097;
     let doe = z - era * 146097;
     let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
@@ -393,6 +395,28 @@ fn today_iso_date() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn today_iso_date_inverts_ymd_to_days() {
+        // today_iso_date must be the exact inverse of lib::ymd_to_days on the
+        // current Unix day. If the epoch constants disagree (the 60-days-stale
+        // bug), the parsed date lands on a different day than the clock.
+        let s = today_iso_date().expect("clock after epoch");
+        let parts: Vec<&str> = s.split('-').collect();
+        let (y, m, d): (i32, u32, u32) = (
+            parts[0].parse().unwrap(),
+            parts[1].parse().unwrap(),
+            parts[2].parse().unwrap(),
+        );
+        let then = crate::ymd_to_days(y, m, d).unwrap();
+        let now_days = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            / 86_400) as i64;
+        // ymd_to_days returns days-since-1970 + 719_468.
+        assert_eq!(then - 719_468, now_days, "today_iso_date drifted: {s}");
+    }
 
     const SAMPLE_PAGE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/">

--- a/hallucinator-rs/crates/hallucinator-iacr-eprint/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-iacr-eprint/src/lib.rs
@@ -219,7 +219,10 @@ fn iso_date_age_days(s: &str) -> Option<u64> {
         .ok()?
         .as_secs();
     let now_days = (now_secs / 86_400) as i64;
-    let epoch_days_to_then = then - 719_162;
+    // ymd_to_days returns era*146097 + doe = days-since-1970 + 719_468
+    // (Hinnant's constant), so subtract 719_468 to put `then` on the same
+    // Unix-epoch basis as now_days.
+    let epoch_days_to_then = then - 719_468;
     Some((now_days - epoch_days_to_then).max(0) as u64)
 }
 
@@ -243,6 +246,47 @@ fn ymd_to_days(year: i32, month: u32, day: u32) -> Option<i64> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn ymd_to_days_matches_hinnant_anchors() {
+        // ymd_to_days returns era*146097 + doe, i.e. days-since-1970 plus
+        // Hinnant's 719_468 offset. Pin that with known anchors so the
+        // constant can't silently drift again.
+        assert_eq!(ymd_to_days(1970, 1, 1), Some(719_468)); // days-since-1970 = 0
+        assert_eq!(ymd_to_days(2000, 1, 1), Some(730_425)); // 10_957 days later
+        assert_eq!(ymd_to_days(2026, 7, 9), Some(719_468 + 20_643));
+    }
+
+    #[test]
+    fn iso_date_age_days_zero_for_today() {
+        // Regression: a build_date equal to today must read as 0 days old,
+        // not ~60 (the symptom of the mismatched epoch constants). Derive
+        // "today" from the same clock the function uses.
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let now_days = (now_secs / 86_400) as i64;
+        // Rebuild the ISO string for `now_days` via a fixed reference date.
+        // 2026-07-09 is day 20_643; offset from there keeps this stable.
+        let today = day_number_to_iso(now_days);
+        assert_eq!(iso_date_age_days(&today), Some(0));
+    }
+
+    // Test-only inverse of ymd_to_days for the day-since-1970 count.
+    fn day_number_to_iso(days_since_1970: i64) -> String {
+        let mut z = days_since_1970 + 719_468;
+        let era = if z >= 0 { z } else { z - 146096 } / 146097;
+        let doe = z - era * 146097;
+        let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+        let y = yoe + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        let mp = (5 * doy + 2) / 153;
+        let d = doy - (153 * mp + 2) / 5 + 1;
+        let m = if mp < 10 { mp + 3 } else { mp - 9 };
+        z = if m <= 2 { y + 1 } else { y };
+        format!("{:04}-{:02}-{:02}", z, m, d)
+    }
 
     #[test]
     fn create_then_open_roundtrip() {


### PR DESCRIPTION
## Problem

A freshly-harvested offline IACR ePrint database was immediately flagged **stale**. After running `update-iacr-eprint` today, the DB recorded `build_date = 2025-07-08` (≈366 days in the past) while `last_harvest` correctly showed today — and the staleness check then reported the DB as ~60 days old, tripping the 30-day warning right after an update.

## Root cause

Two epoch constants in the Howard Hinnant civil-date math were wrong (neither was the canonical `719_468`), and they partially cancelled so it went unnoticed:

- **`today_iso_date`** (builder.rs) shifted the Unix day count by `719_162 - 60 = 719_102` → wrote a `build_date` **366 days too early**.
- **`iso_date_age_days`** (lib.rs) subtracted `719_162` instead of `719_468` when converting `ymd_to_days` output back to a days-since-1970 basis → **under-counted age by 306 days**.

Net apparent age right after a harvest: `366 − 306 = 60 days` → ≥ 30-day threshold → false "stale".

## Fix

Both sites now use **719_468**, the exact inverse of `ymd_to_days` (which returns `era*146097 + doe` = days-since-1970 + 719_468).

Tests added:
- `ymd_to_days_matches_hinnant_anchors` — pins the constant against known dates (1970-01-01 → 719_468, etc.).
- `iso_date_age_days_zero_for_today` — a build_date of today reads as 0 days old.
- `today_iso_date_inverts_ymd_to_days` — round-trips today_iso_date through ymd_to_days against the real clock.

## Note

This only governs the staleness banner (the DB is fully usable regardless). Existing `iacr.db` files carry the wrong stored `build_date` until the next harvest re-writes it; you can correct one in place with:

```
sqlite3 iacr.db "UPDATE metadata SET value='YYYY-MM-DD' WHERE key='build_date';"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)