### PR TITLE
Fix clippy 1.98 drain_collect lint in the file picker

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/processing.rs
@@ -325,7 +325,7 @@ impl App {
     /// (one per tick) so the UI can show progress. JSON result files are loaded
     /// and their papers added as already-complete entries.
     pub fn add_files_from_picker(&mut self) {
-        let new_files: Vec<PathBuf> = self.file_picker.selected.drain(..).collect();
+        let new_files: Vec<PathBuf> = std::mem::take(&mut self.file_picker.selected);
         if new_files.is_empty() {
             return;
         }


### PR DESCRIPTION
Rust 1.98 (released 2026-08-18) promotes `clippy::drain_collect`, which fires on draining a collection straight into a new one of the same type. CI runs clippy on stable with `-D warnings`, so `main` is red on the new toolchain until this is fixed — same shape as the earlier 1.95 and 1.97 lint passes.

```
error: draining all elements of a collection into a new collection of the same type
   --> crates/hallucinator-tui/src/app/processing.rs:328:39
```

`mem::take` is equivalent here: both leave the field an empty `Vec` and hand the caller the previous contents, and `take` skips the extra allocation.

## Verification

Checked out plain `main` at `d69fe71` and ran the workspace with clippy `0.1.98`:

- **before:** fails with the error above, one site workspace-wide
- **after:** `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean

Found this while opening #311 against a red `main`; that PR doesn't touch this file and is clean under 1.98 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
