### PR TITLE
Support Kaggle's new API tokens for the arXiv snapshot download

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,17 @@ hallucinator-cli update-arxiv arxiv.db
 **First-time setup:** Kaggle requires authentication to download datasets. You'll need a free Kaggle account and an API token:
 
 1. Sign up at https://www.kaggle.com and go to https://www.kaggle.com/settings
-2. Click **Create New Token** — this downloads `kaggle.json`
-3. Place it at `~/.kaggle/kaggle.json` (the standard Kaggle CLI location), or export the credentials as env vars: `export KAGGLE_USERNAME=… KAGGLE_KEY=…`
+2. In the **API** section, create a new token. Kaggle shows it once, as a single `KGAT_…` string — copy it before closing the dialog
+3. Hand it to Hallucinator either way — export it, or save it to the file the Kaggle client reads automatically:
+   ```bash
+   export KAGGLE_API_TOKEN=KGAT_your_token_here
+   ```
+   ```bash
+   mkdir -p ~/.kaggle && printf '%s' 'KGAT_your_token_here' > ~/.kaggle/access_token && chmod 600 ~/.kaggle/access_token
+   ```
 4. Open https://www.kaggle.com/datasets/Cornell-University/arxiv **once in a browser** and accept the dataset license (Kaggle returns 403 on first download otherwise)
+
+Already set up with the older credentials? They still work — `~/.kaggle/kaggle.json` and `KAGGLE_USERNAME` + `KAGGLE_KEY` are both still accepted, and Kaggle still issues them under **Legacy API Credentials**. Tokens win when both are present, so if a token is rejected, clear it to fall back. `update-arxiv` prints which credential it picked up before the download starts.
 
 The full build takes ~10-20 minutes (download + ingest). If you already have the Kaggle zip or extracted JSON, point at it directly and skip the download:
 

--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ hallucinator-cli update-arxiv arxiv.db
    ```bash
    mkdir -p ~/.kaggle && printf '%s' 'KGAT_your_token_here' > ~/.kaggle/access_token && chmod 600 ~/.kaggle/access_token
    ```
-4. Open https://www.kaggle.com/datasets/Cornell-University/arxiv **once in a browser** and accept the dataset license (Kaggle returns 403 on first download otherwise)
-
 Already set up with the older credentials? They still work — `~/.kaggle/kaggle.json` and `KAGGLE_USERNAME` + `KAGGLE_KEY` are both still accepted, and Kaggle still issues them under **Legacy API Credentials**. Tokens win when both are present, so if a token is rejected, clear it to fall back. `update-arxiv` prints which credential it picked up before the download starts.
+
+If a download comes back 403, open https://www.kaggle.com/datasets/Cornell-University/arxiv once in a browser — some Kaggle datasets gate downloads behind accepting their terms. The arXiv snapshot currently doesn't, so a 403 is more likely a rejected credential.
 
 The full build takes ~10-20 minutes (download + ingest). If you already have the Kaggle zip or extracted JSON, point at it directly and skip the download:
 

--- a/hallucinator-rs/README.md
+++ b/hallucinator-rs/README.md
@@ -104,9 +104,8 @@ hallucinator-cli update-acl acl.db
 
 # arXiv (~4GB download from Kaggle — needs a Kaggle API token in
 # KAGGLE_API_TOKEN or ~/.kaggle/access_token, or legacy
-# KAGGLE_USERNAME+KAGGLE_KEY / ~/.kaggle/kaggle.json credentials;
-# accept the dataset license once at
-# https://www.kaggle.com/datasets/Cornell-University/arxiv)
+# KAGGLE_USERNAME+KAGGLE_KEY / ~/.kaggle/kaggle.json credentials.
+# Dataset: https://www.kaggle.com/datasets/Cornell-University/arxiv)
 hallucinator-cli update-arxiv arxiv.db
 
 # Alternative: skip the download and point at an already-downloaded

--- a/hallucinator-rs/README.md
+++ b/hallucinator-rs/README.md
@@ -102,9 +102,11 @@ hallucinator-cli update-dblp dblp.db
 # ACL Anthology
 hallucinator-cli update-acl acl.db
 
