### PR TITLE
Offline DB connection pooling + DBLP query performance

### DIFF
--- a/hallucinator-rs/crates/hallucinator-acl/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-acl/src/lib.rs
@@ -12,6 +12,8 @@ mod query;
 mod xml_parser;
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rusqlite::Connection;
 use thiserror::Error;
@@ -87,6 +89,29 @@ pub struct StalenessCheck {
     pub build_date: Option<String>,
 }
 
+/// Open a connection to `path` and verify it is a compatible offline ACL
+/// Anthology database, applying read-side pragmas (`cache_size`,
+/// `mmap_size`) so repeated FTS/join lookups don't pay full-cost page
+/// faults against a large database.
+fn open_and_verify(path: &Path) -> Result<Connection, AclError> {
+    let conn = Connection::open(path)?;
+
+    let table_exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='publications'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if !table_exists {
+        return Err(AclError::Database(rusqlite::Error::QueryReturnedNoRows));
+    }
+
+    let _ = conn.pragma_update(None, "cache_size", -64000);
+    let _ = conn.pragma_update(None, "mmap_size", 268_435_456i64);
+
+    Ok(conn)
+}
+
 /// Handle to an opened offline ACL Anthology database.
 pub struct AclDatabase {
     conn: Connection,
@@ -96,18 +121,7 @@ pub struct AclDatabase {
 impl AclDatabase {
     /// Open an existing offline ACL Anthology database.
     pub fn open(path: &Path) -> Result<Self, AclError> {
-        let conn = Connection::open(path)?;
-
-        let table_exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='publications'",
-            [],
-            |row| row.get(0),
-        )?;
-
-        if !table_exists {
-            return Err(AclError::Database(rusqlite::Error::QueryReturnedNoRows));
-        }
-
+        let conn = open_and_verify(path)?;
         Ok(Self {
             conn,
             path: path.to_path_buf(),
@@ -158,6 +172,112 @@ impl AclDatabase {
             is_stale,
             age_days,
             build_date,
+        })
+    }
+
+    /// Convenience: check staleness with the default 30-day threshold.
+    pub fn is_stale(&self) -> Result<bool, AclError> {
+        Ok(self.check_staleness(30)?.is_stale)
+    }
+
+    /// Get the path to the database file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Default number of read connections held by [`AclPool`]. See
+/// `hallucinator_dblp::DEFAULT_POOL_SIZE` for the rationale.
+pub const DEFAULT_POOL_SIZE: usize = 4;
+
+/// A small fixed pool of read connections to an offline ACL Anthology
+/// database. Mirrors `hallucinator_dblp::DblpPool` — see its docs for why
+/// this replaces a single mutex-guarded connection.
+pub struct AclPool {
+    conns: Vec<Mutex<Connection>>,
+    next: AtomicUsize,
+    path: PathBuf,
+}
+
+impl AclPool {
+    /// Open a pool of [`DEFAULT_POOL_SIZE`] read connections.
+    pub fn open(path: &Path) -> Result<Self, AclError> {
+        Self::open_with_size(path, DEFAULT_POOL_SIZE)
+    }
+
+    /// Open a pool of `size` read connections (minimum 1).
+    pub fn open_with_size(path: &Path, size: usize) -> Result<Self, AclError> {
+        let size = size.max(1);
+        let mut conns = Vec::with_capacity(size);
+        for _ in 0..size {
+            conns.push(Mutex::new(open_and_verify(path)?));
+        }
+        Ok(Self {
+            conns,
+            next: AtomicUsize::new(0),
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn with_conn<T>(
+        &self,
+        f: impl FnOnce(&Connection) -> Result<T, AclError>,
+    ) -> Result<T, AclError> {
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % self.conns.len();
+        let conn = self.conns[idx]
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        f(&conn)
+    }
+
+    /// Query for a title, returning the best fuzzy match above the default threshold.
+    pub fn query(&self, title: &str) -> Result<Option<AclQueryResult>, AclError> {
+        self.with_conn(|conn| query::query_fts(conn, title, DEFAULT_THRESHOLD))
+    }
+
+    /// Query with a custom similarity threshold.
+    pub fn query_with_threshold(
+        &self,
+        title: &str,
+        threshold: f64,
+    ) -> Result<Option<AclQueryResult>, AclError> {
+        self.with_conn(|conn| query::query_fts(conn, title, threshold))
+    }
+
+    /// Get database metadata/info.
+    pub fn info(&self) -> Result<DatabaseInfo, AclError> {
+        self.with_conn(|conn| {
+            Ok(DatabaseInfo {
+                build_date: db::get_metadata(conn, "last_updated")?,
+                schema_version: db::get_metadata(conn, "schema_version")?,
+                publication_count: db::get_metadata(conn, "publication_count")?,
+                author_count: db::get_metadata(conn, "author_count")?,
+                commit_sha: db::get_metadata(conn, "commit_sha")?,
+            })
+        })
+    }
+
+    /// Check if the database is stale (older than `threshold_days`).
+    pub fn check_staleness(&self, threshold_days: u64) -> Result<StalenessCheck, AclError> {
+        self.with_conn(|conn| {
+            let build_date = db::get_metadata(conn, "last_updated")?;
+
+            let age_days = build_date.as_ref().and_then(|ts| {
+                let build_secs: u64 = ts.parse().ok()?;
+                let now_secs = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .ok()?
+                    .as_secs();
+                Some((now_secs.saturating_sub(build_secs)) / 86400)
+            });
+
+            let is_stale = age_days.is_none_or(|days| days >= threshold_days);
+
+            Ok(StalenessCheck {
+                is_stale,
+                age_days,
+                build_date,
+            })
         })
     }
 

--- a/hallucinator-rs/crates/hallucinator-arxiv-offline/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-arxiv-offline/src/lib.rs
@@ -21,6 +21,8 @@ pub mod download;
 pub mod ingest;
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rusqlite::Connection;
 use thiserror::Error;
@@ -84,6 +86,28 @@ pub struct StalenessCheck {
     pub build_date: Option<String>,
 }
 
+/// Open a connection to `path` and verify it is a built offline arXiv
+/// database, applying read-heavy pragmas (matches dblp/acl setup, plus
+/// `mmap_size` for large-database read performance).
+fn open_and_verify(path: &Path) -> Result<Connection, ArxivError> {
+    let conn = Connection::open(path)?;
+    // Fail loud when the file exists but hasn't been built — much
+    // friendlier than silently returning "not found" for every query.
+    let exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='papers'",
+        [],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        return Err(ArxivError::Database(rusqlite::Error::QueryReturnedNoRows));
+    }
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA cache_size = -64000;",
+    )?;
+    let _ = conn.pragma_update(None, "mmap_size", 268_435_456i64);
+    Ok(conn)
+}
+
 /// Handle to an opened offline arXiv database.
 pub struct ArxivDatabase {
     conn: Connection,
@@ -96,22 +120,7 @@ impl ArxivDatabase {
     /// hasn't been initialized (i.e. this file hasn't been populated
     /// by an `update-arxiv` run).
     pub fn open(path: &Path) -> Result<Self, ArxivError> {
-        let conn = Connection::open(path)?;
-        // Fail loud when the file exists but hasn't been built — much
-        // friendlier than silently returning "not found" for every
-        // query.
-        let exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='papers'",
-            [],
-            |row| row.get(0),
-        )?;
-        if !exists {
-            return Err(ArxivError::Database(rusqlite::Error::QueryReturnedNoRows));
-        }
-        // Pragmas for read-heavy workload (matches dblp/acl setup).
-        conn.execute_batch(
-            "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA cache_size = -64000;",
-        )?;
+        let conn = open_and_verify(path)?;
         Ok(Self {
             conn,
             path: path.to_path_buf(),
@@ -302,6 +311,105 @@ impl ArxivDatabase {
             age_days,
             build_date,
         })
+    }
+}
+
+/// Default number of read connections held by [`ArxivPool`]. See
+/// `hallucinator_dblp::DEFAULT_POOL_SIZE` for the rationale.
+pub const DEFAULT_POOL_SIZE: usize = 4;
+
+/// A small fixed pool of read connections to an offline arXiv database.
+/// Mirrors `hallucinator_dblp::DblpPool` — only wraps the read path used by
+/// the runtime backend (lookup/search/staleness); bulk-ingest methods stay
+/// on [`ArxivDatabase`], which the builder opens directly, not through this
+/// pool.
+pub struct ArxivPool {
+    conns: Vec<Mutex<Connection>>,
+    next: AtomicUsize,
+    path: PathBuf,
+}
+
+impl ArxivPool {
+    /// Open a pool of [`DEFAULT_POOL_SIZE`] read connections.
+    pub fn open(path: &Path) -> Result<Self, ArxivError> {
+        Self::open_with_size(path, DEFAULT_POOL_SIZE)
+    }
+
+    /// Open a pool of `size` read connections (minimum 1).
+    pub fn open_with_size(path: &Path, size: usize) -> Result<Self, ArxivError> {
+        let size = size.max(1);
+        let mut conns = Vec::with_capacity(size);
+        for _ in 0..size {
+            conns.push(Mutex::new(open_and_verify(path)?));
+        }
+        Ok(Self {
+            conns,
+            next: AtomicUsize::new(0),
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn with_conn<T>(
+        &self,
+        f: impl FnOnce(&Connection) -> Result<T, ArxivError>,
+    ) -> Result<T, ArxivError> {
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % self.conns.len();
+        let conn = self.conns[idx]
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        f(&conn)
+    }
+
+    /// Exact-ID lookup. See [`ArxivDatabase::lookup_by_id`].
+    pub fn lookup_by_id(&self, arxiv_id: &str) -> Result<Option<ArxivRecord>, ArxivError> {
+        self.with_conn(|conn| db::lookup_by_id(conn, arxiv_id))
+    }
+
+    /// Title search. See [`ArxivDatabase::search_by_title`].
+    pub fn search_by_title(&self, query: &str, limit: usize) -> Result<Vec<String>, ArxivError> {
+        self.with_conn(|conn| db::search_by_title(conn, query, limit))
+    }
+
+    /// Hydrated title search. See [`ArxivDatabase::search_by_title_hydrated`].
+    pub fn search_by_title_hydrated(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<ArxivRecord>, ArxivError> {
+        self.with_conn(|conn| db::search_by_title_hydrated(conn, query, limit))
+    }
+
+    /// Number of papers in the database.
+    pub fn paper_count(&self) -> Result<u64, ArxivError> {
+        self.with_conn(|conn| {
+            let n: i64 = conn.query_row("SELECT COUNT(*) FROM papers", [], |row| row.get(0))?;
+            Ok(n as u64)
+        })
+    }
+
+    /// Check whether the database is older than `threshold_days`.
+    pub fn staleness(&self, threshold_days: u64) -> Result<StalenessCheck, ArxivError> {
+        self.with_conn(|conn| {
+            let build_date = db::get_metadata(conn, "build_date")?;
+            let Some(date) = &build_date else {
+                return Ok(StalenessCheck {
+                    is_stale: false,
+                    age_days: None,
+                    build_date: None,
+                });
+            };
+            let age_days = iso_date_age_days(date);
+            Ok(StalenessCheck {
+                is_stale: age_days.is_some_and(|d| d >= threshold_days),
+                age_days,
+                build_date,
+            })
+        })
+    }
+
+    /// Get the path to the database file.
+    pub fn path(&self) -> &Path {
+        &self.path
     }
 }
 

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -644,10 +644,10 @@ async fn check(
                 path.display()
             );
         }
-        let db = hallucinator_dblp::DblpDatabase::open(path)?;
+        let pool = hallucinator_dblp::DblpPool::open(path)?;
 
         // Check staleness
-        if let Ok(staleness) = db.check_staleness(30)
+        if let Ok(staleness) = pool.check_staleness(30)
             && staleness.is_stale
         {
             let msg = if let Some(days) = staleness.age_days {
@@ -671,7 +671,7 @@ async fn check(
             writeln!(writer)?;
         }
 
-        Some(Arc::new(Mutex::new(db)))
+        Some(Arc::new(pool))
     } else {
         None
     };
@@ -685,7 +685,7 @@ async fn check(
                 path.display()
             );
         }
-        let db = hallucinator_acl::AclDatabase::open(path)?;
+        let db = hallucinator_acl::AclPool::open(path)?;
 
         if let Ok(staleness) = db.check_staleness(30)
             && staleness.is_stale
@@ -711,7 +711,7 @@ async fn check(
             writeln!(writer)?;
         }
 
-        Some(Arc::new(Mutex::new(db)))
+        Some(Arc::new(db))
     } else {
         None
     };
@@ -725,7 +725,7 @@ async fn check(
                 path.display()
             );
         }
-        let db = hallucinator_arxiv_offline::ArxivDatabase::open(path)
+        let db = hallucinator_arxiv_offline::ArxivPool::open(path)
             .map_err(|e| anyhow::anyhow!("{}", e))?;
 
         if let Ok(staleness) = db.staleness(30)
@@ -752,7 +752,7 @@ async fn check(
             writeln!(writer)?;
         }
 
-        Some(Arc::new(Mutex::new(db)))
+        Some(Arc::new(db))
     } else {
         None
     };
@@ -768,8 +768,8 @@ async fn check(
                 path.display()
             );
         }
-        let db = hallucinator_iacr_eprint::IacrDatabase::open(path)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        let db =
+            hallucinator_iacr_eprint::IacrPool::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
 
         if let Ok(staleness) = db.staleness(30)
             && staleness.is_stale
@@ -795,7 +795,7 @@ async fn check(
             writeln!(writer)?;
         }
 
-        Some(Arc::new(Mutex::new(db)))
+        Some(Arc::new(db))
     } else {
         None
     };
@@ -836,7 +836,7 @@ async fn check(
             writeln!(writer)?;
         }
 
-        Some(Arc::new(Mutex::new(db)))
+        Some(Arc::new(db))
     } else {
         None
     };

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -635,6 +635,15 @@ async fn check(
         Box::new(std::io::stdout())
     };
 
+    // Resolved before opening offline DBs so their read-connection pools can
+    // be sized to match — otherwise a user-raised worker count queues behind
+    // a fixed-size pool, inflating the DB's reported average latency (each
+    // worker waits for a free connection on top of that connection's own
+    // query time).
+    let num_workers = num_workers
+        .or_else(|| file_config.concurrency.as_ref().and_then(|c| c.num_workers))
+        .unwrap_or(4);
+
     // Open offline DBLP database if configured
     let dblp_offline_db = if let Some(ref path) = dblp_offline_path {
         if !path.exists() {
@@ -644,7 +653,7 @@ async fn check(
                 path.display()
             );
         }
-        let pool = hallucinator_dblp::DblpPool::open(path)?;
+        let pool = hallucinator_dblp::DblpPool::open_with_size(path, num_workers)?;
 
         // Check staleness
         if let Ok(staleness) = pool.check_staleness(30)
@@ -685,7 +694,7 @@ async fn check(
                 path.display()
             );
         }
-        let db = hallucinator_acl::AclPool::open(path)?;
+        let db = hallucinator_acl::AclPool::open_with_size(path, num_workers)?;
 
         if let Ok(staleness) = db.check_staleness(30)
             && staleness.is_stale
@@ -725,7 +734,7 @@ async fn check(
                 path.display()
             );
         }
-        let db = hallucinator_arxiv_offline::ArxivPool::open(path)
+        let db = hallucinator_arxiv_offline::ArxivPool::open_with_size(path, num_workers)
             .map_err(|e| anyhow::anyhow!("{}", e))?;
 
         if let Ok(staleness) = db.staleness(30)
@@ -768,8 +777,8 @@ async fn check(
                 path.display()
             );
         }
-        let db =
-            hallucinator_iacr_eprint::IacrPool::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
+        let db = hallucinator_iacr_eprint::IacrPool::open_with_size(path, num_workers)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
 
         if let Ok(staleness) = db.staleness(30)
             && staleness.is_stale
@@ -867,9 +876,6 @@ async fn check(
     };
 
     // Build config: CLI flags > env vars > config file > defaults
-    let num_workers = num_workers
-        .or_else(|| file_config.concurrency.as_ref().and_then(|c| c.num_workers))
-        .unwrap_or(4);
     let max_rate_limit_retries = max_rate_limit_retries
         .or_else(|| {
             file_config

--- a/hallucinator-rs/crates/hallucinator-core/src/db/acl.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/acl.rs
@@ -3,14 +3,18 @@ use crate::matching::titles_match;
 use crate::rate_limit::check_rate_limit_response;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 pub struct AclAnthology;
 
 /// Offline ACL Anthology backend backed by a local SQLite database with FTS5.
+///
+/// Uses a small connection pool (see [`hallucinator_acl::AclPool`]) rather
+/// than a single mutex-guarded connection, so concurrent reference checks
+/// can query ACL Anthology in parallel instead of serializing on one lock.
 pub struct AclOffline {
-    pub db: Arc<Mutex<hallucinator_acl::AclDatabase>>,
+    pub db: Arc<hallucinator_acl::AclPool>,
 }
 
 impl DatabaseBackend for AclOffline {
@@ -32,7 +36,6 @@ impl DatabaseBackend for AclOffline {
         let title = title.to_string();
         Box::pin(async move {
             let result = tokio::task::spawn_blocking(move || {
-                let db = db.lock().map_err(|e| DbQueryError::Other(e.to_string()))?;
                 db.query(&title)
                     .map_err(|e| DbQueryError::Other(e.to_string()))
             })

--- a/hallucinator-rs/crates/hallucinator-core/src/db/arxiv_offline.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/arxiv_offline.rs
@@ -17,21 +17,25 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
-use hallucinator_arxiv_offline::ArxivDatabase;
+use hallucinator_arxiv_offline::ArxivPool;
 
 use super::{ArxivIdQueryResult, DatabaseBackend, DbQueryError, DbQueryResult};
 use crate::matching::titles_match;
 
 /// Offline arXiv backend backed by a local SQLite database.
+///
+/// Uses a small connection pool (see [`ArxivPool`]) rather than a single
+/// mutex-guarded connection, so concurrent reference checks can query the
+/// offline index in parallel instead of serializing on one lock.
 pub struct ArxivOffline {
-    pub db: Arc<Mutex<ArxivDatabase>>,
+    pub db: Arc<ArxivPool>,
 }
 
 impl ArxivOffline {
-    pub fn new(db: Arc<Mutex<ArxivDatabase>>) -> Self {
+    pub fn new(db: Arc<ArxivPool>) -> Self {
         Self { db }
     }
 }
@@ -69,19 +73,14 @@ impl DatabaseBackend for ArxivOffline {
         let title = title.to_string();
         Box::pin(async move {
             let maybe_record = tokio::task::spawn_blocking(move || {
-                let db = db.lock().map_err(|e| DbQueryError::Other(e.to_string()))?;
-                // Batch-hydrate in a single mutex hold. The older
+                // Batch-hydrate in a single round trip. The older
                 // `search_by_title` + per-ID `lookup_by_id` loop
-                // issued up to 1 + 5×3 = 16 sequential SQL queries
-                // inside the lock — 4 concurrent workers queued
-                // behind each other's arxiv mutex hold and slowed
-                // the local phase noticeably. This variant always
-                // does exactly 3 round-trips regardless of how
+                // issued up to 1 + 5×3 = 16 sequential SQL queries —
+                // this variant always does exactly 3 regardless of how
                 // many candidates match.
                 let candidates = db
                     .search_by_title_hydrated(&title, 5)
                     .map_err(|e| DbQueryError::Other(e.to_string()))?;
-                drop(db); // release mutex before the (in-memory) title match
                 for rec in candidates {
                     if titles_match(&title, &rec.title) {
                         return Ok::<_, DbQueryError>(Some(rec));
@@ -116,7 +115,6 @@ impl DatabaseBackend for ArxivOffline {
         let title = title.to_string();
         Box::pin(async move {
             let lookup = tokio::task::spawn_blocking(move || {
-                let db = db.lock().map_err(|e| DbQueryError::Other(e.to_string()))?;
                 db.lookup_by_id(&arxiv_id)
                     .map_err(|e| DbQueryError::Other(e.to_string()))
             })

--- a/hallucinator-rs/crates/hallucinator-core/src/db/dblp.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/dblp.rs
@@ -4,7 +4,7 @@ use crate::rate_limit::check_rate_limit_response;
 use crate::text_utils::get_query_words;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Strip DBLP disambiguation suffixes from author names.
@@ -27,8 +27,12 @@ fn strip_dblp_suffix(name: &str) -> String {
 pub struct DblpOnline;
 
 /// Offline DBLP backend backed by a local SQLite database with FTS5.
+///
+/// Uses a small connection pool (see [`hallucinator_dblp::DblpPool`]) rather
+/// than a single mutex-guarded connection, so concurrent reference checks can
+/// query DBLP in parallel instead of serializing on one lock.
 pub struct DblpOffline {
-    pub db: Arc<Mutex<hallucinator_dblp::DblpDatabase>>,
+    pub db: Arc<hallucinator_dblp::DblpPool>,
 }
 
 impl DatabaseBackend for DblpOffline {
@@ -63,7 +67,6 @@ impl DatabaseBackend for DblpOffline {
         let ref_authors = ref_authors.to_vec();
         Box::pin(async move {
             let result = tokio::task::spawn_blocking(move || {
-                let db = db.lock().map_err(|e| DbQueryError::Other(e.to_string()))?;
                 db.query_with_authors(&title, &ref_authors)
                     .map_err(|e| DbQueryError::Other(e.to_string()))
             })

--- a/hallucinator-rs/crates/hallucinator-core/src/db/iacr_eprint.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/iacr_eprint.rs
@@ -15,25 +15,24 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
-use hallucinator_iacr_eprint::IacrDatabase;
+use hallucinator_iacr_eprint::IacrPool;
 
 use super::{DatabaseBackend, DbQueryError, DbQueryResult};
 use crate::matching::titles_match;
 
-/// Offline IACR ePrint backend. Wraps the shared `IacrDatabase`
-/// handle under an `Arc<Mutex<_>>` so the orchestrator can clone
-/// it cheaply per ref without sharing the underlying SQLite
-/// connection across threads directly (rusqlite connections aren't
-/// `Sync`).
+/// Offline IACR ePrint backend. Wraps a small pool of read connections
+/// (see [`IacrPool`]) rather than a single mutex-guarded connection, so
+/// concurrent reference checks can query the offline index in parallel
+/// instead of serializing on one lock.
 pub struct IacrEprintOffline {
-    pub db: Arc<Mutex<IacrDatabase>>,
+    pub db: Arc<IacrPool>,
 }
 
 impl IacrEprintOffline {
-    pub fn new(db: Arc<Mutex<IacrDatabase>>) -> Self {
+    pub fn new(db: Arc<IacrPool>) -> Self {
         Self { db }
     }
 }
@@ -72,11 +71,9 @@ impl DatabaseBackend for IacrEprintOffline {
             // SQLite work off the async runtime — `spawn_blocking`
             // keeps the executor free for other backends.
             let maybe_record = tokio::task::spawn_blocking(move || {
-                let db = db.lock().map_err(|e| DbQueryError::Other(e.to_string()))?;
                 let candidates = db
                     .search_by_title(&title, 5)
                     .map_err(|e| DbQueryError::Other(e.to_string()))?;
-                drop(db);
                 for rec in candidates {
                     if titles_match(&title, &rec.title) {
                         return Ok::<_, DbQueryError>(Some(rec));

--- a/hallucinator-rs/crates/hallucinator-core/src/db/openalex_offline.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/openalex_offline.rs
@@ -1,12 +1,18 @@
 use super::{DatabaseBackend, DbQueryError, DbQueryResult};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Offline OpenAlex backend backed by a local Tantivy index.
+///
+/// Unlike the SQLite-backed offline DBs, `OpenAlexDatabase` needs no mutex:
+/// Tantivy's `Index` and `IndexReader` are both `Send + Sync` and designed
+/// for concurrent reads (`IndexReader::searcher()` hands out a cheap,
+/// independently-usable snapshot), so sharing a plain `Arc` here already
+/// lets concurrent reference checks query OpenAlex in parallel.
 pub struct OpenAlexOffline {
-    pub db: Arc<Mutex<hallucinator_openalex::OpenAlexDatabase>>,
+    pub db: Arc<hallucinator_openalex::OpenAlexDatabase>,
 }
 
 impl DatabaseBackend for OpenAlexOffline {
@@ -28,7 +34,6 @@ impl DatabaseBackend for OpenAlexOffline {
         let title = title.to_string();
         Box::pin(async move {
             let result = tokio::task::spawn_blocking(move || {
-                let db = db.lock().map_err(|e| DbQueryError::Other(e.to_string()))?;
                 db.query(&title)
                     .map_err(|e| DbQueryError::Other(e.to_string()))
             })

--- a/hallucinator-rs/crates/hallucinator-core/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/lib.rs
@@ -1,7 +1,7 @@
 // Licensed under either AGPL-3.0-or-later or MIT license, at your option.
 
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
@@ -285,15 +285,15 @@ pub struct Config {
     pub govinfo_key: Option<String>,
     pub patentsview_key: Option<String>,
     pub dblp_offline_path: Option<PathBuf>,
-    pub dblp_offline_db: Option<Arc<Mutex<hallucinator_dblp::DblpDatabase>>>,
+    pub dblp_offline_db: Option<Arc<hallucinator_dblp::DblpPool>>,
     pub acl_offline_path: Option<PathBuf>,
-    pub acl_offline_db: Option<Arc<Mutex<hallucinator_acl::AclDatabase>>>,
+    pub acl_offline_db: Option<Arc<hallucinator_acl::AclPool>>,
     pub arxiv_offline_path: Option<PathBuf>,
-    pub arxiv_offline_db: Option<Arc<Mutex<hallucinator_arxiv_offline::ArxivDatabase>>>,
+    pub arxiv_offline_db: Option<Arc<hallucinator_arxiv_offline::ArxivPool>>,
     pub iacr_eprint_offline_path: Option<PathBuf>,
-    pub iacr_eprint_offline_db: Option<Arc<Mutex<hallucinator_iacr_eprint::IacrDatabase>>>,
+    pub iacr_eprint_offline_db: Option<Arc<hallucinator_iacr_eprint::IacrPool>>,
     pub openalex_offline_path: Option<PathBuf>,
-    pub openalex_offline_db: Option<Arc<Mutex<hallucinator_openalex::OpenAlexDatabase>>>,
+    pub openalex_offline_db: Option<Arc<hallucinator_openalex::OpenAlexDatabase>>,
     pub num_workers: usize,
     pub db_timeout_secs: u64,
     pub db_timeout_short_secs: u64,

--- a/hallucinator-rs/crates/hallucinator-dblp/src/db.rs
+++ b/hallucinator-rs/crates/hallucinator-dblp/src/db.rs
@@ -48,6 +48,26 @@ pub fn init_database(conn: &Connection) -> Result<(), DblpError> {
     Ok(())
 }
 
+/// Create a session-local (temp-schema) `fts5vocab` table exposing
+/// per-term document frequency for `publications_fts`, so query-time code
+/// can pick the most *selective* words for expensive OR queries instead of
+/// arbitrary extraction order.
+///
+/// 'row' mode reports one row per term with a `doc` column (number of rows
+/// containing the term at least once). Common terms in an 8M+ row corpus
+/// (e.g. "learning") have `doc` in the hundreds of thousands — OR-ing one
+/// into an FTS5 query forces a huge posting-list merge before `ORDER BY
+/// rank LIMIT` can truncate it, which is the dominant cost of the
+/// OR-fallback query on large databases. `temp.` keeps this out of the
+/// on-disk schema — it's rebuilt per connection, not persisted.
+pub fn ensure_vocab_table(conn: &Connection) -> Result<(), DblpError> {
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS temp.publications_vocab \
+         USING fts5vocab('main', 'publications_fts', 'row');",
+    )?;
+    Ok(())
+}
+
 /// Configure pragmas for fast bulk loading.
 /// Uses `synchronous = OFF` to skip fsync on periodic commits — safe because a
 /// crashed build just needs to be re-run from scratch.

--- a/hallucinator-rs/crates/hallucinator-dblp/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-dblp/src/lib.rs
@@ -142,6 +142,11 @@ fn open_and_verify(path: &Path) -> Result<Connection, DblpError> {
     let _ = conn.pragma_update(None, "cache_size", -64000);
     let _ = conn.pragma_update(None, "mmap_size", 268_435_456i64);
 
+    // Non-fatal: powers term-frequency-aware OR-fallback word selection in
+    // `query::query_fts_with_authors`. If this fails (exotic sqlite build),
+    // that code degrades to its original extraction-order behavior.
+    let _ = db::ensure_vocab_table(&conn);
+
     Ok(conn)
 }
 

--- a/hallucinator-rs/crates/hallucinator-dblp/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-dblp/src/lib.rs
@@ -13,6 +13,8 @@ pub mod query;
 pub mod xml_parser;
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rusqlite::Connection;
 use thiserror::Error;
@@ -92,6 +94,57 @@ pub struct StalenessCheck {
     pub build_date: Option<String>,
 }
 
+/// Open a connection to `path` and verify it is a compatible offline DBLP
+/// database (publications table present, schema version 3).
+///
+/// Also applies read-side pragmas (`mmap_size`, `cache_size`) — the database
+/// is built with `synchronous = NORMAL` / WAL, which is fine for readers, but
+/// SQLite's default 2MB page cache is tiny against a multi-GB file, so every
+/// query would otherwise re-fault pages from the OS cache.
+fn open_and_verify(path: &Path) -> Result<Connection, DblpError> {
+    let conn = Connection::open(path)?;
+
+    // Verify the database has been initialized by checking for the publications table
+    let table_exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='publications'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if !table_exists {
+        return Err(DblpError::Database(rusqlite::Error::QueryReturnedNoRows));
+    }
+
+    // Check schema version — v3 uses integer IDs; older versions are incompatible
+    let version = db::get_metadata(&conn, "schema_version")?;
+    match version.as_deref() {
+        Some("3") => {}
+        Some(v) => {
+            return Err(DblpError::Parse(format!(
+                "DBLP database at {} has schema version {}, but version 3 is required. \
+                 Please rebuild with 'hallucinator-tui update-dblp'.",
+                path.display(),
+                v
+            )));
+        }
+        None => {
+            return Err(DblpError::Parse(format!(
+                "DBLP database at {} has no schema version. \
+                 Please rebuild with 'hallucinator-tui update-dblp'.",
+                path.display()
+            )));
+        }
+    }
+
+    // 64MB page cache and a 256MB mapped region make repeated FTS/join
+    // lookups cheaper on a multi-GB database; failures here are non-fatal
+    // (e.g. platforms where mmap is unsupported), so ignore errors.
+    let _ = conn.pragma_update(None, "cache_size", -64000);
+    let _ = conn.pragma_update(None, "mmap_size", 268_435_456i64);
+
+    Ok(conn)
+}
+
 /// Handle to an opened offline DBLP database.
 pub struct DblpDatabase {
     conn: Connection,
@@ -103,40 +156,7 @@ impl DblpDatabase {
     ///
     /// Verifies that the schema tables exist and the schema version is compatible.
     pub fn open(path: &Path) -> Result<Self, DblpError> {
-        let conn = Connection::open(path)?;
-
-        // Verify the database has been initialized by checking for the publications table
-        let table_exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='publications'",
-            [],
-            |row| row.get(0),
-        )?;
-
-        if !table_exists {
-            return Err(DblpError::Database(rusqlite::Error::QueryReturnedNoRows));
-        }
-
-        // Check schema version — v3 uses integer IDs; older versions are incompatible
-        let version = db::get_metadata(&conn, "schema_version")?;
-        match version.as_deref() {
-            Some("3") => {}
-            Some(v) => {
-                return Err(DblpError::Parse(format!(
-                    "DBLP database at {} has schema version {}, but version 3 is required. \
-                     Please rebuild with 'hallucinator-tui update-dblp'.",
-                    path.display(),
-                    v
-                )));
-            }
-            None => {
-                return Err(DblpError::Parse(format!(
-                    "DBLP database at {} has no schema version. \
-                     Please rebuild with 'hallucinator-tui update-dblp'.",
-                    path.display()
-                )));
-            }
-        }
-
+        let conn = open_and_verify(path)?;
         Ok(Self {
             conn,
             path: path.to_path_buf(),
@@ -199,6 +219,138 @@ impl DblpDatabase {
             is_stale,
             age_days,
             build_date,
+        })
+    }
+
+    /// Convenience: check staleness with the default 30-day threshold.
+    pub fn is_stale(&self) -> Result<bool, DblpError> {
+        Ok(self.check_staleness(30)?.is_stale)
+    }
+
+    /// Get the path to the database file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Default number of read connections held by [`DblpPool`], matching the
+/// default reference-processing concurrency (`num_workers` in
+/// `hallucinator-core`) so concurrent lookups don't serialize on one
+/// connection.
+pub const DEFAULT_POOL_SIZE: usize = 4;
+
+/// A small fixed pool of read connections to an offline DBLP database.
+///
+/// `DblpDatabase` wraps a single `Connection`, so callers that share one
+/// behind an `Arc<Mutex<_>>` end up serializing every lookup — including the
+/// fuzzy-match scoring — through a single global lock, even though SQLite in
+/// WAL mode supports multiple concurrent readers just fine. `DblpPool` opens
+/// several independent connections up front and round-robins across them, so
+/// concurrent reference checks can query DBLP in parallel.
+pub struct DblpPool {
+    conns: Vec<Mutex<Connection>>,
+    next: AtomicUsize,
+    path: PathBuf,
+}
+
+impl DblpPool {
+    /// Open a pool of [`DEFAULT_POOL_SIZE`] read connections.
+    pub fn open(path: &Path) -> Result<Self, DblpError> {
+        Self::open_with_size(path, DEFAULT_POOL_SIZE)
+    }
+
+    /// Open a pool of `size` read connections (minimum 1).
+    pub fn open_with_size(path: &Path, size: usize) -> Result<Self, DblpError> {
+        let size = size.max(1);
+        let mut conns = Vec::with_capacity(size);
+        for _ in 0..size {
+            conns.push(Mutex::new(open_and_verify(path)?));
+        }
+        Ok(Self {
+            conns,
+            next: AtomicUsize::new(0),
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Borrow the next connection in round-robin order and run `f` with it.
+    ///
+    /// Recovers from lock poisoning rather than propagating it: a panic
+    /// while holding the lock doesn't leave the underlying SQLite connection
+    /// in an inconsistent state, so continuing to use it is safe.
+    fn with_conn<T>(
+        &self,
+        f: impl FnOnce(&Connection) -> Result<T, DblpError>,
+    ) -> Result<T, DblpError> {
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % self.conns.len();
+        let conn = self.conns[idx]
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        f(&conn)
+    }
+
+    /// Query for a title, returning the best fuzzy match above the default threshold.
+    pub fn query(&self, title: &str) -> Result<Option<DblpQueryResult>, DblpError> {
+        self.with_conn(|conn| query::query_fts(conn, title, DEFAULT_THRESHOLD))
+    }
+
+    /// Query for a title, using the citation's authors to break ties among
+    /// candidates with comparable title similarity. See
+    /// [`query::query_fts_with_authors`] for the scoring details.
+    pub fn query_with_authors(
+        &self,
+        title: &str,
+        ref_authors: &[String],
+    ) -> Result<Option<DblpQueryResult>, DblpError> {
+        self.with_conn(|conn| {
+            query::query_fts_with_authors(conn, title, ref_authors, DEFAULT_THRESHOLD)
+        })
+    }
+
+    /// Query with a custom similarity threshold.
+    pub fn query_with_threshold(
+        &self,
+        title: &str,
+        threshold: f64,
+    ) -> Result<Option<DblpQueryResult>, DblpError> {
+        self.with_conn(|conn| query::query_fts(conn, title, threshold))
+    }
+
+    /// Get database metadata/info.
+    pub fn info(&self) -> Result<DatabaseInfo, DblpError> {
+        self.with_conn(|conn| {
+            Ok(DatabaseInfo {
+                build_date: db::get_metadata(conn, "last_updated")?,
+                schema_version: db::get_metadata(conn, "schema_version")?,
+                publication_count: db::get_metadata(conn, "publication_count")?,
+                author_count: db::get_metadata(conn, "author_count")?,
+                etag: db::get_metadata(conn, "etag")?,
+                last_modified: db::get_metadata(conn, "last_modified")?,
+            })
+        })
+    }
+
+    /// Check if the database is stale (older than `threshold_days`).
+    pub fn check_staleness(&self, threshold_days: u64) -> Result<StalenessCheck, DblpError> {
+        self.with_conn(|conn| {
+            let build_date = db::get_metadata(conn, "last_updated")?;
+
+            let age_days = build_date.as_ref().and_then(|ts| {
+                let build_secs: u64 = ts.parse().ok()?;
+                let now_secs = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .ok()?
+                    .as_secs();
+                Some((now_secs.saturating_sub(build_secs)) / 86400)
+            });
+
+            let is_stale = age_days.is_none_or(|days| days >= threshold_days);
+
+            Ok(StalenessCheck {
+                is_stale,
+                age_days,
+                build_date,
+            })
         })
     }
 

--- a/hallucinator-rs/crates/hallucinator-dblp/src/query.rs
+++ b/hallucinator-rs/crates/hallucinator-dblp/src/query.rs
@@ -511,7 +511,7 @@ pub fn query_fts_with_authors(
         }
     }
 
-    // Fallback B: OR-join the strongest 4 words when both AND queries
+    // Fallback B: OR-join the 4 most selective words when both AND queries
     // returned nothing. The AND requirement misses titles where the
     // citation lists a slightly-truncated form (e.g. citation says
     // "Software bills of materials are required" while DBLP indexes
@@ -522,7 +522,8 @@ pub fn query_fts_with_authors(
     // before being accepted.
     if words.len() >= 2 {
         let take = words.len().min(4);
-        let or_query = words[..take].join(" OR ");
+        let or_words = select_or_fallback_words(conn, &words, take);
+        let or_query = or_words.join(" OR ");
         return fts_match(
             conn,
             &or_query,
@@ -534,6 +535,56 @@ pub fn query_fts_with_authors(
     }
 
     Ok(None)
+}
+
+/// Pick the `take` most selective (lowest document-frequency) words from
+/// `words` for the OR-fallback query.
+///
+/// On an 8M+ row database, OR-ing in a high-frequency word (e.g.
+/// "learning": ~600K/8.4M titles) forces FTS5 to merge and BM25-rank a huge
+/// posting list before `ORDER BY rank LIMIT 50` can truncate it — measured
+/// up to ~1.2s for a single query, vs ~5-10ms for the same query with that
+/// one word swapped out. Preferring rare/specific words is also *more*
+/// likely to surface a genuine match: an OR clause dominated by a common
+/// word mostly returns noise unrelated to the cited paper.
+///
+/// Falls back to `words`' original extraction order (today's behavior)
+/// when frequency data isn't available (e.g. `ensure_vocab_table` failed
+/// on this connection).
+fn select_or_fallback_words(conn: &Connection, words: &[String], take: usize) -> Vec<String> {
+    let freqs = term_doc_frequencies(conn, words);
+    if freqs.is_empty() {
+        return words[..take].to_vec();
+    }
+    let mut ranked: Vec<&String> = words.iter().collect();
+    ranked.sort_by_key(|w| freqs.get(&w.to_lowercase()).copied().unwrap_or(0));
+    ranked.into_iter().take(take).cloned().collect()
+}
+
+/// Look up FTS5 document frequency (`fts5vocab` 'row' mode's `doc` column —
+/// number of rows containing the term at least once) for each of `words`,
+/// via the session-local vocab table `ensure_vocab_table` creates. Returns
+/// an empty map if that table doesn't exist on this connection; a missing
+/// entry for an individual word (not in the vocab, i.e. absent from the
+/// corpus entirely) is treated by the caller as frequency 0 — cheapest to
+/// include, since it contributes no rows to the OR merge.
+fn term_doc_frequencies(
+    conn: &Connection,
+    words: &[String],
+) -> std::collections::HashMap<String, i64> {
+    let mut freqs = std::collections::HashMap::new();
+    let Ok(mut stmt) =
+        conn.prepare_cached("SELECT doc FROM temp.publications_vocab WHERE term = ?1")
+    else {
+        return freqs;
+    };
+    for w in words {
+        let lower = w.to_lowercase();
+        if let Ok(doc) = stmt.query_row(params![lower], |row| row.get::<_, i64>(0)) {
+            freqs.insert(lower, doc);
+        }
+    }
+    freqs
 }
 
 #[cfg(test)]

--- a/hallucinator-rs/crates/hallucinator-iacr-eprint/src/lib.rs
+++ b/hallucinator-rs/crates/hallucinator-iacr-eprint/src/lib.rs
@@ -26,6 +26,8 @@ pub mod builder;
 pub mod db;
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rusqlite::Connection;
 use thiserror::Error;
@@ -85,6 +87,26 @@ pub enum BuildProgress {
     Complete { records: u64, skipped: bool },
 }
 
+/// Open a connection to `path` and verify it is a built offline IACR
+/// ePrint database, applying read-heavy pragmas (matches dblp/acl/arxiv
+/// setup, plus `mmap_size` for large-database read performance).
+fn open_and_verify(path: &Path) -> Result<Connection, IacrError> {
+    let conn = Connection::open(path)?;
+    let exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='papers'",
+        [],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        return Err(IacrError::Database(rusqlite::Error::QueryReturnedNoRows));
+    }
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA cache_size = -64000;",
+    )?;
+    let _ = conn.pragma_update(None, "mmap_size", 268_435_456i64);
+    Ok(conn)
+}
+
 /// Handle to an opened offline IACR ePrint database.
 pub struct IacrDatabase {
     conn: Connection,
@@ -97,18 +119,7 @@ impl IacrDatabase {
     /// been initialized — callers get a clear error rather than
     /// silent empty results.
     pub fn open(path: &Path) -> Result<Self, IacrError> {
-        let conn = Connection::open(path)?;
-        let exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='papers'",
-            [],
-            |row| row.get(0),
-        )?;
-        if !exists {
-            return Err(IacrError::Database(rusqlite::Error::QueryReturnedNoRows));
-        }
-        conn.execute_batch(
-            "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA cache_size = -64000;",
-        )?;
+        let conn = open_and_verify(path)?;
         Ok(Self {
             conn,
             path: path.to_path_buf(),
@@ -199,6 +210,95 @@ impl IacrDatabase {
             age_days,
             build_date,
         })
+    }
+}
+
+/// Default number of read connections held by [`IacrPool`]. See
+/// `hallucinator_dblp::DEFAULT_POOL_SIZE` for the rationale.
+pub const DEFAULT_POOL_SIZE: usize = 4;
+
+/// A small fixed pool of read connections to an offline IACR ePrint
+/// database. Mirrors `hallucinator_dblp::DblpPool` — only wraps the read
+/// path used by the runtime backend (lookup/search/staleness); the
+/// harvester keeps using [`IacrDatabase`] directly, not through this pool.
+pub struct IacrPool {
+    conns: Vec<Mutex<Connection>>,
+    next: AtomicUsize,
+    path: PathBuf,
+}
+
+impl IacrPool {
+    /// Open a pool of [`DEFAULT_POOL_SIZE`] read connections.
+    pub fn open(path: &Path) -> Result<Self, IacrError> {
+        Self::open_with_size(path, DEFAULT_POOL_SIZE)
+    }
+
+    /// Open a pool of `size` read connections (minimum 1).
+    pub fn open_with_size(path: &Path, size: usize) -> Result<Self, IacrError> {
+        let size = size.max(1);
+        let mut conns = Vec::with_capacity(size);
+        for _ in 0..size {
+            conns.push(Mutex::new(open_and_verify(path)?));
+        }
+        Ok(Self {
+            conns,
+            next: AtomicUsize::new(0),
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn with_conn<T>(
+        &self,
+        f: impl FnOnce(&Connection) -> Result<T, IacrError>,
+    ) -> Result<T, IacrError> {
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % self.conns.len();
+        let conn = self.conns[idx]
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        f(&conn)
+    }
+
+    /// Exact-ID lookup. See [`IacrDatabase::lookup_by_id`].
+    pub fn lookup_by_id(&self, id: &str) -> Result<Option<IacrRecord>, IacrError> {
+        self.with_conn(|conn| db::lookup_by_id(conn, id))
+    }
+
+    /// Title search. See [`IacrDatabase::search_by_title`].
+    pub fn search_by_title(&self, query: &str, limit: usize) -> Result<Vec<IacrRecord>, IacrError> {
+        self.with_conn(|conn| db::search_by_title(conn, query, limit))
+    }
+
+    /// Number of papers in the database.
+    pub fn paper_count(&self) -> Result<u64, IacrError> {
+        self.with_conn(|conn| {
+            let n: i64 = conn.query_row("SELECT COUNT(*) FROM papers", [], |row| row.get(0))?;
+            Ok(n as u64)
+        })
+    }
+
+    /// Whether the database is older than `threshold_days`.
+    pub fn staleness(&self, threshold_days: u64) -> Result<StalenessCheck, IacrError> {
+        self.with_conn(|conn| {
+            let build_date = db::get_metadata(conn, "build_date")?;
+            let Some(date) = &build_date else {
+                return Ok(StalenessCheck {
+                    is_stale: false,
+                    age_days: None,
+                    build_date: None,
+                });
+            };
+            let age_days = iso_date_age_days(date);
+            Ok(StalenessCheck {
+                is_stale: age_days.is_some_and(|d| d >= threshold_days),
+                age_days,
+                build_date,
+            })
+        })
+    }
+
+    /// Get the path to the database file.
+    pub fn path(&self) -> &Path {
+        &self.path
     }
 }
 

--- a/hallucinator-rs/crates/hallucinator-python/src/config.rs
+++ b/hallucinator-rs/crates/hallucinator-python/src/config.rs
@@ -44,12 +44,20 @@ impl PyValidatorConfig {
     ///
     /// Opens offline databases if paths are provided.
     pub(crate) fn to_core_config(&self) -> PyResult<Config> {
+        // Size each offline DB's read-connection pool to match num_workers —
+        // a smaller pool makes workers queue for a free connection on top of
+        // that connection's own query time, inflating reported latency.
+        let pool_size = self.num_workers.max(1);
+
         let dblp_offline_db = match &self.dblp_offline_path {
             Some(path) => {
-                let pool = hallucinator_dblp::DblpPool::open(std::path::Path::new(path))
-                    .map_err(|e| {
-                        PyRuntimeError::new_err(format!("Failed to open DBLP database: {}", e))
-                    })?;
+                let pool = hallucinator_dblp::DblpPool::open_with_size(
+                    std::path::Path::new(path),
+                    pool_size,
+                )
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to open DBLP database: {}", e))
+                })?;
                 Some(Arc::new(pool))
             }
             None => None,
@@ -57,9 +65,13 @@ impl PyValidatorConfig {
 
         let acl_offline_db = match &self.acl_offline_path {
             Some(path) => {
-                let pool = hallucinator_acl::AclPool::open(std::path::Path::new(path)).map_err(
-                    |e| PyRuntimeError::new_err(format!("Failed to open ACL database: {}", e)),
-                )?;
+                let pool = hallucinator_acl::AclPool::open_with_size(
+                    std::path::Path::new(path),
+                    pool_size,
+                )
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to open ACL database: {}", e))
+                })?;
                 Some(Arc::new(pool))
             }
             None => None,
@@ -67,9 +79,10 @@ impl PyValidatorConfig {
 
         let arxiv_offline_db = match &self.arxiv_offline_path {
             Some(path) => {
-                let pool = hallucinator_arxiv_offline::ArxivPool::open(std::path::Path::new(
-                    path,
-                ))
+                let pool = hallucinator_arxiv_offline::ArxivPool::open_with_size(
+                    std::path::Path::new(path),
+                    pool_size,
+                )
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to open arXiv database: {}", e))
                 })?;
@@ -80,13 +93,16 @@ impl PyValidatorConfig {
 
         let iacr_eprint_offline_db = match &self.iacr_eprint_offline_path {
             Some(path) => {
-                let pool = hallucinator_iacr_eprint::IacrPool::open(std::path::Path::new(path))
-                    .map_err(|e| {
-                        PyRuntimeError::new_err(format!(
-                            "Failed to open IACR ePrint database: {}",
-                            e
-                        ))
-                    })?;
+                let pool = hallucinator_iacr_eprint::IacrPool::open_with_size(
+                    std::path::Path::new(path),
+                    pool_size,
+                )
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!(
+                        "Failed to open IACR ePrint database: {}",
+                        e
+                    ))
+                })?;
                 Some(Arc::new(pool))
             }
             None => None,

--- a/hallucinator-rs/crates/hallucinator-python/src/config.rs
+++ b/hallucinator-rs/crates/hallucinator-python/src/config.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -46,48 +46,48 @@ impl PyValidatorConfig {
     pub(crate) fn to_core_config(&self) -> PyResult<Config> {
         let dblp_offline_db = match &self.dblp_offline_path {
             Some(path) => {
-                let db = hallucinator_dblp::DblpDatabase::open(std::path::Path::new(path))
+                let pool = hallucinator_dblp::DblpPool::open(std::path::Path::new(path))
                     .map_err(|e| {
                         PyRuntimeError::new_err(format!("Failed to open DBLP database: {}", e))
                     })?;
-                Some(Arc::new(Mutex::new(db)))
+                Some(Arc::new(pool))
             }
             None => None,
         };
 
         let acl_offline_db = match &self.acl_offline_path {
             Some(path) => {
-                let db = hallucinator_acl::AclDatabase::open(std::path::Path::new(path)).map_err(
+                let pool = hallucinator_acl::AclPool::open(std::path::Path::new(path)).map_err(
                     |e| PyRuntimeError::new_err(format!("Failed to open ACL database: {}", e)),
                 )?;
-                Some(Arc::new(Mutex::new(db)))
+                Some(Arc::new(pool))
             }
             None => None,
         };
 
         let arxiv_offline_db = match &self.arxiv_offline_path {
             Some(path) => {
-                let db = hallucinator_arxiv_offline::ArxivDatabase::open(std::path::Path::new(
+                let pool = hallucinator_arxiv_offline::ArxivPool::open(std::path::Path::new(
                     path,
                 ))
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to open arXiv database: {}", e))
                 })?;
-                Some(Arc::new(Mutex::new(db)))
+                Some(Arc::new(pool))
             }
             None => None,
         };
 
         let iacr_eprint_offline_db = match &self.iacr_eprint_offline_path {
             Some(path) => {
-                let db = hallucinator_iacr_eprint::IacrDatabase::open(std::path::Path::new(path))
+                let pool = hallucinator_iacr_eprint::IacrPool::open(std::path::Path::new(path))
                     .map_err(|e| {
                         PyRuntimeError::new_err(format!(
                             "Failed to open IACR ePrint database: {}",
                             e
                         ))
                     })?;
-                Some(Arc::new(Mutex::new(db)))
+                Some(Arc::new(pool))
             }
             None => None,
         };
@@ -101,7 +101,7 @@ impl PyValidatorConfig {
                             e
                         ))
                     })?;
-                Some(Arc::new(Mutex::new(db)))
+                Some(Arc::new(db))
             }
             None => None,
         };

--- a/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
@@ -335,32 +335,45 @@ pub async fn retry_references(
 }
 
 /// Open offline DBLP database if a path is configured, returning the Arc<DblpPool> handle.
-pub fn open_dblp_db(path: &std::path::Path) -> anyhow::Result<Arc<hallucinator_dblp::DblpPool>> {
+///
+/// `pool_size` should match the caller's configured `num_workers` — a
+/// pool smaller than the actual worker count makes workers queue for a
+/// free connection on top of that connection's own query time, which
+/// shows up as inflated per-query averages in the activity panel even
+/// though nothing individually got slower.
+pub fn open_dblp_db(
+    path: &std::path::Path,
+    pool_size: usize,
+) -> anyhow::Result<Arc<hallucinator_dblp::DblpPool>> {
     if !path.exists() {
         anyhow::bail!(
             "Offline DBLP database not found at {}. Build from Config > Databases (b) or run 'hallucinator-tui update-dblp'.",
             path.display()
         );
     }
-    let pool = hallucinator_dblp::DblpPool::open(path)?;
+    let pool = hallucinator_dblp::DblpPool::open_with_size(path, pool_size)?;
     Ok(Arc::new(pool))
 }
 
 /// Open offline ACL Anthology database if a path is configured, returning the Arc<AclPool> handle.
-pub fn open_acl_db(path: &std::path::Path) -> anyhow::Result<Arc<hallucinator_acl::AclPool>> {
+pub fn open_acl_db(
+    path: &std::path::Path,
+    pool_size: usize,
+) -> anyhow::Result<Arc<hallucinator_acl::AclPool>> {
     if !path.exists() {
         anyhow::bail!(
             "Offline ACL database not found at {}. Build from Config > Databases (b) or run 'hallucinator-tui update-acl'.",
             path.display(),
         );
     }
-    let pool = hallucinator_acl::AclPool::open(path)?;
+    let pool = hallucinator_acl::AclPool::open_with_size(path, pool_size)?;
     Ok(Arc::new(pool))
 }
 
 /// Open offline arXiv metadata database if a path is configured, returning the Arc<ArxivPool> handle.
 pub fn open_arxiv_db(
     path: &std::path::Path,
+    pool_size: usize,
 ) -> anyhow::Result<Arc<hallucinator_arxiv_offline::ArxivPool>> {
     if !path.exists() {
         anyhow::bail!(
@@ -369,8 +382,8 @@ pub fn open_arxiv_db(
             path.display(),
         );
     }
-    let pool =
-        hallucinator_arxiv_offline::ArxivPool::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
+    let pool = hallucinator_arxiv_offline::ArxivPool::open_with_size(path, pool_size)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     Ok(Arc::new(pool))
 }
 
@@ -379,6 +392,7 @@ pub fn open_arxiv_db(
 /// without this local index the IACR backend never registers.
 pub fn open_iacr_eprint_db(
     path: &std::path::Path,
+    pool_size: usize,
 ) -> anyhow::Result<Arc<hallucinator_iacr_eprint::IacrPool>> {
     if !path.exists() {
         anyhow::bail!(
@@ -387,8 +401,8 @@ pub fn open_iacr_eprint_db(
             path.display(),
         );
     }
-    let pool =
-        hallucinator_iacr_eprint::IacrPool::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
+    let pool = hallucinator_iacr_eprint::IacrPool::open_with_size(path, pool_size)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     Ok(Arc::new(pool))
 }
 

--- a/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/backend.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -334,38 +334,34 @@ pub async fn retry_references(
     }
 }
 
-/// Open offline DBLP database if a path is configured, returning the Arc<Mutex<..>> handle.
-pub fn open_dblp_db(
-    path: &std::path::Path,
-) -> anyhow::Result<Arc<Mutex<hallucinator_dblp::DblpDatabase>>> {
+/// Open offline DBLP database if a path is configured, returning the Arc<DblpPool> handle.
+pub fn open_dblp_db(path: &std::path::Path) -> anyhow::Result<Arc<hallucinator_dblp::DblpPool>> {
     if !path.exists() {
         anyhow::bail!(
             "Offline DBLP database not found at {}. Build from Config > Databases (b) or run 'hallucinator-tui update-dblp'.",
             path.display()
         );
     }
-    let db = hallucinator_dblp::DblpDatabase::open(path)?;
-    Ok(Arc::new(Mutex::new(db)))
+    let pool = hallucinator_dblp::DblpPool::open(path)?;
+    Ok(Arc::new(pool))
 }
 
-/// Open offline ACL Anthology database if a path is configured, returning the Arc<Mutex<..>> handle.
-pub fn open_acl_db(
-    path: &std::path::Path,
-) -> anyhow::Result<Arc<Mutex<hallucinator_acl::AclDatabase>>> {
+/// Open offline ACL Anthology database if a path is configured, returning the Arc<AclPool> handle.
+pub fn open_acl_db(path: &std::path::Path) -> anyhow::Result<Arc<hallucinator_acl::AclPool>> {
     if !path.exists() {
         anyhow::bail!(
             "Offline ACL database not found at {}. Build from Config > Databases (b) or run 'hallucinator-tui update-acl'.",
             path.display(),
         );
     }
-    let db = hallucinator_acl::AclDatabase::open(path)?;
-    Ok(Arc::new(Mutex::new(db)))
+    let pool = hallucinator_acl::AclPool::open(path)?;
+    Ok(Arc::new(pool))
 }
 
-/// Open offline arXiv metadata database if a path is configured, returning the Arc<Mutex<..>> handle.
+/// Open offline arXiv metadata database if a path is configured, returning the Arc<ArxivPool> handle.
 pub fn open_arxiv_db(
     path: &std::path::Path,
-) -> anyhow::Result<Arc<Mutex<hallucinator_arxiv_offline::ArxivDatabase>>> {
+) -> anyhow::Result<Arc<hallucinator_arxiv_offline::ArxivPool>> {
     if !path.exists() {
         anyhow::bail!(
             "Offline arXiv database not found at {}. Build with `hallucinator-cli update-arxiv {}`.",
@@ -373,17 +369,17 @@ pub fn open_arxiv_db(
             path.display(),
         );
     }
-    let db = hallucinator_arxiv_offline::ArxivDatabase::open(path)
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-    Ok(Arc::new(Mutex::new(db)))
+    let pool =
+        hallucinator_arxiv_offline::ArxivPool::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
+    Ok(Arc::new(pool))
 }
 
 /// Open offline IACR Cryptology ePrint Archive database, returning the
-/// `Arc<Mutex<..>>` handle. The archive has no online search API, so
+/// `Arc<IacrPool>` handle. The archive has no online search API, so
 /// without this local index the IACR backend never registers.
 pub fn open_iacr_eprint_db(
     path: &std::path::Path,
-) -> anyhow::Result<Arc<Mutex<hallucinator_iacr_eprint::IacrDatabase>>> {
+) -> anyhow::Result<Arc<hallucinator_iacr_eprint::IacrPool>> {
     if !path.exists() {
         anyhow::bail!(
             "Offline IACR ePrint database not found at {}. Build it with `hallucinator-cli update-iacr-eprint {}`.",
@@ -391,15 +387,15 @@ pub fn open_iacr_eprint_db(
             path.display(),
         );
     }
-    let db =
-        hallucinator_iacr_eprint::IacrDatabase::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
-    Ok(Arc::new(Mutex::new(db)))
+    let pool =
+        hallucinator_iacr_eprint::IacrPool::open(path).map_err(|e| anyhow::anyhow!("{}", e))?;
+    Ok(Arc::new(pool))
 }
 
-/// Open offline OpenAlex Tantivy index if a path is configured, returning the Arc<Mutex<..>> handle.
+/// Open offline OpenAlex Tantivy index if a path is configured, returning the Arc<OpenAlexDatabase> handle.
 pub fn open_openalex_db(
     path: &std::path::Path,
-) -> anyhow::Result<Arc<Mutex<hallucinator_openalex::OpenAlexDatabase>>> {
+) -> anyhow::Result<Arc<hallucinator_openalex::OpenAlexDatabase>> {
     if !path.exists() {
         anyhow::bail!(
             "Offline OpenAlex index not found at {}. Build from Config > Databases (b) or run 'hallucinator-tui update-openalex'.",
@@ -408,5 +404,5 @@ pub fn open_openalex_db(
     }
     let db = hallucinator_openalex::OpenAlexDatabase::open(path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
-    Ok(Arc::new(Mutex::new(db)))
+    Ok(Arc::new(db))
 }

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -269,6 +269,9 @@ async fn main() -> anyhow::Result<()> {
     if let Some(n) = cli.num_workers {
         config_state.num_workers = n.max(1);
     }
+    // Captured now (before `config_state` moves into `app.config_state`
+    // below) so the backend command loop can track it for pool resizing.
+    let startup_num_workers = config_state.num_workers;
 
     // SearxNG URL: only enabled if --searxng flag is set
     if cli.searxng {
@@ -383,7 +386,7 @@ async fn main() -> anyhow::Result<()> {
     let mut startup_info: Vec<String> = Vec::new();
     let dblp_offline_db: Option<Arc<hallucinator_dblp::DblpPool>> =
         if let Some(ref path) = dblp_offline_path {
-            match backend::open_dblp_db(path) {
+            match backend::open_dblp_db(path, config_state.num_workers) {
                 Ok(db) => {
                     startup_info.push(format!("DBLP offline DB loaded: {}", path.display()));
                     Some(db)
@@ -407,7 +410,7 @@ async fn main() -> anyhow::Result<()> {
     // Open ACL database if configured (fall back to None if file missing or corrupt)
     let acl_offline_db: Option<Arc<hallucinator_acl::AclPool>> =
         if let Some(ref path) = acl_offline_path {
-            match backend::open_acl_db(path) {
+            match backend::open_acl_db(path, config_state.num_workers) {
                 Ok(db) => {
                     startup_info.push(format!("ACL offline DB loaded: {}", path.display()));
                     Some(db)
@@ -431,7 +434,7 @@ async fn main() -> anyhow::Result<()> {
     // Open arXiv database if configured (fall back to None if file missing or corrupt)
     let arxiv_offline_db: Option<Arc<hallucinator_arxiv_offline::ArxivPool>> =
         if let Some(ref path) = arxiv_offline_path {
-            match backend::open_arxiv_db(path) {
+            match backend::open_arxiv_db(path, config_state.num_workers) {
                 Ok(db) => {
                     startup_info.push(format!("arXiv offline DB loaded: {}", path.display()));
                     Some(db)
@@ -458,7 +461,7 @@ async fn main() -> anyhow::Result<()> {
     // registers — non-fatal if missing or corrupt.
     let iacr_eprint_offline_db: Option<Arc<hallucinator_iacr_eprint::IacrPool>> =
         if let Some(ref path) = iacr_eprint_offline_path {
-            match backend::open_iacr_eprint_db(path) {
+            match backend::open_iacr_eprint_db(path, config_state.num_workers) {
                 Ok(db) => {
                     startup_info.push(format!("IACR ePrint offline DB loaded: {}", path.display()));
                     Some(db)
@@ -717,6 +720,12 @@ async fn main() -> anyhow::Result<()> {
     let mut cached_iacr_eprint_db = iacr_eprint_offline_db.clone();
     let mut cached_openalex_path = openalex_offline_path.clone();
     let mut cached_openalex_db = openalex_offline_db.clone();
+    // Tracks the worker count the offline DB pools were last sized for, so a
+    // num_workers change in the config screen (without a path change) still
+    // triggers a resize on the next batch — otherwise workers queue behind a
+    // stale, too-small pool and per-query averages in the activity panel
+    // balloon even though nothing individually got slower.
+    let mut cached_num_workers = startup_num_workers;
     let check_openalex_authors = cli.check_openalex_authors;
     tokio::spawn(async move {
         // Per-batch cancel token — cancelled when user requests stop
@@ -732,47 +741,56 @@ async fn main() -> anyhow::Result<()> {
                     // Fresh token for this batch
                     batch_cancel = CancellationToken::new();
 
-                    // If user changed the DBLP path in config, try to open the new DB
-                    if config.dblp_offline_path != cached_dblp_path {
+                    // Re-open whenever the path changed OR the worker count changed —
+                    // a pool sized for the old worker count queues workers on the new
+                    // (higher) count, inflating the activity panel's per-query average.
+                    let num_workers_changed = config.num_workers != cached_num_workers;
+
+                    // If user changed the DBLP path or worker count, (re)open the DB
+                    if config.dblp_offline_path != cached_dblp_path || num_workers_changed {
                         cached_dblp_path = config.dblp_offline_path.clone();
                         cached_dblp_db = if let Some(ref path) = cached_dblp_path {
-                            backend::open_dblp_db(path).ok()
+                            backend::open_dblp_db(path, config.num_workers).ok()
                         } else {
                             None
                         };
                     }
 
-                    // If user changed the ACL path in config, try to open the new DB
-                    if config.acl_offline_path != cached_acl_path {
+                    // If user changed the ACL path or worker count, (re)open the DB
+                    if config.acl_offline_path != cached_acl_path || num_workers_changed {
                         cached_acl_path = config.acl_offline_path.clone();
                         cached_acl_db = if let Some(ref path) = cached_acl_path {
-                            backend::open_acl_db(path).ok()
+                            backend::open_acl_db(path, config.num_workers).ok()
                         } else {
                             None
                         };
                     }
 
-                    // If user changed the arXiv path in config, try to open the new DB
-                    if config.arxiv_offline_path != cached_arxiv_path {
+                    // If user changed the arXiv path or worker count, (re)open the DB
+                    if config.arxiv_offline_path != cached_arxiv_path || num_workers_changed {
                         cached_arxiv_path = config.arxiv_offline_path.clone();
                         cached_arxiv_db = if let Some(ref path) = cached_arxiv_path {
-                            backend::open_arxiv_db(path).ok()
+                            backend::open_arxiv_db(path, config.num_workers).ok()
                         } else {
                             None
                         };
                     }
 
-                    // If user changed the IACR ePrint path in config, try to open the new DB
-                    if config.iacr_eprint_offline_path != cached_iacr_eprint_path {
+                    // If user changed the IACR ePrint path or worker count, (re)open the DB
+                    if config.iacr_eprint_offline_path != cached_iacr_eprint_path
+                        || num_workers_changed
+                    {
                         cached_iacr_eprint_path = config.iacr_eprint_offline_path.clone();
                         cached_iacr_eprint_db = if let Some(ref path) = cached_iacr_eprint_path {
-                            backend::open_iacr_eprint_db(path).ok()
+                            backend::open_iacr_eprint_db(path, config.num_workers).ok()
                         } else {
                             None
                         };
                     }
 
-                    // If user changed the OpenAlex path in config, try to open the new index
+                    // If user changed the OpenAlex path in config, try to open the new index.
+                    // No pool_size here — OpenAlexDatabase shares one Tantivy Index/IndexReader
+                    // across workers (both Send + Sync), so worker count doesn't apply.
                     if config.openalex_offline_path != cached_openalex_path {
                         cached_openalex_path = config.openalex_offline_path.clone();
                         cached_openalex_db = if let Some(ref path) = cached_openalex_path {
@@ -781,6 +799,8 @@ async fn main() -> anyhow::Result<()> {
                             None
                         };
                     }
+
+                    cached_num_workers = config.num_workers;
 
                     config.dblp_offline_path = cached_dblp_path.clone();
                     config.dblp_offline_db = cached_dblp_db.clone();

--- a/hallucinator-rs/crates/hallucinator-tui/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/main.rs
@@ -4,7 +4,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::io;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use clap::{Parser, Subcommand};
@@ -381,7 +381,7 @@ async fn main() -> anyhow::Result<()> {
     // Open DBLP database if configured (fall back to None if file missing or corrupt)
     let mut startup_warnings: Vec<String> = Vec::new();
     let mut startup_info: Vec<String> = Vec::new();
-    let dblp_offline_db: Option<Arc<Mutex<hallucinator_dblp::DblpDatabase>>> =
+    let dblp_offline_db: Option<Arc<hallucinator_dblp::DblpPool>> =
         if let Some(ref path) = dblp_offline_path {
             match backend::open_dblp_db(path) {
                 Ok(db) => {
@@ -405,7 +405,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Open ACL database if configured (fall back to None if file missing or corrupt)
-    let acl_offline_db: Option<Arc<Mutex<hallucinator_acl::AclDatabase>>> =
+    let acl_offline_db: Option<Arc<hallucinator_acl::AclPool>> =
         if let Some(ref path) = acl_offline_path {
             match backend::open_acl_db(path) {
                 Ok(db) => {
@@ -429,7 +429,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Open arXiv database if configured (fall back to None if file missing or corrupt)
-    let arxiv_offline_db: Option<Arc<Mutex<hallucinator_arxiv_offline::ArxivDatabase>>> =
+    let arxiv_offline_db: Option<Arc<hallucinator_arxiv_offline::ArxivPool>> =
         if let Some(ref path) = arxiv_offline_path {
             match backend::open_arxiv_db(path) {
                 Ok(db) => {
@@ -456,7 +456,7 @@ async fn main() -> anyhow::Result<()> {
     // Open IACR ePrint database if configured. The archive has no
     // online search API, so without a local index this backend never
     // registers — non-fatal if missing or corrupt.
-    let iacr_eprint_offline_db: Option<Arc<Mutex<hallucinator_iacr_eprint::IacrDatabase>>> =
+    let iacr_eprint_offline_db: Option<Arc<hallucinator_iacr_eprint::IacrPool>> =
         if let Some(ref path) = iacr_eprint_offline_path {
             match backend::open_iacr_eprint_db(path) {
                 Ok(db) => {
@@ -480,7 +480,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Open OpenAlex index if configured (fall back to None if missing or corrupt)
-    let openalex_offline_db: Option<Arc<Mutex<hallucinator_openalex::OpenAlexDatabase>>> =
+    let openalex_offline_db: Option<Arc<hallucinator_openalex::OpenAlexDatabase>> =
         if let Some(ref path) = openalex_offline_path {
             match backend::open_openalex_db(path) {
                 Ok(db) => {

--- a/hallucinator-rs/crates/hallucinator-web/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-web/src/main.rs
@@ -1,5 +1,5 @@
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 mod handlers;
 mod models;
@@ -22,10 +22,10 @@ async fn main() -> anyhow::Result<()> {
     if let Some(ref path_str) = dblp_offline_path {
         let path = std::path::PathBuf::from(path_str);
         if path.exists() {
-            match hallucinator_dblp::DblpDatabase::open(&path) {
-                Ok(db) => {
+            match hallucinator_dblp::DblpPool::open(&path) {
+                Ok(pool) => {
                     // Check staleness (30 days)
-                    if let Ok(staleness) = db.check_staleness(30)
+                    if let Ok(staleness) = pool.check_staleness(30)
                         && staleness.is_stale
                     {
                         eprintln!(
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
                         );
                     }
                     dblp_offline_path_display = path_str.clone();
-                    dblp_offline_db = Some(Arc::new(Mutex::new(db)));
+                    dblp_offline_db = Some(Arc::new(pool));
                     println!("DBLP offline database loaded: {}", path_str);
                 }
                 Err(e) => {

--- a/hallucinator-rs/crates/hallucinator-web/src/state.rs
+++ b/hallucinator-rs/crates/hallucinator-web/src/state.rs
@@ -1,10 +1,10 @@
-use hallucinator_dblp::DblpDatabase;
+use hallucinator_dblp::DblpPool;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Shared application state accessible from all handlers.
 pub struct AppState {
     pub dblp_offline_path: Option<PathBuf>,
-    pub dblp_offline_db: Option<Arc<Mutex<DblpDatabase>>>,
+    pub dblp_offline_db: Option<Arc<DblpPool>>,
     pub dblp_offline_path_display: String,
 }


### PR DESCRIPTION
## Summary
Three related performance fixes for the offline (SQLite/Tantivy-backed) databases, prompted by DBLP feeling slow relative to the other offline backends:

- **Connection pooling** — DBLP, ACL Anthology, arXiv, and IACR ePrint offline backends each shared a single SQLite connection behind `Arc<Mutex<_>>`, serializing every lookup through one lock regardless of configured concurrency. Replaced with a small pool of independent read connections (round-robin, striped locking). OpenAlex is backed by Tantivy instead — its `Index`/`IndexReader` are already `Send + Sync` and safe for concurrent reads, so the `Mutex` there was pure unnecessary serialization; just share it via a plain `Arc` now.
- **DBLP OR-fallback query selectivity** — profiling against the real ~2.76GB/8.4M-row `dblp.db` showed the not-found path (common, since that's exactly what this tool checks for) falls through to an OR-fallback FTS5 query, and FTS5's `ORDER BY rank LIMIT k` has no top-k pruning — cost scales with the document frequency of the *rarest* included term, not the limit. OR-ing in a common word (e.g. "learning": ~600K/8.4M titles) could cost over a second. Now picks the most selective (lowest document-frequency) words via a session-local `fts5vocab` table instead of arbitrary extraction order. Cuts the not-found average from ~450ms to ~150ms and the worst observed case from ~1.2s to ~140ms.
- **Pool sizing matches `num_workers`** — the pools above defaulted to a hardcoded size of 4, matching only the *default* worker count. Raising `num_workers` (reasonable for more throughput) made per-query averages *worse*, not better: extra workers queued behind only 4 connections, and DBLP's not-found path is expensive enough that the queueing wait alone pushed reported averages into the seconds range. Pool size now follows `num_workers` in the CLI, TUI (at startup and on config changes — a `num_workers` edit alone now triggers a resize, not just a path change), and Python bindings.

## Test plan
- [x] `cargo check --workspace` / `cargo clippy --workspace -- -D warnings` clean
- [x] Full test suite across touched crates (hallucinator-dblp, -acl, -arxiv-offline, -iacr-eprint, -core, -cli, -tui) passes, including the DBLP OR-fallback regression test
- [x] `hallucinator-python` checked separately (excluded from the main workspace)
- [x] Verified against the real production databases with a synthetic `ValidationPool` benchmark mirroring the TUI's actual concurrency: confirmed no queueing inflation at `num_workers=4`, and confirmed (separately, as expected) that pushing `num_workers` past the machine's core count makes DBLP's CPU/IO-heavy not-found path genuinely slower under real contention — not something a pool-size fix can or should paper over

🤖 Generated with [Claude Code](https://claude.com/claude-code)