### PR TITLE
Prepare 0.2.2 release

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-acl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-arxiv-offline"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dirs",
  "flate2",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-bbl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "biblatex",
  "hallucinator-core",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-dblp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-grobid"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hallucinator-core",
  "quick-xml",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-iacr-eprint"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "once_cell",
  "quick-xml",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-ingest"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "flate2",
  "hallucinator-bbl",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-openalex"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-compression",
  "flate2",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-parsing"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-pdf-mupdf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hallucinator-core",
  "mupdf",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-reporting"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hallucinator-core",
 ]
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-tui"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/hallucinator-rs/Cargo.toml
+++ b/hallucinator-rs/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/gianlucasb/hallucinator"

--- a/hallucinator-rs/crates/hallucinator-python/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hallucinator-python"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 description = "Python bindings for hallucinator reference extraction"


### PR DESCRIPTION
Patch release bumping the workspace + `hallucinator-python` versions to **0.2.2**.

Rolls up the fixes landed since 0.2.1:

- **#306** — single-paper mode (`hallucinator-tui <paper.pdf>`) never started processing; the app would sit indefinitely on the Paper detail screen since that mode skips the Queue screen where manual-start lives. Now auto-starts.
- **#307** — offline DB (DBLP/ACL/arXiv/IACR) connection pooling replaces per-DB mutex-guarded single connections; DBLP's OR-fallback query now picks selective (low document-frequency) terms instead of arbitrary ones, cutting worst-case not-found latency from ~1.2s to ~140ms; offline DB pool sizes now follow `num_workers` instead of a hardcoded 4.

Tag `v0.2.2` after merge triggers the cargo-dist Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)