-# arXiv (~4GB download from Kaggle — needs ~/.kaggle/kaggle.json or
-# KAGGLE_USERNAME+KAGGLE_KEY env vars; accept the dataset license once
-# at https://www.kaggle.com/datasets/Cornell-University/arxiv)
+# arXiv (~4GB download from Kaggle — needs a Kaggle API token in
+# KAGGLE_API_TOKEN or ~/.kaggle/access_token, or legacy
+# KAGGLE_USERNAME+KAGGLE_KEY / ~/.kaggle/kaggle.json credentials;
+# accept the dataset license once at
+# https://www.kaggle.com/datasets/Cornell-University/arxiv)
 hallucinator-cli update-arxiv arxiv.db
 
 # Alternative: skip the download and point at an already-downloaded

--- a/hallucinator-rs/crates/hallucinator-arxiv-offline/src/download.rs
+++ b/hallucinator-rs/crates/hallucinator-arxiv-offline/src/download.rs
@@ -1,11 +1,23 @@
 //! Kaggle dataset download for the arXiv metadata snapshot.
 //!
-//! Uses Kaggle's public API (Basic auth with username + key). Streams
-//! the zip to disk instead of buffering in RAM so the ~4 GB payload
-//! doesn't blow up memory usage. Credentials come from either the
-//! standard `~/.kaggle/kaggle.json` file (same location `kaggle` CLI
-//! uses) or from `KAGGLE_USERNAME` + `KAGGLE_KEY` env vars — env vars
-//! win when both are set.
+//! Streams the zip to disk instead of buffering it in RAM so the ~4 GB
+//! payload doesn't blow up memory usage.
+//!
+//! Kaggle has two generations of credentials in circulation and we
+//! accept both:
+//!
+//! - **API tokens** — one opaque `KGAT_…` string, which is what the
+//!   settings page hands out now. Sent as `Authorization: Bearer …`.
+//!   Read from the `KAGGLE_API_TOKEN` env var or
+//!   `~/.kaggle/access_token`.
+//! - **Legacy API keys** — the older username + key pair from
+//!   `kaggle.json`. Still honoured by the API, and still obtainable
+//!   under "Legacy API Credentials". Sent as HTTP Basic auth. Read
+//!   from `KAGGLE_USERNAME` + `KAGGLE_KEY` or `~/.kaggle/kaggle.json`.
+//!
+//! Source order matches the official Kaggle SDK: every token source
+//! before any legacy key source, env vars before files within each
+//! tier.
 
 use std::fs::File;
 use std::io::Write;
@@ -24,6 +36,12 @@ pub const KAGGLE_DATASET: &str = "Cornell-University/arxiv";
 /// years; if that ever changes we'd rather fail loud than guess.
 pub const KAGGLE_DUMP_ENTRY: &str = "arxiv-metadata-oai-snapshot.json";
 
