### PR TITLE
Fix single-paper mode never starting processing

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -705,6 +705,18 @@ async fn main() -> anyhow::Result<()> {
 
     app.backend_cmd_tx = Some(cmd_tx);
 
+    // Single-paper mode (`hallucinator-tui paper.pdf`) navigates straight to
+    // the Paper detail screen, skipping Screen::Queue entirely. Processing
+    // is otherwise manual-start (StartProcessing / 'r'), but that action is
+    // only handled when `screen == Screen::Queue` (see app/update.rs) — so
+    // without this, single-paper mode had no code path that ever called
+    // start_processing(), and the app just sat on an empty Paper screen
+    // forever (issue #305). Auto-start here instead: there's nothing to
+    // review in the queue when there's exactly one paper.
+    if app.single_paper_mode {
+        app.start_processing();
+    }
+
     // Spawn backend command listener
     let event_tx_for_backend = event_tx.clone();
     let mut cached_dblp_path = dblp_offline_path.clone();


### PR DESCRIPTION
## Summary
- `hallucinator-tui <paper.pdf>` (exactly one file, no archives) triggers single-paper mode, which navigates straight to the Paper detail screen, skipping `Screen::Queue` entirely.
- Processing is manual-start by design (the `StartProcessing` action / `r` key), but that handler only fires when `screen == Screen::Queue` — so single-paper mode had no code path that ever called `start_processing()`. The app just sat on an empty Paper screen indefinitely, which read as "loops forever."
- Fix: auto-start processing right after the backend command channel is wired up, since there's nothing to review in a queue of one paper.

Fixes #305.

## Test plan
- [x] Reproduced on unpatched code: ran the TUI against a real PDF, confirmed zero processing log activity after 8s (app truly stuck).
- [x] Confirmed the fix: same PDF, same flags — extraction and DB checks ran and completed normally, logged to the tracing log file.
- [x] `cargo check`/`clippy -D warnings`/`cargo test -p hallucinator-tui` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)