### PR TITLE
Add disclaimer: detections are leads to verify, not proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Created by Gianluca Stringhini with Claude Code and ChatGPT.
 
 ---
 
+> [!IMPORTANT]
+> **This tool surfaces suspicion, not proof.** It flags references that it could not find in—or whose authors did not match—the bibliographic databases it checks (CrossRef, arXiv, DBLP, OpenAlex, and the others). A "Not Found" or "Author Mismatch" result **does not mean the reference is fake or that it does not exist elsewhere.** Databases are incomplete: technical reports, books, workshop papers, brand-new work, non-English venues, and software/websites are often missing or indexed with partial metadata, and title/author matching is fuzzy and imperfect. Every flagged reference is a lead to check, not a verdict.
+>
+> **Confirm every detection by hand before drawing conclusions.** Verify the reference yourself—search the Web, the publisher, Google Scholar, or the authors' own pages—before treating a flag as a problem.
+
+---
+
 
 
 ## Rust TUI (Recommended for Most Scenarios)

--- a/hallucinator-rs/README.md
+++ b/hallucinator-rs/README.md
@@ -6,6 +6,11 @@ Same validation engine as the Python version — queries 14 databases in paralle
 
 ---
 
+> [!IMPORTANT]
+> **This tool surfaces suspicion, not proof.** A "Not Found" or "Author Mismatch" result means only that a reference could not be found in—or its authors did not match—the bibliographic databases it checks. It **does not** mean the reference is fake or that it does not exist elsewhere: databases are incomplete (tech reports, books, workshop papers, new or non-English work, software/websites are often missing or partially indexed), and title/author matching is fuzzy and imperfect. Every flagged reference is a lead to check, not a verdict. **Confirm every detection by hand before drawing conclusions.**
+
+---
+
 ## Python Bindings
 
 Pre-compiled wheels are available — no Rust toolchain needed:


### PR DESCRIPTION
Adds a prominent `[!IMPORTANT]` callout to both the top-level and `hallucinator-rs` READMEs.

It clarifies that a **Not Found** or **Author Mismatch** result reflects only that a reference could not be found in — or its authors did not match — the bibliographic databases checked. It **does not** mean the reference is fake or absent elsewhere: databases are incomplete (tech reports, books, workshop papers, new/non-English work, software/websites) and title/author matching is fuzzy and imperfect. **Every flag is a lead to confirm by hand, not a verdict.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)