+/// Plain-text token files the Kaggle settings page tells users to
+/// create. The `.txt` sibling is checked because Windows editors like
+/// to append the extension — the official SDK checks it for the same
+/// reason.
+const ACCESS_TOKEN_FILENAMES: [&str; 2] = ["access_token", "access_token.txt"];
+
 /// Progress events emitted while downloading.
 #[derive(Debug, Clone)]
 pub enum DownloadProgress {
@@ -40,36 +58,104 @@ pub enum DownloadProgress {
     Complete { bytes: u64, elapsed: Duration },
 }
 
+/// A Kaggle credential together with the wire format it has to be
+/// presented in.
+#[derive(Clone, PartialEq, Eq)]
+pub enum KaggleAuth {
+    /// New-style API token (`KGAT_…`), sent as a bearer token.
+    Token(String),
+    /// Legacy username + API key pair, sent as HTTP Basic auth.
+    ApiKey { username: String, key: String },
+}
+
+impl KaggleAuth {
+    /// Attach the credential to an outgoing request.
+    pub fn apply(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self {
+            Self::Token(token) => request.bearer_auth(token),
+            Self::ApiKey { username, key } => request.basic_auth(username, Some(key)),
+        }
+    }
+
+    /// Human-readable credential kind, for progress and error output.
+    /// Never includes the secret itself.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Token(_) => "API token",
+            Self::ApiKey { .. } => "legacy username + key",
+        }
+    }
+}
+
+/// Redacted on purpose — this type flows through error paths that get
+/// printed and logged.
+impl std::fmt::Debug for KaggleAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Token(_) => f.write_str("Token(<redacted>)"),
+            Self::ApiKey { username, .. } => f
+                .debug_struct("ApiKey")
+                .field("username", username)
+                .field("key", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+/// Legacy `kaggle.json` shape. Both fields default so a file missing
+/// one of them lands on the "empty username or key" message instead of
+/// a serde error nobody can act on.
 #[derive(Debug, Deserialize)]
-struct KaggleCredentials {
+struct LegacyCredentialsFile {
+    #[serde(default)]
     username: String,
+    #[serde(default)]
     key: String,
 }
 
-/// Locate Kaggle credentials. Tries `KAGGLE_USERNAME` + `KAGGLE_KEY`
-/// first, then `~/.kaggle/kaggle.json`. Error messages point at the
-/// Kaggle settings page so first-time users know where to go.
-pub fn load_credentials() -> Result<(String, String), ArxivError> {
-    if let (Ok(u), Ok(k)) = (
-        std::env::var("KAGGLE_USERNAME"),
-        std::env::var("KAGGLE_KEY"),
-    ) && !u.is_empty()
-        && !k.is_empty()
-    {
-        return Ok((u, k));
+/// Read a token out of a file. Missing, unreadable and empty-after-
+/// trimming are all treated alike: no token here, try the next source.
+fn read_token_file(path: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let token = contents.trim();
+    if token.is_empty() {
+        return None;
     }
-    let home =
-        dirs::home_dir().ok_or_else(|| ArxivError::Harvest("HOME directory not found".into()))?;
-    let path = home.join(".kaggle").join("kaggle.json");
-    let file = File::open(&path).map_err(|e| {
-        ArxivError::Harvest(format!(
-            "Kaggle credentials missing at {}: {e}\n\
-             Set KAGGLE_USERNAME + KAGGLE_KEY env vars, or place kaggle.json there.\n\
-             Get a token at https://www.kaggle.com/settings → \"Create New Token\".",
-            path.display()
-        ))
-    })?;
-    let creds: KaggleCredentials = serde_json::from_reader(file)
+    Some(token.to_string())
+}
+
+/// `KAGGLE_API_TOKEN` normally holds the token itself. The official SDK
+/// also accepts a path to a file containing one, so tooling that can
+/// only hand over file paths keeps working; mirror that.
+fn token_from_env() -> Option<String> {
+    let value = std::env::var("KAGGLE_API_TOKEN").ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let as_path = Path::new(value);
+    if as_path.is_file() {
+        return read_token_file(as_path);
+    }
+    Some(value.to_string())
+}
+
+fn legacy_key_from_env() -> Option<KaggleAuth> {
+    let username = std::env::var("KAGGLE_USERNAME").ok()?;
+    let key = std::env::var("KAGGLE_KEY").ok()?;
+    if username.is_empty() || key.is_empty() {
+        return None;
+    }
+    Some(KaggleAuth::ApiKey { username, key })
+}
+
+/// Parse a legacy `kaggle.json`. Unlike the token files, a file that
+/// exists but doesn't parse is a hard error rather than a fallthrough —
+/// the user clearly meant to authenticate with it.
+fn legacy_key_from_file(path: &Path) -> Result<KaggleAuth, ArxivError> {
+    let file = File::open(path)
+        .map_err(|e| ArxivError::Harvest(format!("opening {}: {e}", path.display())))?;
+    let creds: LegacyCredentialsFile = serde_json::from_reader(file)
         .map_err(|e| ArxivError::Harvest(format!("parsing {}: {e}", path.display())))?;
     if creds.username.is_empty() || creds.key.is_empty() {
         return Err(ArxivError::Harvest(format!(
@@ -77,17 +163,71 @@ pub fn load_credentials() -> Result<(String, String), ArxivError> {
             path.display()
         )));
     }
-    Ok((creds.username, creds.key))
+    Ok(KaggleAuth::ApiKey {
+        username: creds.username,
+        key: creds.key,
+    })
+}
+
+/// Locate a Kaggle credential. See the module docs for the source
+/// order; the error walks first-time users through creating a token.
+pub fn load_credentials() -> Result<KaggleAuth, ArxivError> {
+    let kaggle_dir = dirs::home_dir().map(|home| home.join(".kaggle"));
+    load_credentials_from(kaggle_dir.as_deref())
+}
+
+/// Resolution against an explicit config dir. Split out so tests can
+/// point at a temp dir rather than the developer's real `~/.kaggle`.
+fn load_credentials_from(kaggle_dir: Option<&Path>) -> Result<KaggleAuth, ArxivError> {
+    if let Some(token) = token_from_env() {
+        return Ok(KaggleAuth::Token(token));
+    }
+    if let Some(dir) = kaggle_dir {
+        for filename in ACCESS_TOKEN_FILENAMES {
+            if let Some(token) = read_token_file(&dir.join(filename)) {
+                return Ok(KaggleAuth::Token(token));
+            }
+        }
+    }
+    if let Some(auth) = legacy_key_from_env() {
+        return Ok(auth);
+    }
+    if let Some(dir) = kaggle_dir {
+        let path = dir.join("kaggle.json");
+        if path.exists() {
+            return legacy_key_from_file(&path);
+        }
+    }
+
+    Err(ArxivError::Harvest(missing_credentials_message(kaggle_dir)))
+}
+
+/// First-run guidance. Leads with the token flow because that is what
+/// the settings page offers now, and mentions `kaggle.json` after it so
+/// users who already have one still recognise their setup.
+fn missing_credentials_message(kaggle_dir: Option<&Path>) -> String {
+    let token_file = match kaggle_dir {
+        Some(dir) => dir.join("access_token").display().to_string(),
+        None => "~/.kaggle/access_token".to_string(),
+    };
+    format!(
+        "Kaggle credentials not found.\n\
+         Create a token in the API section of https://www.kaggle.com/settings, then either:\n\
+         - export KAGGLE_API_TOKEN=<token>\n\
+         - or save the token to {token_file}\n\
+         Legacy credentials still work too: set KAGGLE_USERNAME + KAGGLE_KEY, or place a \
+         kaggle.json next to the path above."
+    )
 }
 
 /// Download the Kaggle dataset zip to `dest_path`, streaming to disk.
 /// Returns the number of bytes written. `reqwest` follows the
-/// Kaggle → S3 pre-signed-URL redirect automatically.
+/// Kaggle → cloud-storage pre-signed-URL redirect automatically.
 pub async fn download_kaggle_zip<P>(dest_path: &Path, mut progress: P) -> Result<u64, ArxivError>
 where
     P: FnMut(DownloadProgress),
 {
-    let (user, key) = load_credentials()?;
+    let auth = load_credentials()?;
     let url = format!("https://www.kaggle.com/api/v1/datasets/download/{KAGGLE_DATASET}");
     // 1 h cap: 4 GB on a slow home link (~5 Mbit/s) takes roughly that
     // long. Longer than the default reqwest timeout, shorter than
@@ -101,9 +241,8 @@ where
         .build()
         .map_err(|e| ArxivError::Harvest(format!("http client: {e}")))?;
     let start = Instant::now();
-    let resp = client
-        .get(&url)
-        .basic_auth(&user, Some(&key))
+    let resp = auth
+        .apply(client.get(&url))
         .send()
         .await
         .map_err(|e| ArxivError::Harvest(format!("kaggle request: {e}")))?;
@@ -112,10 +251,12 @@ where
         || resp.status() == reqwest::StatusCode::FORBIDDEN
     {
         return Err(ArxivError::Harvest(format!(
-            "Kaggle returned HTTP {} — credentials rejected, or you haven't accepted \
-             the dataset license. Open https://www.kaggle.com/datasets/{KAGGLE_DATASET} \
-             in a browser once to accept, then retry.",
-            resp.status()
+            "Kaggle returned HTTP {} for your {} — the credential was rejected (tokens \
+             expire and can be revoked), or you haven't accepted the dataset license. \
+             Open https://www.kaggle.com/datasets/{KAGGLE_DATASET} in a browser once to \
+             accept, then retry.",
+            resp.status(),
+            auth.kind()
         )));
     }
     if !resp.status().is_success() {
@@ -171,39 +312,257 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
 
-    #[test]
-    fn credentials_env_vars_win() {
-        // SAFETY: single-threaded test; no other threads reading env.
-        unsafe {
-            std::env::set_var("KAGGLE_USERNAME", "env-user");
-            std::env::set_var("KAGGLE_KEY", "env-key");
+    /// Every credential env var the loader consults, so a test can
+    /// start from a known-empty environment.
+    const CREDENTIAL_VARS: [&str; 3] = ["KAGGLE_API_TOKEN", "KAGGLE_USERNAME", "KAGGLE_KEY"];
+
+    /// Env vars are process-global, so these tests have to run one at a
+    /// time.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Clears every credential env var for the duration of a test, so a
+    /// test only sees the sources it sets up itself and a developer's
+    /// own `KAGGLE_*` exports can't change the outcome.
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            // A test that panics mid-assert poisons the lock; the env is
+            // still cleaned up by Drop, so keep going.
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            clear_credential_vars();
+            Self { _lock: lock }
         }
-        let (u, k) = load_credentials().unwrap();
-        assert_eq!(u, "env-user");
-        assert_eq!(k, "env-key");
-        unsafe {
-            std::env::remove_var("KAGGLE_USERNAME");
-            std::env::remove_var("KAGGLE_KEY");
+
+        fn set(&self, key: &str, value: &str) {
+            // SAFETY: ENV_LOCK serialises every test that touches env.
+            unsafe { std::env::set_var(key, value) }
         }
     }
 
-    #[test]
-    fn missing_credentials_has_helpful_message() {
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            clear_credential_vars();
+        }
+    }
+
+    fn clear_credential_vars() {
+        // SAFETY: callers hold ENV_LOCK.
         unsafe {
-            std::env::remove_var("KAGGLE_USERNAME");
-            std::env::remove_var("KAGGLE_KEY");
+            for var in CREDENTIAL_VARS {
+                std::env::remove_var(var);
+            }
         }
-        // We can't easily hide the real ~/.kaggle/kaggle.json, but the
-        // error message contract is still exercised when it's absent.
-        // Skip if the dev machine happens to have one.
-        let path = dirs::home_dir().map(|h| h.join(".kaggle").join("kaggle.json"));
-        if path.as_ref().is_some_and(|p| p.exists()) {
-            return;
-        }
-        let err = load_credentials().unwrap_err();
-        let msg = format!("{err}");
+    }
+
+    /// Creates `<dir>/<name>` with `contents`, standing in for a file in
+    /// the user's `~/.kaggle`.
+    fn write_config_file(dir: &Path, name: &str, contents: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    fn authorization_header(auth: &KaggleAuth) -> String {
+        let request = auth
+            .apply(reqwest::Client::new().get("https://www.kaggle.com/"))
+            .build()
+            .unwrap();
+        request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .expect("credential set no Authorization header")
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn token_goes_out_as_a_bearer_header() {
+        let auth = KaggleAuth::Token("KGAT_testtoken".to_string());
+        assert_eq!(authorization_header(&auth), "Bearer KGAT_testtoken");
+    }
+
+    #[test]
+    fn legacy_key_goes_out_as_basic_auth() {
+        let auth = KaggleAuth::ApiKey {
+            username: "user".to_string(),
+            key: "key".to_string(),
+        };
+        // base64("user:key")
+        assert_eq!(authorization_header(&auth), "Basic dXNlcjprZXk=");
+    }
+
+    #[test]
+    fn debug_does_not_leak_the_secret() {
+        let token = format!("{:?}", KaggleAuth::Token("KGAT_secret".to_string()));
+        assert!(!token.contains("KGAT_secret"), "got: {token}");
+        let legacy = format!(
+            "{:?}",
+            KaggleAuth::ApiKey {
+                username: "user".to_string(),
+                key: "supersecret".to_string(),
+            }
+        );
+        assert!(!legacy.contains("supersecret"), "got: {legacy}");
+        assert!(legacy.contains("user"), "got: {legacy}");
+    }
+
+    #[test]
+    fn token_env_var_wins_over_every_other_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = EnvGuard::new();
+        env.set("KAGGLE_API_TOKEN", "KGAT_fromenv");
+        env.set("KAGGLE_USERNAME", "env-user");
+        env.set("KAGGLE_KEY", "env-key");
+        write_config_file(dir.path(), "access_token", "KGAT_fromfile");
+        write_config_file(dir.path(), "kaggle.json", r#"{"username":"f","key":"k"}"#);
+        assert_eq!(
+            load_credentials_from(Some(dir.path())).unwrap(),
+            KaggleAuth::Token("KGAT_fromenv".to_string())
+        );
+    }
+
+    /// Kaggle's own tooling accepts a path in `KAGGLE_API_TOKEN`, so a
+    /// secret mounted as a file works without a wrapper script.
+    #[test]
+    fn token_env_var_may_hold_a_file_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = EnvGuard::new();
+        let token_path = dir.path().join("mounted-secret");
+        std::fs::write(&token_path, "KGAT_fromfilepath\n").unwrap();
+        env.set("KAGGLE_API_TOKEN", token_path.to_str().unwrap());
+        assert_eq!(
+            load_credentials_from(None).unwrap(),
+            KaggleAuth::Token("KGAT_fromfilepath".to_string())
+        );
+    }
+
+    #[test]
+    fn access_token_file_is_read_and_trimmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new();
+        write_config_file(dir.path(), "access_token", "  KGAT_fromfile\n");
+        assert_eq!(
+            load_credentials_from(Some(dir.path())).unwrap(),
+            KaggleAuth::Token("KGAT_fromfile".to_string())
+        );
+    }
+
+    #[test]
+    fn access_token_txt_is_a_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new();
+        write_config_file(dir.path(), "access_token.txt", "KGAT_windows\n");
+        assert_eq!(
+            load_credentials_from(Some(dir.path())).unwrap(),
+            KaggleAuth::Token("KGAT_windows".to_string())
+        );
+    }
+
+    /// An access_token file left empty by a failed copy-paste shouldn't
+    /// shadow working legacy credentials.
+    #[test]
+    fn empty_access_token_file_falls_through_to_kaggle_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new();
+        write_config_file(dir.path(), "access_token", "\n  \n");
+        write_config_file(
+            dir.path(),
+            "kaggle.json",
+            r#"{"username":"json-user","key":"json-key"}"#,
+        );
+        assert_eq!(
+            load_credentials_from(Some(dir.path())).unwrap(),
+            KaggleAuth::ApiKey {
+                username: "json-user".to_string(),
+                key: "json-key".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_env_vars_still_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = EnvGuard::new();
+        env.set("KAGGLE_USERNAME", "env-user");
+        env.set("KAGGLE_KEY", "env-key");
+        assert_eq!(
+            load_credentials_from(Some(dir.path())).unwrap(),
+            KaggleAuth::ApiKey {
+                username: "env-user".to_string(),
+                key: "env-key".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_env_vars_lose_to_a_token_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = EnvGuard::new();
+        env.set("KAGGLE_USERNAME", "env-user");
+        env.set("KAGGLE_KEY", "env-key");
+        write_config_file(dir.path(), "access_token", "KGAT_fromfile");
+        assert_eq!(
+            load_credentials_from(Some(dir.path())).unwrap(),
+            KaggleAuth::Token("KGAT_fromfile".to_string())
+        );
+    }
+
+    #[test]
+    fn kaggle_json_still_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new();
+        write_config_file(
+            dir.path(),
+            "kaggle.json",
+            r#"{"username":"json-user","key":"json-key"}"#,
+        );
+        assert_eq!(
+            load_credentials_from(Some(dir.path())).unwrap(),
+            KaggleAuth::ApiKey {
+                username: "json-user".to_string(),
+                key: "json-key".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_kaggle_json_is_a_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new();
+        write_config_file(dir.path(), "kaggle.json", "{not json");
+        let msg = load_credentials_from(Some(dir.path()))
+            .unwrap_err()
+            .to_string();
         assert!(msg.contains("kaggle.json"), "got: {msg}");
-        assert!(msg.contains("Create New Token"), "got: {msg}");
+    }
+
+    #[test]
+    fn kaggle_json_without_a_key_is_reported_as_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new();
+        write_config_file(dir.path(), "kaggle.json", r#"{"username":"u"}"#);
+        let msg = load_credentials_from(Some(dir.path()))
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("empty username or key"), "got: {msg}");
+    }
+
+    #[test]
+    fn missing_credentials_points_at_the_token_flow() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new();
+        let msg = load_credentials_from(Some(dir.path()))
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("KAGGLE_API_TOKEN"), "got: {msg}");
+        assert!(msg.contains("access_token"), "got: {msg}");
+        assert!(msg.contains("kaggle.com/settings"), "got: {msg}");
+        // The legacy path stays discoverable for anyone who already has one.
+        assert!(msg.contains("kaggle.json"), "got: {msg}");
     }
 }

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -148,9 +148,10 @@ enum Command {
 
     /// Ingest the Kaggle arXiv metadata snapshot into a local SQLite database.
     ///
-    /// By default downloads the ~4 GB Kaggle dump (Cornell-University/arxiv)
-    /// using credentials from KAGGLE_USERNAME+KAGGLE_KEY env vars or
-    /// ~/.kaggle/kaggle.json, then streams it into the SQLite schema.
+    /// By default downloads the ~4 GB Kaggle dump (Cornell-University/arxiv),
+    /// then streams it into the SQLite schema. Credentials come from the
+    /// KAGGLE_API_TOKEN env var or ~/.kaggle/access_token, falling back to
+    /// legacy KAGGLE_USERNAME+KAGGLE_KEY or ~/.kaggle/kaggle.json.
     /// Use --dump to point at an already-downloaded zip or JSON file.
     UpdateArxiv {
         /// Path to store the arXiv SQLite database
@@ -2077,6 +2078,13 @@ async fn update_arxiv(
                 .map(|p| p.to_path_buf())
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join("arxiv-kaggle.zip");
+            // Resolve credentials up front: a missing token should fail
+            // in a second, not after the progress bar is on screen. The
+            // kind is worth echoing during the token migration, when a
+            // stale kaggle.json and a fresh access_token can both be
+            // sitting in ~/.kaggle.
+            let auth = download::load_credentials()?;
+            println!("Authenticating to Kaggle with your {}", auth.kind());
             println!("Downloading Kaggle arxiv snapshot to: {}", dest.display());
             println!(
                 "(If this is your first run, open https://www.kaggle.com/datasets/Cornell-University/arxiv\n\

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -2086,10 +2086,6 @@ async fn update_arxiv(
             let auth = download::load_credentials()?;
             println!("Authenticating to Kaggle with your {}", auth.kind());
             println!("Downloading Kaggle arxiv snapshot to: {}", dest.display());
-            println!(
-                "(If this is your first run, open https://www.kaggle.com/datasets/Cornell-University/arxiv\n\
-                 once in a browser and accept the dataset license.)"
-            );
             let bar = ProgressBar::new(0);
             bar.set_style(
                 ProgressStyle::with_template(

--- a/hallucinator-rs/crates/hallucinator-tui/src/tips.txt
+++ b/hallucinator-rs/crates/hallucinator-tui/src/tips.txt
@@ -20,7 +20,7 @@ Pro-tip: Press o to add more PDFs to the queue without restarting
 Pro-tip: Build an offline ACL Anthology database for local lookups (hallucinator-tui update-acl)
 Pro-tip: Build an offline OpenAlex index for local lookups (hallucinator-tui update-openalex)
 Pro-tip: Build an offline arXiv database from the weekly Kaggle snapshot (hallucinator-tui update-arxiv)
-Pro-tip: Offline arXiv needs Kaggle credentials -- put kaggle.json in ~/.kaggle/ or set KAGGLE_USERNAME+KAGGLE_KEY
+Pro-tip: Offline arXiv needs a Kaggle API token -- set KAGGLE_API_TOKEN or save it to ~/.kaggle/access_token
 Pro-tip: Filter OpenAlex imports by date (--since 2024-01-01) or publication year (--min-year 2020)
 Pro-tip: Enable SearxNG as a fallback web search source (--searxng or configure URL in config)
 Pro-tip: Get a free GovInfo API key at api.data.gov for US federal laws, regulations, and court opinions


### PR DESCRIPTION
> Superseded #310, which I opened against the wrong base by mistake and closed within minutes. Same work, correctly scoped — not a resubmission.

## The problem

Kaggle's settings page no longer hands out a `kaggle.json` with a username and key. It now issues a single opaque `KGAT_…` token, surfaced to users as either `KAGGLE_API_TOKEN` or a plain-text `~/.kaggle/access_token` file — and that token authenticates as a **bearer** token, not HTTP Basic.

`update-arxiv` only knew how to read `username` + `key`, and only knew how to send Basic auth. So anyone setting Kaggle up from scratch today had no working path to the offline arXiv database: they'd follow the README, get a `KGAT_…` string, and find nowhere to put it.

## The change

`KaggleAuth` carries the credential together with the wire format it has to go out in — bearer for tokens, Basic for legacy keys — so the transport can't drift from the credential kind.

Source order mirrors the official Kaggle SDK (`kagglesdk`), every token source before any legacy key source:

| Priority | Source | Sent as |
|---|---|---|
| 1 | `KAGGLE_API_TOKEN` env var (may hold the token, or a path to a file containing it) | `Authorization: Bearer …` |
| 2 | `~/.kaggle/access_token`, then `~/.kaggle/access_token.txt` | `Authorization: Bearer …` |
| 3 | `KAGGLE_USERNAME` + `KAGGLE_KEY` env vars | HTTP Basic |
| 4 | `~/.kaggle/kaggle.json` | HTTP Basic |

**Existing setups keep working untouched.** Kaggle still honours legacy keys and still issues them under "Legacy API Credentials", so 3 and 4 stay supported rather than being deprecated out.

Around the edges:

- A token file that exists but is **empty** falls through to the next source, so a failed copy-paste can't shadow working legacy credentials. A `kaggle.json` that exists but **doesn't parse** stays a hard error — the user clearly meant to authenticate with it.
- `KaggleAuth`'s `Debug` redacts the secret; it reaches error paths that get printed and logged.
- `update-arxiv` resolves credentials *before* starting the download, so a missing token fails in a second rather than after the progress bar is up. It also names the credential kind it found — worth having while a stale `kaggle.json` and a fresh `access_token` can both be sitting in `~/.kaggle`.

## Second commit: the license claim was wrong

Three places asserted that the arXiv snapshot needs its license accepted before it will download, one of them an **unconditional** `println!` in `update-arxiv` that fired before every download regardless of outcome. When a slow transfer went quiet, that line read as a diagnosis of what had gone wrong — it cost me a real debugging detour on a live run.

It isn't true. A request to the download route with no `Authorization` header at all returns `206` with a valid signed storage URL, so nothing gates that dataset behind accepting terms.

- Dropped the unconditional `println!`. The 401/403 error in `download.rs` already names the license as one possible cause, on a path that only runs when a 403 actually happened — which is where that guidance belongs, and it's left alone.
- Demoted the README claims ("accept the dataset license" as a required setup step, "Kaggle returns 403 on first download otherwise") to a troubleshooting note: some Kaggle datasets do gate downloads, this one currently doesn't, so a 403 here more likely means a rejected credential.

## Docs

- `README.md` — first-time setup walks through the token flow, notes that legacy credentials still work and that tokens win when both are present.
- `hallucinator-rs/README.md` — credential sources in the `update-arxiv` comment.
- `update-arxiv --help` — same.
- TUI pro-tip — points at `KAGGLE_API_TOKEN` / `~/.kaggle/access_token`.

## Verification

- 14 new unit tests over credential resolution: each source, the precedence between them, the empty-file fallthrough, the malformed-JSON hard error, `Debug` redaction, and — pinning the actual point of this PR — that a token goes out as `Bearer …` and a legacy key as `Basic …`.
- Against the live endpoint: a bearer token on `/api/v1/datasets/download/Cornell-University/arxiv` returns `206` with a valid signed storage URL.
- End to end on two machines: `update-arxiv` picks up `~/.kaggle/access_token`, reports `Authenticating to Kaggle with your API token`, and streams the snapshot. On a Linux box it completed a full ~4 GB download and ingest.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean under clippy 1.98 once #312 lands. `main` itself is currently red on the new stable via `clippy::drain_collect` in a file this PR doesn't touch — that's what the failing check here is, not this change.

Because that dataset currently downloads anonymously, the live check confirms a bearer token is *accepted* on that route rather than *required*. The auth transport is taken from `kagglesdk`'s `kaggle_http_client.py`, which sends `Authorization: Bearer …` for access tokens and Basic for legacy key pairs, and the source order from its `kaggle_env.py`.

## Two things I deliberately left out

**Anonymous fallback.** If that dataset downloads with no credentials, `update-arxiv` could attempt anonymous access when it finds no credential instead of erroring — no Kaggle account needed at all. That's a contract change and speculative about how Kaggle treats unauthenticated bulk downloads, so it doesn't belong here.

**Download robustness.** The client sets a total request timeout but no read timeout, and `File::create` truncates rather than resuming. A mid-transfer stall therefore hangs until the hour is up and then restarts from zero — I hit this on a 4 GB pull over a slow link. A read timeout plus `Range`-based resume would fix it, but it's orthogonal to credentials.

The workspace test suite passes, but it has pre-existing flakiness worth flagging: across repeated full-suite runs on plain `main` I saw three different tests fail intermittently (in `hallucinator-tui`'s `app::processing` and `hallucinator-core`'s `cache`), each passing 5/5 when run in isolation — which points at parallel-test interference rather than anything in this PR. CI doesn't run `cargo test`, so it doesn't surface here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
