### PR TITLE
Local corpus: 8 new venue importers, FTS5 hyphen-quoting fix, CrossRef/OpenAlex fixes

### DIFF
--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -737,6 +737,114 @@ enum Command {
         #[arg(long, conflicts_with = "url")]
         from_file: Option<PathBuf>,
     },
+
+    /// Import ACM SIGCOMM's accepted-papers page into the local corpus.
+    ImportSigcomm {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "sigcomm2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Fetch live from this URL (e.g.
+        /// https://conferences.sigcomm.org/sigcomm/2026/accepted-papers/)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import ACM IMC's accepted-papers page into the local corpus.
+    ImportImc {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "imc2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Fetch live from this URL (e.g.
+        /// https://conferences.sigcomm.org/imc/2026/accepted-papers/)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import a DSN accepted-papers page into the local corpus.
+    ImportDsn {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "dsn2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Fetch live from this URL (e.g.
+        /// https://dsn2026.github.io/cpaccepted.html)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import a EuroSys accepted-papers page into the local corpus.
+    ImportEurosys {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "eurosys2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Fetch live from this URL (e.g.
+        /// https://2026.eurosys.org/papers.html)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import a SIGMOD accepted-papers page into the local corpus.
+    ImportSigmod {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "sigmod2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Fetch live from this URL (e.g.
+        /// https://2026.sigmod.org/sigmod_papers.shtml)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import a WWW ("The Web Conference") accepted-papers track page
+    /// into the local corpus. Separate pages exist per track — run once
+    /// per page you want indexed.
+    ImportWww {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "www2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Fetch live from this URL (e.g.
+        /// https://www2026.thewebconf.org/accepted/research-tracks.html)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import a KDD accepted-papers page into the local corpus (parses
+    /// embedded JS data, not HTML — see the `kdd` ingest module).
+    ImportKdd {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "kdd2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Fetch live from this URL (e.g.
+        /// https://kdd2026.kdd.org/papers/)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -938,6 +1046,48 @@ async fn main() -> anyhow::Result<()> {
             url,
             from_file,
         } => import_infocom(&corpus, &source_tag, url, from_file).await,
+        Command::ImportSigcomm {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_sigcomm(&corpus, &source_tag, url, from_file).await,
+        Command::ImportImc {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_imc(&corpus, &source_tag, url, from_file).await,
+        Command::ImportDsn {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_dsn(&corpus, &source_tag, url, from_file).await,
+        Command::ImportEurosys {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_eurosys(&corpus, &source_tag, url, from_file).await,
+        Command::ImportSigmod {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_sigmod(&corpus, &source_tag, url, from_file).await,
+        Command::ImportWww {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_www(&corpus, &source_tag, url, from_file).await,
+        Command::ImportKdd {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_kdd(&corpus, &source_tag, url, from_file).await,
         Command::Check {
             file_path,
             no_color,
@@ -3529,6 +3679,146 @@ async fn import_infocom(
     let conn = hallucinator_local_corpus::open_or_create(corpus_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let stats = hallucinator_local_corpus::ingest::import_infocom(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import an ACM SIGCOMM accepted-papers page into the local corpus.
+async fn import_sigcomm(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_sigcomm(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import an ACM IMC accepted-papers page into the local corpus.
+async fn import_imc(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_imc(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a DSN accepted-papers page into the local corpus.
+async fn import_dsn(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_dsn(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a EuroSys accepted-papers page into the local corpus.
+async fn import_eurosys(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_eurosys(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a SIGMOD accepted-papers page into the local corpus.
+async fn import_sigmod(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_sigmod(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a WWW accepted-papers track page into the local corpus.
+async fn import_www(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_www(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a KDD accepted-papers page into the local corpus.
+async fn import_kdd(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_kdd(&conn, source, source_tag)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     print_import_stats(&stats);

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -845,6 +845,24 @@ enum Command {
         #[arg(long, conflicts_with = "url")]
         from_file: Option<PathBuf>,
     },
+
+    /// Import CHI (or any ACM-DL-front-matter-formatted) proceedings
+    /// from its front-matter PDF's table of contents into the local
+    /// corpus. CHI's own program site has no static content to scrape
+    /// (a JS app shell) — the ACM DL front-matter PDF (freely
+    /// downloadable, no paywall, linked from the proceedings' ACM DL
+    /// page) is the only usable source.
+    ImportChi {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "chi2026"
+        #[arg(long)]
+        source_tag: String,
+        /// Path to the downloaded front-matter PDF (e.g. a
+        /// `<id>.fm.pdf` file from the ACM DL proceedings page)
+        #[arg(long)]
+        pdf_path: PathBuf,
+    },
 }
 
 #[tokio::main]
@@ -1088,6 +1106,11 @@ async fn main() -> anyhow::Result<()> {
             url,
             from_file,
         } => import_kdd(&corpus, &source_tag, url, from_file).await,
+        Command::ImportChi {
+            corpus,
+            source_tag,
+            pdf_path,
+        } => import_chi(&corpus, &source_tag, &pdf_path),
         Command::Check {
             file_path,
             no_color,
@@ -3800,6 +3823,26 @@ async fn import_www(
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let stats = hallucinator_local_corpus::ingest::import_www(&conn, source, source_tag)
         .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import CHI (or any ACM-DL-front-matter-formatted) proceedings from
+/// its front-matter PDF into the local corpus. Not `async` — no network
+/// access, just local PDF text extraction + parsing.
+fn import_chi(corpus_path: &Path, source_tag: &str, pdf_path: &Path) -> anyhow::Result<()> {
+    use hallucinator_core::PdfBackend as _;
+    let text = hallucinator_pdf_mupdf::MupdfBackend
+        .extract_text(pdf_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_chi_frontmatter(&conn, &text, source_tag)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     print_import_stats(&stats);
     let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -863,6 +863,22 @@ enum Command {
         #[arg(long)]
         pdf_path: PathBuf,
     },
+
+    /// Import a PVLDB issue's front-matter PDF (its table of contents)
+    /// into the local corpus. PVLDB publishes monthly with no single
+    /// consolidated "accepted papers" page — run once per issue you
+    /// want indexed (the front-matter PDF is freely downloadable, no
+    /// paywall, from dl.acm.org/journal/pvldb or pvldb.org).
+    ImportVldb {
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Provenance tag stored on each record, e.g. "vldb2026-v19n9"
+        #[arg(long)]
+        source_tag: String,
+        /// Path to the downloaded issue front-matter PDF
+        #[arg(long)]
+        pdf_path: PathBuf,
+    },
 }
 
 #[tokio::main]
@@ -1111,6 +1127,11 @@ async fn main() -> anyhow::Result<()> {
             source_tag,
             pdf_path,
         } => import_chi(&corpus, &source_tag, &pdf_path),
+        Command::ImportVldb {
+            corpus,
+            source_tag,
+            pdf_path,
+        } => import_vldb(&corpus, &source_tag, &pdf_path),
         Command::Check {
             file_path,
             no_color,
@@ -3843,6 +3864,25 @@ fn import_chi(corpus_path: &Path, source_tag: &str, pdf_path: &Path) -> anyhow::
     let conn = hallucinator_local_corpus::open_or_create(corpus_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let stats = hallucinator_local_corpus::ingest::import_chi_frontmatter(&conn, &text, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a PVLDB issue's front-matter PDF into the local corpus. Not
+/// `async` — no network access, just local PDF text extraction + parsing.
+fn import_vldb(corpus_path: &Path, source_tag: &str, pdf_path: &Path) -> anyhow::Result<()> {
+    use hallucinator_core::PdfBackend as _;
+    let text = hallucinator_pdf_mupdf::MupdfBackend
+        .extract_text(pdf_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_vldb_toc(&conn, &text, source_tag)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     print_import_stats(&stats);
     let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -665,6 +665,34 @@ enum Command {
         #[arg(long, conflicts_with = "url")]
         from_file: Option<PathBuf>,
     },
+
+    /// Import a Paper Digest "<Venue> Papers with Code & Data" page into
+    /// the local corpus. Built for ICLR, whose own sources are all
+    /// unusable (OpenReview's clean endpoint 403s behind a challenge and
+    /// its open endpoint leaks review content; ICLR's own site needs
+    /// ~5,500 per-paper fetches and disallows GPTBot from that path;
+    /// Papers With Code no longer exists). Only covers accepted papers
+    /// with an associated public code/data repo — a real but incomplete
+    /// subset of the full accepted list.
+    ImportIclr {
+        /// Path to the local corpus SQLite database (created if missing)
+        #[arg(long)]
+        corpus: PathBuf,
+
+        /// Provenance tag stored on each record, e.g. "iclr2026"
+        #[arg(long)]
+        source_tag: String,
+
+        /// Fetch live from this URL (e.g.
+        /// https://www.paperdigest.org/2026/04/iclr-2026-papers-with-code-data/)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+
+        /// Parse an already-downloaded copy of the page instead of
+        /// fetching live.
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -848,6 +876,12 @@ async fn main() -> anyhow::Result<()> {
             url,
             from_file,
         } => import_icml(&corpus, &source_tag, url, from_file).await,
+        Command::ImportIclr {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_iclr(&corpus, &source_tag, url, from_file).await,
         Command::Check {
             file_path,
             no_color,
@@ -3378,6 +3412,27 @@ async fn import_icml(
     let conn = hallucinator_local_corpus::open_or_create(corpus_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let stats = hallucinator_local_corpus::ingest::import_icml(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a Paper Digest "papers with code & data" page into the local
+/// corpus.
+async fn import_iclr(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_iclr(&conn, source, source_tag)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     print_import_stats(&stats);

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -575,6 +575,96 @@ enum Command {
         #[arg(long, conflicts_with = "url")]
         from_file: Option<PathBuf>,
     },
+
+    /// Import a SOSP (ACM SIGOPS Symposium on Operating Systems
+    /// Principles) accepted-papers page into the local corpus.
+    ImportSosp {
+        /// Path to the local corpus SQLite database (created if missing)
+        #[arg(long)]
+        corpus: PathBuf,
+
+        /// Provenance tag stored on each record, e.g. "sosp2025"
+        #[arg(long)]
+        source_tag: String,
+
+        /// Fetch live from this URL (e.g.
+        /// https://sigops.org/s/conferences/sosp/2025/accepted.html)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+
+        /// Parse an already-downloaded copy of the page instead of
+        /// fetching live.
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import an ASPLOS program page into the local corpus.
+    ImportAsplos {
+        /// Path to the local corpus SQLite database (created if missing)
+        #[arg(long)]
+        corpus: PathBuf,
+
+        /// Provenance tag stored on each record, e.g. "asplos2026"
+        #[arg(long)]
+        source_tag: String,
+
+        /// Fetch live from this URL (e.g.
+        /// https://www.asplos-conference.org/asplos2026/program/index.html)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+
+        /// Parse an already-downloaded copy of the page instead of
+        /// fetching live.
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import an ISCA program page into the local corpus. Reuses the
+    /// ASPLOS parser — same underlying page template.
+    ImportIsca {
+        /// Path to the local corpus SQLite database (created if missing)
+        #[arg(long)]
+        corpus: PathBuf,
+
+        /// Provenance tag stored on each record, e.g. "isca2026"
+        #[arg(long)]
+        source_tag: String,
+
+        /// Fetch live from this URL (e.g.
+        /// https://iscaconf.org/isca2026/program/index.php)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+
+        /// Parse an already-downloaded copy of the page instead of
+        /// fetching live.
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import an ICML `proceedings.mlr.press` volume page into the local
+    /// corpus. Only exists once PMLR publishes that year's volume
+    /// (weeks after the conference, same lag as NeurIPS) — check
+    /// https://proceedings.mlr.press/ for the current "Proceedings of
+    /// ICML <year>" volume number first.
+    ImportIcml {
+        /// Path to the local corpus SQLite database (created if missing)
+        #[arg(long)]
+        corpus: PathBuf,
+
+        /// Provenance tag stored on each record, e.g. "icml2026"
+        #[arg(long)]
+        source_tag: String,
+
+        /// Fetch live from this URL (e.g.
+        /// https://proceedings.mlr.press/v267/)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+
+        /// Parse an already-downloaded copy of the page instead of
+        /// fetching live.
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -734,6 +824,30 @@ async fn main() -> anyhow::Result<()> {
             url,
             from_file,
         } => import_eurosp(&corpus, &source_tag, url, from_file).await,
+        Command::ImportSosp {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_sosp(&corpus, &source_tag, url, from_file).await,
+        Command::ImportAsplos {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_asplos(&corpus, &source_tag, url, from_file).await,
+        Command::ImportIsca {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_isca(&corpus, &source_tag, url, from_file).await,
+        Command::ImportIcml {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_icml(&corpus, &source_tag, url, from_file).await,
         Command::Check {
             file_path,
             no_color,
@@ -3184,6 +3298,86 @@ async fn import_eurosp(
     let conn = hallucinator_local_corpus::open_or_create(corpus_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let stats = hallucinator_local_corpus::ingest::import_eurosp(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a SOSP accepted-papers page into the local corpus.
+async fn import_sosp(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_sosp(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import an ASPLOS program page into the local corpus.
+async fn import_asplos(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_asplos(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import an ISCA program page into the local corpus.
+async fn import_isca(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_isca(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import an ICML PMLR volume page into the local corpus.
+async fn import_icml(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_icml(&conn, source, source_tag)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     print_import_stats(&stats);

--- a/hallucinator-rs/crates/hallucinator-cli/src/main.rs
+++ b/hallucinator-rs/crates/hallucinator-cli/src/main.rs
@@ -693,6 +693,50 @@ enum Command {
         #[arg(long, conflicts_with = "url")]
         from_file: Option<PathBuf>,
     },
+
+    /// Import a PETS/PoPETs paper-list page into the local corpus. One
+    /// page covers every quarterly issue for the year.
+    ImportPets {
+        /// Path to the local corpus SQLite database (created if missing)
+        #[arg(long)]
+        corpus: PathBuf,
+
+        /// Provenance tag stored on each record, e.g. "pets2026"
+        #[arg(long)]
+        source_tag: String,
+
+        /// Fetch live from this URL (e.g.
+        /// https://petsymposium.org/2026/paperlist.php)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+
+        /// Parse an already-downloaded copy of the page instead of
+        /// fetching live.
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
+
+    /// Import an IEEE INFOCOM accepted-paper-list page into the local
+    /// corpus.
+    ImportInfocom {
+        /// Path to the local corpus SQLite database (created if missing)
+        #[arg(long)]
+        corpus: PathBuf,
+
+        /// Provenance tag stored on each record, e.g. "infocom2026"
+        #[arg(long)]
+        source_tag: String,
+
+        /// Fetch live from this URL (e.g.
+        /// https://infocom2026.ieee-infocom.org/accepted-paper-list-main-conference)
+        #[arg(long, conflicts_with = "from_file")]
+        url: Option<String>,
+
+        /// Parse an already-downloaded copy of the page instead of
+        /// fetching live.
+        #[arg(long, conflicts_with = "url")]
+        from_file: Option<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -882,6 +926,18 @@ async fn main() -> anyhow::Result<()> {
             url,
             from_file,
         } => import_iclr(&corpus, &source_tag, url, from_file).await,
+        Command::ImportPets {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_pets(&corpus, &source_tag, url, from_file).await,
+        Command::ImportInfocom {
+            corpus,
+            source_tag,
+            url,
+            from_file,
+        } => import_infocom(&corpus, &source_tag, url, from_file).await,
         Command::Check {
             file_path,
             no_color,
@@ -3433,6 +3489,46 @@ async fn import_iclr(
     let conn = hallucinator_local_corpus::open_or_create(corpus_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let stats = hallucinator_local_corpus::ingest::import_iclr(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import a PETS/PoPETs paper-list page into the local corpus.
+async fn import_pets(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_pets(&conn, source, source_tag)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    print_import_stats(&stats);
+    let total_for_tag = hallucinator_local_corpus::count_by_source(&conn, source_tag)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    println!("Corpus now has {total_for_tag} publications tagged \"{source_tag}\"");
+    Ok(())
+}
+
+/// Import an IEEE INFOCOM accepted-paper-list page into the local corpus.
+async fn import_infocom(
+    corpus_path: &Path,
+    source_tag: &str,
+    url: Option<String>,
+    from_file: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let source = resolve_html_source(url, from_file)?;
+    let conn = hallucinator_local_corpus::open_or_create(corpus_path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let stats = hallucinator_local_corpus::ingest::import_infocom(&conn, source, source_tag)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     print_import_stats(&stats);

--- a/hallucinator-rs/crates/hallucinator-core/src/db/crossref.rs
+++ b/hallucinator-rs/crates/hallucinator-core/src/db/crossref.rs
@@ -76,30 +76,32 @@ impl DatabaseBackend for CrossRef {
                         .and_then(|a| a.first())
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
+                    let item_subtype = item["subtype"].as_str().unwrap_or("");
 
-                    // Detect review articles: type is "journal-article" but the
-                    // found title is short (book title) and container looks like a
-                    // review journal, or the item has a "relation.is-review-of" field
-                    let is_review =
-                        item["relation"]["is-review-of"].is_array() || item_type == "peer-review";
+                    // Detect review articles: explicit CrossRef relation, "peer-review"
+                    // type, or "review-article" subtype.
+                    let is_review = item["relation"]["is-review-of"].is_array()
+                        || item_type == "peer-review"
+                        || item_subtype == "review-article";
 
-                    // Detect when a journal article matches a book title query.
-                    // CrossRef returns these when someone reviewed the book in a journal.
-                    // Heuristic: if found_title closely matches query but the item is a
-                    // journal-article and the container-title doesn't match at all,
-                    // it's likely a review article about the queried book.
-                    let is_likely_book_review =
-                        item_type == "journal-article" && !item_container.is_empty() && {
-                            // Check if the container title is a journal (review source)
-                            // while the query looks like a book title (no journal-like words)
-                            let query_lower = title.to_lowercase();
-                            !query_lower.contains("journal")
-                                && !query_lower.contains("transactions")
-                                && !query_lower.contains("proceedings")
-                                && !query_lower.contains("conference")
-                        };
+                    // Detect book reviews CrossRef doesn't tag via the relation above:
+                    // these still show up as plain "journal-article" items, but the
+                    // *returned* title or container announces it's a review (e.g.
+                    // "Review of ...", container "Book Reviews"). We only trust signals
+                    // on the matched item here, never on the query title's wording — a
+                    // prior version of this check flagged any short journal-article
+                    // title lacking words like "journal"/"transactions" as "likely a
+                    // book review", which wrongly discarded real short-titled papers
+                    // (e.g. IEEE Transactions articles) that happened to match.
+                    let found_title_lower = found_title.to_lowercase();
+                    let container_lower = item_container.to_lowercase();
+                    let is_likely_book_review = item_type == "journal-article"
+                        && (found_title_lower.starts_with("review of ")
+                            || found_title_lower.starts_with("book review")
+                            || found_title_lower.contains(": review of ")
+                            || container_lower.contains("book review"));
 
-                    if is_review {
+                    if is_review || is_likely_book_review {
                         continue;
                     }
 
@@ -121,20 +123,6 @@ impl DatabaseBackend for CrossRef {
                     // causes false AuthorMismatch when we can't verify authors
                     if authors.is_empty() {
                         continue;
-                    }
-
-                    // For likely book reviews: if authors don't match, skip this
-                    // result and let other DBs try. Only flag mismatch if it's
-                    // NOT a likely book review.
-                    if is_likely_book_review {
-                        // Import is at the crate level via `use crate::authors::validate_authors`
-                        // but we're inside an async block. We do a quick check here:
-                        // if the query has ≤8 words (short title, likely a book), skip
-                        // this result entirely to avoid book-review false matches.
-                        let word_count = title.split_whitespace().count();
-                        if word_count <= 8 {
-                            continue;
-                        }
                     }
 
                     let doi = item["DOI"].as_str();

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/asplos.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/asplos.rs
@@ -1,0 +1,110 @@
+//! Parse ASPLOS's (ACM International Conference on Architectural Support
+//! for Programming Languages and Operating Systems) program page into
+//! corpus records.
+//!
+//! One page per year at `asplos-conference.org/asplos<year>/program/`,
+//! WordPress-hosted with a session-by-session schedule. Structure:
+//! `div.paper` → `div.paper-title` (plain text) + `div.paper-authors`
+//! (plain `"Name (Affiliation), Name (Affiliation)"` text — the same
+//! shape [`parse_paren_grouped_names`] already handles). Papers appear
+//! nested inside collapsible per-session panels, but selecting `div.paper`
+//! directly (rather than walking the session structure) picks up every
+//! paper regardless of which session panel it's under.
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+
+/// Parse an ASPLOS program page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"asplos2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let paper_sel = Selector::parse("div.paper").unwrap();
+    let title_sel = Selector::parse("div.paper-title").unwrap();
+    let authors_sel = Selector::parse("div.paper-authors").unwrap();
+
+    let mut out = Vec::new();
+    for paper in document.select(&paper_sel) {
+        let Some(title_el) = paper.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let Some(authors_el) = paper.select(&authors_sel).next() else {
+            continue;
+        };
+        let authors_text: String = authors_el.text().collect();
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <div class="panel-body">
+          <div class="paper">
+            <div class="paper-title">
+              Towards High-Goodput LLM Serving with Prefill-decode Multiplexing
+            </div>
+            <div class="paper-authors">
+              Weihao Cui (Shanghai Jiao Tong University), Yukang Chen (Shanghai Jiao Tong University)
+            </div>
+          </div>
+          <hr />
+          <div class="paper">
+            <div class="paper-title">
+              Bullet: Boosting GPU Utilization for LLM Serving via Dynamic Spatial-Temporal Orchestration
+            </div>
+            <div class="paper-authors">
+              Zejia Lin (Sun Yat-sen University), Hongxin Xu (Sun Yat-sen University)
+            </div>
+          </div>
+        </div>
+    "#;
+
+    #[test]
+    fn test_parse_two_papers() {
+        let out = parse_accepted_papers(SAMPLE, "asplos2026");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "Towards High-Goodput LLM Serving with Prefill-decode Multiplexing"
+        );
+        assert_eq!(out[0].authors, vec!["Weihao Cui", "Yukang Chen"]);
+        assert_eq!(out[0].source, "asplos2026");
+    }
+
+    #[test]
+    fn test_second_paper() {
+        let out = parse_accepted_papers(SAMPLE, "asplos2026");
+        assert_eq!(
+            out[1].title,
+            "Bullet: Boosting GPU Utilization for LLM Serving via Dynamic Spatial-Temporal Orchestration"
+        );
+        assert_eq!(out[1].authors, vec!["Zejia Lin", "Hongxin Xu"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "asplos2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/chi.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/chi.rs
@@ -1,0 +1,245 @@
+//! Parse CHI's ACM DL proceedings front-matter PDF (its table of
+//! contents) into corpus records.
+//!
+//! CHI's own program site is a JavaScript app with no static content
+//! (`<app-root></app-root>`, confirmed by direct fetch), so unlike every
+//! other venue in this module there's no HTML page to scrape. ACM
+//! publishes a "front matter" PDF per proceedings volume that's freely
+//! downloadable (no paywall) and contains a full table of contents —
+//! title, full author list, and DOI for every paper. This module doesn't
+//! read the PDF itself (that stays isolated to the `hallucinator-pdf-
+//! mupdf` crate, the project's one deliberate AGPL dependency boundary —
+//! see that crate's doc comment); the CLI layer extracts the PDF's text
+//! (it already depends on that crate for the main check pipeline) and
+//! hands this module the plain text, same "pure function over a string"
+//! shape every other importer here has.
+//!
+//! Structure (via `pdftotext -layout`, one paper per block):
+//!
+//! ```text
+//! PAPER001 Title text that may wrap onto one or more indented
+//!          continuation lines before the first author starts
+//!          Author One, Affiliation, Affiliation Continuation
+//!          if the affiliation itself wraps onto its own indented
+//!          line, with no name-shaped prefix
+//!          Author Two, Affiliation
+//!          DOI: 10.1145/xxxxxxx.xxxxxxx
+//! ```
+//!
+//! Title-wrap lines and affiliation-wrap lines are visually
+//! indistinguishable (same indentation, no blank-line separator) — the
+//! only usable signal is content shape. This walks each entry forward as
+//! a small state machine: every line up to the *first* line that looks
+//! like `"Name Name, ..."` (title case, one or more words, a comma) is
+//! title text; from there on, a line matching that shape starts a new
+//! author (we keep just the name, before the first comma), and any line
+//! that *doesn't* match is a continuation of the current author's
+//! affiliation and is discarded (we only need names).
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::db::NewPublication;
+
+/// `PAPER123 ` at the start of a line — the only reliable per-entry
+/// boundary marker.
+static PAPER_MARKER: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)^PAPER\d+\s").unwrap());
+
+/// A line that looks like `"Name Name, rest..."` — 1 to 6 space-
+/// separated tokens, each starting with an uppercase (Unicode-aware)
+/// letter or an opening paren (for parenthetical nicknames like
+/// `"Rie Helene (Lindy) Hernandez,"`), followed by a comma. Title-wrap
+/// lines almost never take this shape (they resume mid-title, often
+/// lowercase, and rarely place a bare comma right after 1-6 capitalized
+/// words); affiliation-wrap continuation lines never have a leading
+/// comma at all.
+static AUTHOR_START: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"^(?:\p{Lu}[\p{L}'.-]*|\([\p{L}\s]+\))(?:\s+(?:\p{Lu}[\p{L}'.-]*|\([\p{L}\s]+\))){0,5},",
+    )
+    .unwrap()
+});
+
+/// Join a wrapped title's lines back into one string. A line ending in
+/// `-` immediately followed by a lowercase-starting continuation is
+/// treated as a PDF line-break mid-word and de-hyphenated (`"On-"` +
+/// `"boarding"` -> `"Onboarding"`); anything else just gets a space.
+/// Imperfect (a genuine compound like `"well-"` / `"known"` loses its
+/// hyphen too), but titles only need to clear a fuzzy-match threshold
+/// downstream, not render typeset-perfect.
+fn join_title_lines(lines: &[&str]) -> String {
+    let mut out = String::new();
+    for line in lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(stripped) = out.strip_suffix('-') {
+            let starts_lower = line.chars().next().is_some_and(|c| c.is_lowercase());
+            if starts_lower {
+                out = format!("{stripped}{line}");
+                continue;
+            }
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// Extract just the name portion (before the first comma) of an author
+/// line already confirmed to match [`AUTHOR_START`].
+fn extract_author_name(line: &str) -> String {
+    line.split_once(',')
+        .map(|(name, _)| name)
+        .unwrap_or(line)
+        .trim()
+        .to_string()
+}
+
+/// Parse extracted PDF text from a CHI (or any ACM-DL-front-matter-
+/// formatted) proceedings front matter into publication records.
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"chi2026"`.
+pub fn parse_frontmatter(text: &str, source_tag: &str) -> Vec<NewPublication> {
+    let marker_starts: Vec<usize> = PAPER_MARKER.find_iter(text).map(|m| m.start()).collect();
+
+    let mut out = Vec::new();
+    for (i, &start) in marker_starts.iter().enumerate() {
+        let end = marker_starts.get(i + 1).copied().unwrap_or(text.len());
+        let entry = &text[start..end];
+
+        // Drop the "PAPER123 " marker itself, then the "DOI: ..." line
+        // and everything after it (organizer bios, session headers
+        // between entries, etc. all live past that point).
+        let after_marker = match entry.find(char::is_whitespace) {
+            Some(idx) => &entry[idx..],
+            None => continue,
+        };
+        let body = match after_marker.find("DOI:") {
+            Some(idx) => &after_marker[..idx],
+            None => continue, // no DOI line -> not a real paper entry
+        };
+
+        let mut title_lines: Vec<&str> = Vec::new();
+        let mut authors: Vec<String> = Vec::new();
+        for line in body.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if AUTHOR_START.is_match(trimmed) {
+                authors.push(extract_author_name(trimmed));
+            } else if authors.is_empty() {
+                title_lines.push(trimmed);
+            }
+            // else: affiliation-wrap continuation of the current author — discard.
+        }
+
+        let title = join_title_lines(&title_lines);
+        if title.is_empty() || authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+  Paper
+
+  AI & Data Visualization
+
+PAPER001 \u{201c}Hey Dashboard!\u{201d}: Supporting Voice, Text, and Pointing Modalities in Dashboard On-
+         boarding using Large Language Models
+         Vaishali Dhanoa, Aarhus University, TU Wien
+         Gabriela Molina Le\u{f3}n, Aarhus University
+         Eve Hoggan, Aarhus University
+         DOI: 10.1145/3772318.3791766
+
+
+PAPER002 Contrastive Learning for Large-scale Color-Name Dataset
+         Kecheng Lu, Renmin University of China
+         DOI: 10.1145/3772318.3791278
+
+
+PAPER1702 Player Safety by Design: Co-Designing Child-Centered Safety Mechanisms with Children
+          Zinan Zhang, College of Information Sciences and Technology, The Pennsylvania State University
+          Rie Helene (Lindy) Hernandez, College of Information Sciences and Technology, The Pennsylvania
+          State University
+          Yubo Kou, College of Information Sciences and Technology, The Pennsylvania State University
+          DOI: 10.1145/3772318.3791090
+                            Organization Committee
+
+
+ General Chairs
+";
+
+    #[test]
+    fn test_hyphenated_title_wrap_dehyphenated() {
+        let out = parse_frontmatter(SAMPLE, "chi2026");
+        assert_eq!(
+            out[0].title,
+            "\u{201c}Hey Dashboard!\u{201d}: Supporting Voice, Text, and Pointing Modalities in Dashboard Onboarding using Large Language Models"
+        );
+        assert_eq!(out[0].source, "chi2026");
+    }
+
+    #[test]
+    fn test_authors_extracted_names_only() {
+        let out = parse_frontmatter(SAMPLE, "chi2026");
+        assert_eq!(
+            out[0].authors,
+            vec!["Vaishali Dhanoa", "Gabriela Molina Le\u{f3}n", "Eve Hoggan"]
+        );
+    }
+
+    #[test]
+    fn test_single_line_title_second_entry() {
+        let out = parse_frontmatter(SAMPLE, "chi2026");
+        assert_eq!(
+            out[1].title,
+            "Contrastive Learning for Large-scale Color-Name Dataset"
+        );
+        assert_eq!(out[1].authors, vec!["Kecheng Lu"]);
+    }
+
+    #[test]
+    fn test_wrapped_affiliation_continuation_does_not_become_a_bogus_author_or_leak_into_title() {
+        // "State University" is a continuation of Rie Helene (Lindy)
+        // Hernandez's affiliation, not a 4th author and not part of the
+        // title — it must be silently discarded.
+        let out = parse_frontmatter(SAMPLE, "chi2026");
+        assert_eq!(
+            out[2].title,
+            "Player Safety by Design: Co-Designing Child-Centered Safety Mechanisms with Children"
+        );
+        assert_eq!(
+            out[2].authors,
+            vec!["Zinan Zhang", "Rie Helene (Lindy) Hernandez", "Yubo Kou"]
+        );
+    }
+
+    #[test]
+    fn test_trailing_non_paper_content_after_last_entry_ignored() {
+        let out = parse_frontmatter(SAMPLE, "chi2026");
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_empty_text() {
+        assert!(parse_frontmatter("", "chi2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/dom_text.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/dom_text.rs
@@ -1,0 +1,18 @@
+//! Shared DOM text-extraction helper, used by venues whose title/authors
+//! aren't both inside their own dedicated child elements — PETS (title is
+//! direct text before an optional artifact-badge `<a>` and an author
+//! `<span>`) and IMC (title is inside a `<strong>`, authors are the
+//! direct text that follows it).
+
+use scraper::ElementRef;
+use std::ops::Deref;
+
+/// Collect only an element's own direct text-node children (not text from
+/// nested elements), concatenated and trimmed.
+pub(crate) fn direct_text(el: &ElementRef) -> String {
+    el.children()
+        .filter_map(|child| child.value().as_text().map(|t| t.deref()))
+        .collect::<String>()
+        .trim()
+        .to_string()
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/dsn.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/dsn.rs
@@ -1,0 +1,95 @@
+//! Parse the DSN (Dependable Systems and Networks) accepted-papers page
+//! into corpus records.
+//!
+//! One page per year at `dsn<year>.github.io/cpaccepted.html`.
+//! Structure: `li.w3-padding-large` → `b` (title, an element — so it's
+//! excluded from the `<li>`'s own direct text) followed by direct text
+//! (authors: `"Name, Name (Affiliation); Name (Affiliation); ..."` — the
+//! same shape [`parse_paren_grouped_names`] already handles).
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+use crate::ingest::dom_text::direct_text;
+
+/// Parse a DSN accepted-papers page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"dsn2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let item_sel = Selector::parse("li.w3-padding-large").unwrap();
+    let title_sel = Selector::parse("b").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let Some(title_el) = item.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let authors_text = direct_text(&item);
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <ul>
+        <li class="w3-padding-large"><b>5G-STREAM: 5G Service Mesh Tailored for Reliable, Efficient and Authorized Microservices in the Cloud</b><br>Tolga Atalay, Alireza Famili, Sudip Maitra (Virginia Tech); Dragoslav Stojadinovic (Kryptowire LLC); Angelos Stavrou, Haining Wang (Virginia Tech)<br></li>
+        <li class="w3-padding-large"><b>A Solo-Author DSN Paper</b><br>Solo Author (Some University)<br></li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_title_and_multi_group_authors() {
+        let out = parse_accepted_papers(SAMPLE, "dsn2026");
+        assert_eq!(
+            out[0].title,
+            "5G-STREAM: 5G Service Mesh Tailored for Reliable, Efficient and Authorized Microservices in the Cloud"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec![
+                "Tolga Atalay",
+                "Alireza Famili",
+                "Sudip Maitra",
+                "Dragoslav Stojadinovic",
+                "Angelos Stavrou",
+                "Haining Wang"
+            ]
+        );
+        assert_eq!(out[0].source, "dsn2026");
+    }
+
+    #[test]
+    fn test_second_entry() {
+        let out = parse_accepted_papers(SAMPLE, "dsn2026");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[1].title, "A Solo-Author DSN Paper");
+        assert_eq!(out[1].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "dsn2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/eurosys.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/eurosys.rs
@@ -1,0 +1,103 @@
+//! Parse the EuroSys accepted-papers page into corpus records.
+//!
+//! One page per year at `<year>.eurosys.org/papers.html`. Structure:
+//! `table.papers` → `tr` → first `td`'s `a` (title, a DOI link) + second
+//! `td` (authors, `"Name (Affiliation), Name (Affiliation), ..."` — the
+//! same shape [`parse_paren_grouped_names`] already handles). The header
+//! row uses `<th>`, not `<td>`, so it's naturally skipped.
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+
+/// Parse a EuroSys accepted-papers page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"eurosys2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let row_sel = Selector::parse("table.papers tr").unwrap();
+    let title_sel = Selector::parse("td:nth-child(1) a").unwrap();
+    let authors_sel = Selector::parse("td:nth-child(2)").unwrap();
+
+    let mut out = Vec::new();
+    for row in document.select(&row_sel) {
+        let Some(title_el) = row.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let Some(authors_el) = row.select(&authors_sel).next() else {
+            continue;
+        };
+        let authors_text: String = authors_el.text().collect();
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <table class="papers">
+          <thead class="pap">
+            <tr><th class="bord" title="Field #2">Title</th><th title="Field #3">Authors</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="https://dl.acm.org/doi/10.1145/example">AdaServe: Accelerating Multi-SLO LLM Serving</a></td>
+              <td>Zikun Li (Carnegie Mellon University), Zhuofu Chen (Princeton University), Zhihao Jia (Carnegie Mellon University and Amazon Web Services)</td>
+            </tr>
+            <tr>
+              <td><a href="https://dl.acm.org/doi/10.1145/example2">A Second EuroSys Paper</a></td>
+              <td>Solo Author (Some University)</td>
+            </tr>
+          </tbody>
+        </table>
+    "#;
+
+    #[test]
+    fn test_header_row_skipped() {
+        let out = parse_accepted_papers(SAMPLE, "eurosys2026");
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn test_title_and_authors() {
+        let out = parse_accepted_papers(SAMPLE, "eurosys2026");
+        assert_eq!(out[0].title, "AdaServe: Accelerating Multi-SLO LLM Serving");
+        assert_eq!(
+            out[0].authors,
+            vec!["Zikun Li", "Zhuofu Chen", "Zhihao Jia"]
+        );
+        assert_eq!(out[0].source, "eurosys2026");
+    }
+
+    #[test]
+    fn test_second_row() {
+        let out = parse_accepted_papers(SAMPLE, "eurosys2026");
+        assert_eq!(out[1].title, "A Second EuroSys Paper");
+        assert_eq!(out[1].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "eurosys2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/iclr.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/iclr.rs
@@ -1,0 +1,139 @@
+//! Parse a Paper Digest "<Venue> Papers with Code & Data" page into corpus
+//! records — built for ICLR specifically (no other clean, ethically-usable
+//! source exists: OpenReview's venue-scoped query endpoint 403s with a
+//! challenge page, and its one reachable endpoint serves peer-review
+//! content rather than paper metadata; ICLR's own `iclr.cc/virtual` site
+//! requires ~5,500 individual per-paper page fetches for author data and
+//! explicitly disallows GPTBot from that path in robots.txt; Papers With
+//! Code itself no longer exists, redirecting to a generic Hugging Face
+//! feed with no venue listing).
+//!
+//! `paperdigest.org` publishes one such page per venue/year at URLs like
+//! `paperdigest.org/<year>/<month>/<venue>-<year>-papers-with-code-data/`.
+//! Structure: one `<table>` on the page, `<tr>` → `<td>` (index) +
+//! `<td>` (title, as `<a><b>Title</b></a>` followed by unrelated
+//! "Related Papers/Patents/.../Highlight" clutter we ignore — selecting
+//! the first `b` inside the cell rather than the cell's full text avoids
+//! all of it) + `<td>` (authors, as `<a>Name</a>; <a>Name</a>; ...` — the
+//! name is the link *text*, not the `?name=` slug in its href, which is
+//! lowercased/underscored) + `<td>` (an external code-repo link, unused
+//! here). The header row uses `<th>`, not `<td>`, so it's naturally
+//! skipped by matching on `<td>`.
+//!
+//! Caveat this importer's caller should know: Paper Digest's "with code"
+//! pages only cover accepted papers that have an associated public code
+//! or data repository — a meaningful but incomplete subset of the full
+//! accepted-papers list, not the whole venue.
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+
+/// Parse a Paper Digest "papers with code & data" page into publication
+/// records. `source_tag` is the provenance string to store on each
+/// record, e.g. `"iclr2026"`.
+pub fn parse_papers_with_code(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let row_sel = Selector::parse("tr").unwrap();
+    let title_cell_sel = Selector::parse("td:nth-child(2)").unwrap();
+    let title_bold_sel = Selector::parse("b").unwrap();
+    let authors_cell_sel = Selector::parse("td:nth-child(3)").unwrap();
+    let author_link_sel = Selector::parse("a").unwrap();
+
+    let mut out = Vec::new();
+    for row in document.select(&row_sel) {
+        let Some(title_cell) = row.select(&title_cell_sel).next() else {
+            continue;
+        };
+        let Some(title_el) = title_cell.select(&title_bold_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let Some(authors_cell) = row.select(&authors_cell_sel).next() else {
+            continue;
+        };
+        let authors: Vec<String> = authors_cell
+            .select(&author_link_sel)
+            .map(|a| a.text().collect::<String>().trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <table>
+        <col width="5%"/><col width="65%"/><col width="25%"/>
+        <tr><th></th><th>Paper</th><th>Author(s)</th><th>Code</th></tr>
+        <tr>
+        <td>1</td>
+        <td><a href=https://www.paperdigest.org/reader/?paper_id=x><b>Cosmos Policy: Fine-Tuning Video Models for Visuomotor Control and Planning</b></a><br />
+        <small><a href=https://www.paperdigest.org/review/?paper_id=x>Related Papers</a></small>
+        <i><u>Highlight</u>: In this work, we introduce Cosmos Policy...</i></td>
+        <td><a href=https://www.paperdigest.org/isearch/?name=moo_jin_kim>Moo Jin Kim</a>; <a href=https://www.paperdigest.org/isearch/?name=chelsea_finn>Chelsea Finn</a>;</td>
+        <td><a href='https://github.com/example/repo' target='_blank'>code</a></td>
+        </tr>
+        <tr>
+        <td>2</td>
+        <td><a href=https://www.paperdigest.org/reader/?paper_id=y><b>A Second Paper</b></a><br />
+        <i><u>Highlight</u>: Some other summary.</i></td>
+        <td><a href=https://www.paperdigest.org/isearch/?name=solo_author>Solo Author</a>;</td>
+        <td><a href='https://arxiv.org/abs/1234.5678' target='_blank'>code</a></td>
+        </tr>
+        </table>
+    "#;
+
+    #[test]
+    fn test_header_row_skipped() {
+        // The header row has <th>, not <td> — must not produce a bogus record.
+        let out = parse_papers_with_code(SAMPLE, "iclr2026");
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn test_title_ignores_highlight_and_related_links_clutter() {
+        let out = parse_papers_with_code(SAMPLE, "iclr2026");
+        assert_eq!(
+            out[0].title,
+            "Cosmos Policy: Fine-Tuning Video Models for Visuomotor Control and Planning"
+        );
+    }
+
+    #[test]
+    fn test_authors_use_link_text_not_href_slug() {
+        let out = parse_papers_with_code(SAMPLE, "iclr2026");
+        // Names, not the lowercased/underscored `?name=` slug from the href.
+        assert_eq!(out[0].authors, vec!["Moo Jin Kim", "Chelsea Finn"]);
+        assert_eq!(out[0].source, "iclr2026");
+    }
+
+    #[test]
+    fn test_solo_author_second_row() {
+        let out = parse_papers_with_code(SAMPLE, "iclr2026");
+        assert_eq!(out[1].title, "A Second Paper");
+        assert_eq!(out[1].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_papers_with_code("<html></html>", "iclr2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/icml.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/icml.rs
@@ -1,0 +1,122 @@
+//! Parse an ICML `proceedings.mlr.press` volume page into corpus records.
+//!
+//! ICML's own site (`icml.cc/virtual/<year>/papers.html`) renders its
+//! paper list client-side via JavaScript, so it can't be scraped directly
+//! — and per this project's policy (see MANIFESTO.md) OpenReview is off
+//! the table too. PMLR (Proceedings of Machine Learning Research) is the
+//! canonical static-HTML archive instead, same role NeurIPS's
+//! `papers.nips.cc` plays for that venue — but it only gets a volume
+//! *after* proceedings are formally published, typically weeks after the
+//! conference (same lag documented for NeurIPS's importer). Find the
+//! current ICML volume number at <https://proceedings.mlr.press/> (look
+//! for "Proceedings of ICML <year>") before importing.
+//!
+//! Structure: `div.paper` → `p.title` (plain text) + `span.authors`
+//! (comma-separated plain names, **no** parenthesized affiliations —
+//! unlike every venue using [`super::author_parsing::parse_paren_grouped_names`],
+//! so this module splits on comma directly instead).
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+
+/// Parse a PMLR ICML volume page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"icml2026"`.
+pub fn parse_volume(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let paper_sel = Selector::parse("div.paper").unwrap();
+    let title_sel = Selector::parse("p.title").unwrap();
+    let authors_sel = Selector::parse("span.authors").unwrap();
+
+    let mut out = Vec::new();
+    for paper in document.select(&paper_sel) {
+        let Some(title_el) = paper.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let Some(authors_el) = paper.select(&authors_sel).next() else {
+            continue;
+        };
+        let authors_text: String = authors_el.text().collect();
+        let authors: Vec<String> = authors_text
+            .split(',')
+            // PMLR's markup uses `&nbsp;` after the comma, decoded by
+            // the HTML parser to U+00A0 — an ordinary `trim()` (which
+            // only strips ASCII/Unicode whitespace it recognizes, and
+            // U+00A0 *is* Unicode whitespace per `char::is_whitespace`,
+            // so plain `.trim()` already covers it) is enough here.
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "
+        <div class=\"paper\">
+          <p class=\"title\">Aggregation of Dependent Expert Distributions in Multimodal Variational Autoencoders</p>
+          <p class=\"details\">
+            <span class=\"authors\">Rogelio A. Mancisidor,&nbsp;Robert Jenssen,&nbsp;Shujian Yu,&nbsp;Michael Kampffmeyer</span>;
+            <span class=\"info\"><i>Proceedings of the 42nd International Conference on Machine Learning</i>, PMLR 267:1-26</span>
+          </p>
+        </div>
+        <div class=\"paper\">
+          <p class=\"title\">A Second Paper Title</p>
+          <p class=\"details\">
+            <span class=\"authors\">Solo Author</span>;
+          </p>
+        </div>
+    ";
+
+    #[test]
+    fn test_parse_multi_author_no_affiliations() {
+        let out = parse_volume(SAMPLE, "icml2026");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "Aggregation of Dependent Expert Distributions in Multimodal Variational Autoencoders"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec![
+                "Rogelio A. Mancisidor",
+                "Robert Jenssen",
+                "Shujian Yu",
+                "Michael Kampffmeyer"
+            ]
+        );
+        assert_eq!(out[0].source, "icml2026");
+    }
+
+    #[test]
+    fn test_solo_author() {
+        let out = parse_volume(SAMPLE, "icml2026");
+        assert_eq!(out[1].title, "A Second Paper Title");
+        assert_eq!(out[1].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_volume("<html></html>", "icml2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/imc.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/imc.rs
@@ -1,0 +1,100 @@
+//! Parse ACM IMC's (Internet Measurement Conference) accepted-papers page
+//! into corpus records.
+//!
+//! One page per year at `conferences.sigcomm.org/imc/<year>/accepted-papers/`
+//! — same host as SIGCOMM's own accepted-papers page, but a different,
+//! much plainer template: `li` → `strong` (title) + direct text following
+//! it (authors). Unlike every other venue here, IMC's author line carries
+//! **no parenthesized affiliations at all** — just a flat comma-separated
+//! name list (`"Name, Name, Name"`), so [`parse_paren_grouped_names`]
+//! (which requires at least one `(...)` group to anchor on) would return
+//! nothing; this splits on comma directly instead, the same approach
+//! [`super::icml`] uses for the same reason.
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::dom_text::direct_text;
+
+/// Parse an IMC accepted-papers page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"imc2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let item_sel = Selector::parse("li").unwrap();
+    let title_sel = Selector::parse("strong").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let Some(title_el) = item.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let authors_text = direct_text(&item);
+        let authors: Vec<String> = authors_text
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <h2 id=cycle-1>Cycle 1</h2>
+        <ul>
+        <li><strong>Exploration of the Dynamics of Buy and Sale of Social Media Accounts</strong><br>Mario Beluri, Bhupendra Acharya, Thorsten Holz</li>
+        <li><strong>Sibling Prefixes: Identifying Similarities in IPv4 and IPv6 Prefixes</strong><br>Fariba Osali, Khwaja Zubair Sediqi, Oliver Gasser</li>
+        </ul>
+        <h2 id=cycle-2>Cycle 2</h2>
+        <ul>
+        <li><strong>A Cycle-2 Paper</strong><br>Solo Author</li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_title_and_flat_author_list_no_affiliations() {
+        let out = parse_accepted_papers(SAMPLE, "imc2026");
+        assert_eq!(
+            out[0].title,
+            "Exploration of the Dynamics of Buy and Sale of Social Media Accounts"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec!["Mario Beluri", "Bhupendra Acharya", "Thorsten Holz"]
+        );
+        assert_eq!(out[0].source, "imc2026");
+    }
+
+    #[test]
+    fn test_both_cycles_picked_up() {
+        let out = parse_accepted_papers(SAMPLE, "imc2026");
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[2].title, "A Cycle-2 Paper");
+        assert_eq!(out[2].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "imc2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/infocom.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/infocom.rs
@@ -1,0 +1,132 @@
+//! Parse the IEEE INFOCOM "Accepted Paper List" page into corpus records.
+//!
+//! Unlike every other venue here, INFOCOM's ComSoc "minisite" theme
+//! doesn't wrap each paper in its own element at all — the entire list
+//! lives inside one giant `<p>`, formatted as repeated
+//! `<strong>N. Title</strong><br>Author, Author and Author
+//! (Affiliation); Author (Affiliation)&nbsp;<br><br>` runs with no
+//! per-paper container to select. So instead of a CSS selector per
+//! paper, this walks the DOM directly: select every `<strong>` (each one
+//! *is* its own real element, just a sibling of all the others rather
+//! than a child of a per-paper wrapper), then for each one walks forward
+//! through [`ElementRef::next_siblings`] — collecting text nodes,
+//! stopping at the next `<strong>` — to gather that paper's author text
+//! before the following `<strong>` starts the next entry.
+//!
+//! Authors are grouped per-affiliation and semicolon-separated —
+//! `"Name, Name and Name (Affiliation); Name (Affiliation); ..."` — the
+//! same shape [`parse_paren_grouped_names`] already handles.
+
+use scraper::{Html, Selector};
+use std::ops::Deref;
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+
+/// Strip a leading `"12. "`-style ordinal prefix from a title.
+fn strip_ordinal_prefix(s: &str) -> &str {
+    let trimmed = s.trim();
+    match trimmed.split_once(". ") {
+        Some((digits, rest))
+            if !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()) =>
+        {
+            rest.trim()
+        }
+        _ => trimmed,
+    }
+}
+
+/// Parse an INFOCOM accepted-paper-list page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"infocom2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let strong_sel = Selector::parse("strong").unwrap();
+
+    let mut out = Vec::new();
+    for strong in document.select(&strong_sel) {
+        let raw_title: String = strong.text().collect();
+        let title = strip_ordinal_prefix(&raw_title).to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        // Walk forward through this <strong>'s siblings, collecting text
+        // (skipping element nodes like <br>), until the next <strong>
+        // starts the following paper.
+        let mut authors_text = String::new();
+        for sibling in strong.next_siblings() {
+            let is_next_strong = sibling
+                .value()
+                .as_element()
+                .is_some_and(|e| e.name() == "strong");
+            if is_next_strong {
+                break;
+            }
+            if let Some(t) = sibling.value().as_text() {
+                authors_text.push_str(t.deref());
+            }
+        }
+
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <div class="text field field--name-field-text field__item"><p>
+        <strong>1. P2C-MUX: Multiplexing with Power and Polarity Coding</strong><br>Zhao Li, Lijuan Zhang and Zhangbo Gao (Xidian University, China); Kang G. Shin (University of Michigan, USA)&nbsp;<br><br>
+        <strong>2. Generative Covert Communication</strong><br>Zhao Li (Xidian University, China); Kang G. Shin (University of Michigan, USA)&nbsp;<br><br>
+        <strong>3. Solo-Author Paper</strong><br>Weiyi Qin (Hong Kong Baptist University, Hong Kong)&nbsp;
+        </p></div>
+    "#;
+
+    #[test]
+    fn test_strips_ordinal_prefix_from_title() {
+        let out = parse_accepted_papers(SAMPLE, "infocom2026");
+        assert_eq!(
+            out[0].title,
+            "P2C-MUX: Multiplexing with Power and Polarity Coding"
+        );
+        assert_eq!(out[0].source, "infocom2026");
+    }
+
+    #[test]
+    fn test_authors_stop_at_next_strong_not_bleeding_into_next_paper() {
+        let out = parse_accepted_papers(SAMPLE, "infocom2026");
+        assert_eq!(
+            out[0].authors,
+            vec!["Zhao Li", "Lijuan Zhang", "Zhangbo Gao", "Kang G. Shin"]
+        );
+        assert_eq!(out[1].title, "Generative Covert Communication");
+        assert_eq!(out[1].authors, vec!["Zhao Li", "Kang G. Shin"]);
+    }
+
+    #[test]
+    fn test_last_entry_with_no_trailing_strong() {
+        let out = parse_accepted_papers(SAMPLE, "infocom2026");
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[2].title, "Solo-Author Paper");
+        assert_eq!(out[2].authors, vec!["Weiyi Qin"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "infocom2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/kdd.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/kdd.rs
@@ -1,0 +1,115 @@
+//! Parse the KDD accepted-papers page into corpus records.
+//!
+//! Unlike every other venue here, KDD's paper list isn't in the HTML at
+//! all — the page renders it client-side from data embedded as plain
+//! JavaScript array literals: `const cycle1Papers = [{"track": ...,
+//! "title": ..., "url": ..., "authors": "Name (Affiliation); Name
+//! (Affiliation)"}, ...];` (and a second `cycle2Papers` array, same
+//! shape). Since each array literal *is* valid JSON, this locates each
+//! `const cycleNPapers = ` marker and hands the text starting at that
+//! array straight to `serde_json`'s streaming deserializer, which parses
+//! just the one JSON value and stops — ignoring the trailing `;` and the
+//! rest of the `<script>` block — rather than trying to scrape any HTML
+//! structure.
+//!
+//! `authors` is `"Name (Affiliation); Name (Affiliation); ..."` — the
+//! same shape [`parse_paren_grouped_names`] already handles.
+
+use serde::Deserialize;
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+
+#[derive(Deserialize)]
+struct KddPaper {
+    title: String,
+    authors: String,
+}
+
+/// Every `const cycleNPapers = [...]` variable name this page has used so
+/// far. New cycles (if KDD ever adds a `cycle3Papers`) just need adding
+/// here.
+const CYCLE_MARKERS: &[&str] = &["const cycle1Papers = ", "const cycle2Papers = "];
+
+/// Parse a KDD accepted-papers page (its embedded JS data, not its HTML)
+/// into publication records. `source_tag` is the provenance string to
+/// store on each record, e.g. `"kdd2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let mut out = Vec::new();
+    for marker in CYCLE_MARKERS {
+        let Some(start) = html.find(marker) else {
+            continue;
+        };
+        let array_start = &html[start + marker.len()..];
+        let mut stream =
+            serde_json::Deserializer::from_str(array_start).into_iter::<Vec<KddPaper>>();
+        let Some(Ok(papers)) = stream.next() else {
+            continue;
+        };
+
+        for paper in papers {
+            let title = paper.title.trim().to_string();
+            if title.is_empty() {
+                continue;
+            }
+            let authors = parse_paren_grouped_names(&paper.authors);
+            if authors.is_empty() {
+                continue;
+            }
+            out.push(NewPublication {
+                title,
+                authors,
+                url: None,
+                source: source_tag.to_string(),
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <script>
+        const cycle1Papers = [{"track": "rtp", "title": "Spatiotemporal Graph Learning", "url": "https://doi.org/10.1145/example1", "authors": "Yuan Mi (Renmin University of China); Qi Wang (Renmin University of China)"}, {"track": "rtp", "title": "Towards Self-cognitive Exploration", "url": "https://doi.org/10.1145/example2", "authors": "Xujie Yuan (Sun Yat-Sen University)"}];
+        const cycle2Papers = [{"track": "dtb", "title": "RELIANCE: Curating Reproductive Health Information", "url": "https://doi.org/10.1145/example3", "authors": "Vaibhav Balloli (University of Michigan); Laura Peyton Ellis (University of Connecticut Health)"}];
+        </script>
+    "#;
+
+    #[test]
+    fn test_both_cycles_parsed() {
+        let out = parse_accepted_papers(SAMPLE, "kdd2026");
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].source, "kdd2026");
+    }
+
+    #[test]
+    fn test_cycle1_titles_and_authors() {
+        let out = parse_accepted_papers(SAMPLE, "kdd2026");
+        assert_eq!(out[0].title, "Spatiotemporal Graph Learning");
+        assert_eq!(out[0].authors, vec!["Yuan Mi", "Qi Wang"]);
+        assert_eq!(out[1].authors, vec!["Xujie Yuan"]);
+    }
+
+    #[test]
+    fn test_cycle2_trailing_script_content_ignored() {
+        // The streaming deserializer must stop at the array's closing `]`
+        // and not choke on the trailing `;` / </script> that follows.
+        let out = parse_accepted_papers(SAMPLE, "kdd2026");
+        assert_eq!(
+            out[2].title,
+            "RELIANCE: Curating Reproductive Health Information"
+        );
+        assert_eq!(
+            out[2].authors,
+            vec!["Vaibhav Balloli", "Laura Peyton Ellis"]
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "kdd2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
@@ -5,6 +5,7 @@
 pub mod aaai;
 pub mod acsac;
 pub mod asiaccs;
+pub mod asplos;
 pub(crate) mod author_parsing;
 pub mod blackhat;
 pub mod ccs;
@@ -12,12 +13,14 @@ pub mod cvf;
 pub mod defcon;
 pub mod esorics;
 pub mod eurosp;
+pub mod icml;
 pub mod icse;
 pub mod ieee_sp;
 pub mod ndss;
 pub mod neurips;
 pub mod raid;
 pub mod report_json;
+pub mod sosp;
 pub mod usenix;
 
 use std::path::PathBuf;
@@ -327,6 +330,61 @@ pub async fn import_blackhat(
     // applies unchanged.
     let json = fetch_html(&source).await?;
     let records = blackhat::parse_sessions(&json, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a SOSP accepted-papers page. `source_tag` is stored as each
+/// record's provenance, e.g. `"sosp2025"`.
+pub async fn import_sosp(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = sosp::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import an ASPLOS program page. `source_tag` is stored as each
+/// record's provenance, e.g. `"asplos2026"`.
+pub async fn import_asplos(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = asplos::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import an ISCA program page. `source_tag` is stored as each record's
+/// provenance, e.g. `"isca2026"`.
+///
+/// ISCA's `iscaconf.org` program page uses the exact same
+/// `div.paper`/`div.paper-title`/`div.paper-authors` markup as ASPLOS's
+/// site — evidently a shared conference-site template across systems/
+/// architecture venues — so this reuses [`asplos::parse_accepted_papers`]
+/// directly rather than duplicating it, the same way NSDI/OSDI reuse
+/// `import_usenix` for their shared USENIX Drupal template.
+pub async fn import_isca(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = asplos::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import an ICML PMLR volume page. `source_tag` is stored as each
+/// record's provenance, e.g. `"icml2026"`.
+pub async fn import_icml(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = icml::parse_volume(&html, source_tag);
     insert_all(conn, records)
 }
 

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
@@ -17,8 +17,10 @@ pub mod iclr;
 pub mod icml;
 pub mod icse;
 pub mod ieee_sp;
+pub mod infocom;
 pub mod ndss;
 pub mod neurips;
+pub mod pets;
 pub mod raid;
 pub mod report_json;
 pub mod sosp;
@@ -399,6 +401,30 @@ pub async fn import_iclr(
 ) -> Result<ImportStats, CorpusError> {
     let html = fetch_html(&source).await?;
     let records = iclr::parse_papers_with_code(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a PETS/PoPETs paper-list page. `source_tag` is stored as each
+/// record's provenance, e.g. `"pets2026"`.
+pub async fn import_pets(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = pets::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import an IEEE INFOCOM accepted-paper-list page. `source_tag` is
+/// stored as each record's provenance, e.g. `"infocom2026"`.
+pub async fn import_infocom(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = infocom::parse_accepted_papers(&html, source_tag);
     insert_all(conn, records)
 }
 

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
@@ -11,20 +11,28 @@ pub mod blackhat;
 pub mod ccs;
 pub mod cvf;
 pub mod defcon;
+pub(crate) mod dom_text;
+pub mod dsn;
 pub mod esorics;
 pub mod eurosp;
+pub mod eurosys;
 pub mod iclr;
 pub mod icml;
 pub mod icse;
 pub mod ieee_sp;
+pub mod imc;
 pub mod infocom;
+pub mod kdd;
 pub mod ndss;
 pub mod neurips;
 pub mod pets;
 pub mod raid;
 pub mod report_json;
+pub mod sigcomm;
+pub mod sigmod;
 pub mod sosp;
 pub mod usenix;
+pub mod www;
 
 use std::path::PathBuf;
 
@@ -425,6 +433,93 @@ pub async fn import_infocom(
 ) -> Result<ImportStats, CorpusError> {
     let html = fetch_html(&source).await?;
     let records = infocom::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import ACM SIGCOMM's accepted-papers page. `source_tag` is stored as
+/// each record's provenance, e.g. `"sigcomm2026"`.
+pub async fn import_sigcomm(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = sigcomm::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import ACM IMC's accepted-papers page. `source_tag` is stored as each
+/// record's provenance, e.g. `"imc2026"`.
+pub async fn import_imc(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = imc::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a DSN accepted-papers page. `source_tag` is stored as each
+/// record's provenance, e.g. `"dsn2026"`.
+pub async fn import_dsn(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = dsn::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a EuroSys accepted-papers page. `source_tag` is stored as each
+/// record's provenance, e.g. `"eurosys2026"`.
+pub async fn import_eurosys(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = eurosys::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a SIGMOD accepted-papers page. `source_tag` is stored as each
+/// record's provenance, e.g. `"sigmod2026"`.
+pub async fn import_sigmod(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = sigmod::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a WWW ("The Web Conference") accepted-papers track page.
+/// `source_tag` is stored as each record's provenance, e.g. `"www2026"`.
+/// Separate pages exist per track (research/industry/short-papers/...) —
+/// run once per page you want indexed.
+pub async fn import_www(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = www::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a KDD accepted-papers page (parsing its embedded JS data, not
+/// its HTML). `source_tag` is stored as each record's provenance, e.g.
+/// `"kdd2026"`.
+pub async fn import_kdd(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = kdd::parse_accepted_papers(&html, source_tag);
     insert_all(conn, records)
 }
 

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
@@ -9,6 +9,7 @@ pub mod asplos;
 pub(crate) mod author_parsing;
 pub mod blackhat;
 pub mod ccs;
+pub mod chi;
 pub mod cvf;
 pub mod defcon;
 pub(crate) mod dom_text;
@@ -520,6 +521,21 @@ pub async fn import_kdd(
 ) -> Result<ImportStats, CorpusError> {
     let html = fetch_html(&source).await?;
     let records = kdd::parse_accepted_papers(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a CHI (or any ACM-DL-front-matter-formatted) proceedings
+/// front-matter PDF, given its already-extracted text — the CLI layer
+/// does the actual PDF extraction (see the `chi` module docs for why:
+/// keeping this crate free of the AGPL `mupdf` dependency). No network
+/// access, so unlike every other importer here this isn't `async`.
+/// `source_tag` is stored as each record's provenance, e.g. `"chi2026"`.
+pub fn import_chi_frontmatter(
+    conn: &Connection,
+    text: &str,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let records = chi::parse_frontmatter(text, source_tag);
     insert_all(conn, records)
 }
 

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
@@ -13,6 +13,7 @@ pub mod cvf;
 pub mod defcon;
 pub mod esorics;
 pub mod eurosp;
+pub mod iclr;
 pub mod icml;
 pub mod icse;
 pub mod ieee_sp;
@@ -385,6 +386,19 @@ pub async fn import_icml(
 ) -> Result<ImportStats, CorpusError> {
     let html = fetch_html(&source).await?;
     let records = icml::parse_volume(&html, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a Paper Digest "<Venue> Papers with Code & Data" page — built
+/// for ICLR, whose own sources are all unusable (see `iclr` module docs).
+/// `source_tag` is stored as each record's provenance, e.g. `"iclr2026"`.
+pub async fn import_iclr(
+    conn: &Connection,
+    source: HtmlSource,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let html = fetch_html(&source).await?;
+    let records = iclr::parse_papers_with_code(&html, source_tag);
     insert_all(conn, records)
 }
 

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/mod.rs
@@ -33,6 +33,7 @@ pub mod sigcomm;
 pub mod sigmod;
 pub mod sosp;
 pub mod usenix;
+pub mod vldb;
 pub mod www;
 
 use std::path::PathBuf;
@@ -536,6 +537,20 @@ pub fn import_chi_frontmatter(
     source_tag: &str,
 ) -> Result<ImportStats, CorpusError> {
     let records = chi::parse_frontmatter(text, source_tag);
+    insert_all(conn, records)
+}
+
+/// Import a PVLDB issue's front-matter PDF table of contents, given its
+/// already-extracted text (see the `chi` module docs for why PDF
+/// extraction stays out of this crate). No network access, so this
+/// isn't `async`. `source_tag` is stored as each record's provenance,
+/// e.g. `"vldb2026-v19n9"` — call once per issue you want indexed.
+pub fn import_vldb_toc(
+    conn: &Connection,
+    text: &str,
+    source_tag: &str,
+) -> Result<ImportStats, CorpusError> {
+    let records = vldb::parse_table_of_contents(text, source_tag);
     insert_all(conn, records)
 }
 

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/pets.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/pets.rs
@@ -12,11 +12,11 @@
 //! `"Name (Affiliation), Name (Affiliation), and Name (Affiliation)"` —
 //! the same shape [`parse_paren_grouped_names`] already handles.
 
-use scraper::{ElementRef, Selector};
-use std::ops::Deref;
+use scraper::Selector;
 
 use crate::db::NewPublication;
 use crate::ingest::author_parsing::parse_paren_grouped_names;
+use crate::ingest::dom_text::direct_text;
 
 /// Parse a PETS/PoPETs paper-list page into publication records.
 ///
@@ -51,16 +51,6 @@ pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication
         });
     }
     out
-}
-
-/// Collect only an element's own direct text-node children (not text from
-/// nested elements), concatenated and trimmed.
-fn direct_text(el: &ElementRef) -> String {
-    el.children()
-        .filter_map(|child| child.value().as_text().map(|t| t.deref()))
-        .collect::<String>()
-        .trim()
-        .to_string()
 }
 
 #[cfg(test)]

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/pets.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/pets.rs
@@ -1,0 +1,125 @@
+//! Parse the PETS/PoPETs accepted-papers page into corpus records.
+//!
+//! PoPETs (Proceedings on Privacy Enhancing Technologies) publishes
+//! quarterly, and `petsymposium.org/<year>/paperlist.php` lists every
+//! issue's accepted papers on one page. Structure: `div.accepted-list`
+//! (one per issue) → `ul` → `li`, where the title is the `<li>`'s own
+//! direct text (its first non-empty text-node child — everything after
+//! that, an optional `artifact-*` badge link and an italic `<span>` of
+//! authors, comes from child *elements*, not direct text, so collecting
+//! only direct text nodes cleanly isolates the title without needing to
+//! know whether an artifact badge is present). Authors are
+//! `"Name (Affiliation), Name (Affiliation), and Name (Affiliation)"` —
+//! the same shape [`parse_paren_grouped_names`] already handles.
+
+use scraper::{ElementRef, Selector};
+use std::ops::Deref;
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+
+/// Parse a PETS/PoPETs paper-list page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"pets2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = scraper::Html::parse_document(html);
+    let item_sel = Selector::parse("div.accepted-list li").unwrap();
+    let authors_sel = Selector::parse("span").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let title = direct_text(&item);
+        if title.is_empty() {
+            continue;
+        }
+
+        let Some(authors_el) = item.select(&authors_sel).next() else {
+            continue;
+        };
+        let authors_text: String = authors_el.text().collect();
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+/// Collect only an element's own direct text-node children (not text from
+/// nested elements), concatenated and trimmed.
+fn direct_text(el: &ElementRef) -> String {
+    el.children()
+        .filter_map(|child| child.value().as_text().map(|t| t.deref()))
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <h3 class="side-headings">Issue 1</h3>
+        <div class="accepted-list">
+        <ul>
+        <li>How We Define Privacy Literacy: Teaching Experiences &amp; Challenges<br />
+        <span style="font-style: italic;">Tanisha Afnan (University of Michigan), Sheza Naveed (University of Michigan), and Florian Schaub (University of Michigan)</span></li>
+
+        <li>Obscura: Enabling Ephemeral Proxies <a href="https://github.com/example" target="_blank" class="artifact-available artifact-functional">Artifact: Available, Functional</a><br />
+        <span style="font-style: italic;">Afonso Vilalonga (NOVA LINCS), Kevin Gallagher (NOVA LINCS)</span></li>
+        </ul>
+        </div>
+        <h3 class="side-headings">Issue 2</h3>
+        <div class="accepted-list">
+        <ul>
+        <li>A Second-Issue Paper<br />
+        <span style="font-style: italic;">Solo Author (Some University)</span></li>
+        </ul>
+        </div>
+    "#;
+
+    #[test]
+    fn test_title_without_artifact_badge() {
+        let out = parse_accepted_papers(SAMPLE, "pets2026");
+        assert_eq!(
+            out[0].title,
+            "How We Define Privacy Literacy: Teaching Experiences & Challenges"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec!["Tanisha Afnan", "Sheza Naveed", "Florian Schaub"]
+        );
+        assert_eq!(out[0].source, "pets2026");
+    }
+
+    #[test]
+    fn test_title_ignores_artifact_badge_link_text() {
+        let out = parse_accepted_papers(SAMPLE, "pets2026");
+        // Direct-text extraction must not pick up "Artifact: Available, Functional"
+        // from the badge <a>, which is a child *element*, not direct text.
+        assert_eq!(out[1].title, "Obscura: Enabling Ephemeral Proxies");
+        assert_eq!(out[1].authors, vec!["Afonso Vilalonga", "Kevin Gallagher"]);
+    }
+
+    #[test]
+    fn test_second_issue_picked_up() {
+        let out = parse_accepted_papers(SAMPLE, "pets2026");
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[2].title, "A Second-Issue Paper");
+        assert_eq!(out[2].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "pets2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sigcomm.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sigcomm.rs
@@ -1,0 +1,98 @@
+//! Parse ACM SIGCOMM's accepted-papers page into corpus records.
+//!
+//! One page per year at `conferences.sigcomm.org/sigcomm/<year>/accepted-papers/`,
+//! covering both "Full papers" and "Short papers" sections identically.
+//! Structure: `li` → `p > span.text-color-primary` (title) +
+//! `p.style_italic` (authors, `"Name (Affiliation); Name, Name
+//! (Affiliation); ..."` — the same shape [`parse_paren_grouped_names`]
+//! already handles).
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+
+/// Parse a SIGCOMM accepted-papers page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"sigcomm2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let item_sel = Selector::parse("li").unwrap();
+    let title_sel = Selector::parse("span.text-color-primary").unwrap();
+    let authors_sel = Selector::parse("p.style_italic").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let Some(title_el) = item.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let Some(authors_el) = item.select(&authors_sel).next() else {
+            continue;
+        };
+        let authors_text: String = authors_el.text().collect();
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <h2>Full papers</h2>
+        <ul>
+            <li>
+                <p><span class="text-color-primary">Nezha: SmartNIC-based Virtual Switch Load Sharing</span></p>
+                <p class="style_italic">Xing Li (Zhejiang University and Alibaba Cloud); Enge Song, Bowen Yang (Alibaba Cloud)</p>
+            </li>
+        </ul>
+        <h2>Short papers</h2>
+        <ul>
+            <li>
+                <p><span class="text-color-primary">A Short Paper Title</span></p>
+                <p class="style_italic">Solo Author (Some University)</p>
+            </li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_full_papers_section() {
+        let out = parse_accepted_papers(SAMPLE, "sigcomm2026");
+        assert_eq!(
+            out[0].title,
+            "Nezha: SmartNIC-based Virtual Switch Load Sharing"
+        );
+        assert_eq!(out[0].authors, vec!["Xing Li", "Enge Song", "Bowen Yang"]);
+        assert_eq!(out[0].source, "sigcomm2026");
+    }
+
+    #[test]
+    fn test_short_papers_section_also_picked_up() {
+        let out = parse_accepted_papers(SAMPLE, "sigcomm2026");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[1].title, "A Short Paper Title");
+        assert_eq!(out[1].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "sigcomm2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sigmod.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sigmod.rs
@@ -1,0 +1,91 @@
+//! Parse the SIGMOD accepted-papers page into corpus records.
+//!
+//! One page per year at `<year>.sigmod.org/sigmod_papers.shtml`, listing
+//! every PACMMOD submission round's papers directly (no need to follow
+//! out to the separate ACM DL table-of-contents page per round).
+//! Structure: `li` → `b` (title) followed by direct text (authors:
+//! `"Name (Affiliation); Name (Affiliation)*; ..."` — the same shape
+//! [`parse_paren_grouped_names`] already handles, except for the
+//! trailing `*` SIGMOD marks the corresponding/presenting author with,
+//! which sits *outside* the parenthesized affiliation and would
+//! otherwise leak into the next name — stripped before parsing).
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+use crate::ingest::dom_text::direct_text;
+
+/// Parse a SIGMOD accepted-papers page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"sigmod2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let item_sel = Selector::parse("li").unwrap();
+    let title_sel = Selector::parse("b").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let Some(title_el) = item.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let authors_text = direct_text(&item).replace('*', "");
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <h3>Round 1</h3>
+        <ul>
+        <li><b>SWIFT: Enabling Large-Scale Temporal Graph Learning on a Single Machine</b><br>Rui Guo (University of Science and Technology of China); Zezhong Ding (University of Science and Technology of China); Xike Xie (University of Science and Technology of China)*; Jianliang Xu (Hong Kong Baptist University)</li>
+        <li><b>A Solo-Author Paper</b><br>Solo Author (Some University)*</li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_trailing_asterisk_does_not_leak_into_next_name() {
+        let out = parse_accepted_papers(SAMPLE, "sigmod2026");
+        assert_eq!(
+            out[0].title,
+            "SWIFT: Enabling Large-Scale Temporal Graph Learning on a Single Machine"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec!["Rui Guo", "Zezhong Ding", "Xike Xie", "Jianliang Xu"]
+        );
+        assert_eq!(out[0].source, "sigmod2026");
+    }
+
+    #[test]
+    fn test_trailing_asterisk_on_last_author_stripped() {
+        let out = parse_accepted_papers(SAMPLE, "sigmod2026");
+        assert_eq!(out[1].title, "A Solo-Author Paper");
+        assert_eq!(out[1].authors, vec!["Solo Author"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "sigmod2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sosp.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sosp.rs
@@ -1,0 +1,111 @@
+//! Parse SOSP's (ACM SIGOPS Symposium on Operating Systems Principles)
+//! accepted-papers page into corpus records.
+//!
+//! Hosted on sigops.org (not ACM's own site), one static page per year at
+//! `sigops.org/s/conferences/sosp/<year>/accepted.html`. Structure:
+//! `ul.paperlist` → `li` → `b` (title) → `br` → `em` (authors, the same
+//! `"Name (Affiliation), Name (Affiliation)"` shape
+//! [`parse_paren_grouped_names`] already handles — trailing entries in a
+//! shared affiliation group without their own parenthesized affiliation,
+//! e.g. `"Yanyan Shen, Linpeng Huang, Hong Mei (Shanghai Jiao Tong
+//! University)"`, still parse fine since the helper doesn't require every
+//! name to have its own affiliation).
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::author_parsing::parse_paren_grouped_names;
+
+/// Parse a SOSP accepted-papers page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"sosp2025"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let list_sel = Selector::parse("ul.paperlist").unwrap();
+    let item_sel = Selector::parse("li").unwrap();
+    let title_sel = Selector::parse("b").unwrap();
+    let authors_sel = Selector::parse("em").unwrap();
+
+    let mut out = Vec::new();
+    for list in document.select(&list_sel) {
+        for item in list.select(&item_sel) {
+            let Some(title_el) = item.select(&title_sel).next() else {
+                continue;
+            };
+            let title: String = title_el.text().collect::<String>().trim().to_string();
+            if title.is_empty() {
+                continue;
+            }
+
+            let Some(authors_el) = item.select(&authors_sel).next() else {
+                continue;
+            };
+            let authors_text: String = authors_el.text().collect();
+            let authors = parse_paren_grouped_names(&authors_text);
+            if authors.is_empty() {
+                continue;
+            }
+
+            out.push(NewPublication {
+                title,
+                authors,
+                url: None,
+                source: source_tag.to_string(),
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <ul class="paperlist">
+        <li><b>Rearchitecting the Thread Model of In-Memory Key-Value Stores with &mu;TPS</b><br>
+        <em>Youmin Chen (Shanghai Jiao Tong University), Jiwu Shu (Tsinghua University), Yanyan Shen, Linpeng Huang, Hong Mei (Shanghai Jiao Tong University) </em></li>
+
+        <li><b>Device-Assisted Live Migration of RDMA Devices</b><br>
+        <em>Artem Y. Polyakov, Gal Shalom, Asaf Schwartz, Aviad Yehezkel, Omri Ben David, Omri Kahalon, Ariel Shahar, Liran Liss (NVIDIA Corporation) </em></li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_parse_two_entries() {
+        let out = parse_accepted_papers(SAMPLE, "sosp2025");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "Rearchitecting the Thread Model of In-Memory Key-Value Stores with μTPS"
+        );
+        assert_eq!(out[0].source, "sosp2025");
+        assert!(out[0].authors.contains(&"Youmin Chen".to_string()));
+        assert!(out[0].authors.contains(&"Hong Mei".to_string()));
+    }
+
+    #[test]
+    fn test_shared_affiliation_group_all_captured() {
+        let out = parse_accepted_papers(SAMPLE, "sosp2025");
+        // Trailing names in the first entry share the last parenthesized
+        // affiliation rather than each having their own — all 5 names
+        // must still come through.
+        assert_eq!(out[0].authors.len(), 5);
+    }
+
+    #[test]
+    fn test_second_entry() {
+        let out = parse_accepted_papers(SAMPLE, "sosp2025");
+        assert_eq!(
+            out[1].title,
+            "Device-Assisted Live Migration of RDMA Devices"
+        );
+        assert_eq!(out[1].authors.len(), 8);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "sosp2025").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/vldb.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/vldb.rs
@@ -1,0 +1,292 @@
+//! Parse a PVLDB (Proceedings of the VLDB Endowment) issue's front-matter
+//! PDF table of contents into corpus records.
+//!
+//! PVLDB publishes monthly, and VLDB's conference program is drawn from
+//! whichever issues land before each year's submission-rollover cutoff —
+//! there's no single consolidated "VLDB <year> accepted papers" page,
+//! only these per-issue front-matter PDFs (freely downloadable from
+//! `dl.acm.org/journal/pvldb` or `pvldb.org`, no paywall). Call this once
+//! per issue you want indexed.
+//!
+//! Unlike CHI's front matter (see the `chi` module), this is a genuine
+//! table of contents, not a full per-paper block — and it carries no
+//! author affiliations at all, just plain names. Structure (via
+//! `pdftotext -layout`):
+//!
+//! ```text
+//! Some Paper Title That May Wrap Onto A Second
+//! Line Before The Dot Leader ......................... 1867
+//! Author One, Author Two, Author Three
+//!
+//! Next Title .......................................... 1880
+//! Solo Author
+//! ```
+//!
+//! The dot-leader-then-page-number is the one unambiguous signal
+//! (real titles don't contain long runs of periods): whatever text
+//! precedes it, across as many wrapped lines as needed, is the title;
+//! the first non-blank, non-page-footer line *after* it is the
+//! (single-line, comma-separated, no affiliations) author list. A
+//! "PVLDB Vol. <N>, No. <M> ... <page>" header/footer line can land
+//! *between* a title's dot-leader line and its author line when a page
+//! break falls right there — skipped like blank lines rather than
+//! treated as content.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::db::NewPublication;
+
+/// A line ending in a run of dots (a "dot leader") followed by a page
+/// number — group 1 is whatever title text precedes it on that same
+/// line (possibly empty, if the whole line is just the leader).
+static DOT_LEADER: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(.*?)\.{3,}\s*\d+\s*$").unwrap());
+
+/// A running header/footer line stamped on every page — not content.
+static PAGE_STAMP: Lazy<Regex> = Lazy::new(|| Regex::new(r"^PVLDB Vol\.").unwrap());
+
+/// The bare page number that goes with a `PAGE_STAMP` line — usually
+/// part of the same physical line (`"PVLDB Vol. 19, No. 9 ... iii"`),
+/// but PDF text extractors don't agree on that: MuPDF (this project's
+/// own backend, confirmed empirically — poppler's `pdftotext -layout`
+/// keeps them joined) sometimes splits the trailing page number onto
+/// its own line, a roman numeral (front matter) or plain integer (body)
+/// with nothing else on it. Left unrecognized, a stray line like this
+/// gets mistaken for that entry's author line, and its *real* author
+/// line then gets mistaken for the start of the next title — corrupting
+/// two consecutive entries from one missed line. No legitimate title or
+/// author line is ever *just* a bare number/numeral, so skipping this
+/// unconditionally is safe.
+static STANDALONE_PAGE_NUM: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^[ivxlcdm]+$|^\d+$").unwrap());
+
+/// Section-header labels PVLDB issues use to group entries (this list
+/// isn't necessarily exhaustive across every issue — new track names
+/// appear occasionally). Only skipped when they'd otherwise become the
+/// *start* of a title (i.e. no title text has been collected yet for
+/// the entry in progress); a real title that happened to be exactly one
+/// of these strings would be astronomically unlikely.
+const SECTION_HEADERS: &[&str] = &[
+    "Research Papers",
+    "Industry and Applications Papers",
+    "Industrial Track",
+    "Experiment, Analysis & Benchmark Papers",
+    "Experiment, Analysis and Benchmark Papers",
+    "Demonstrations",
+    "Tutorials",
+    "Tutorial",
+    "Vision Papers",
+    "Vision Track",
+    "Systems and Applications Papers",
+    "Scalable Data Science Papers",
+    "PhD Workshop",
+    "Reproducibility",
+];
+
+/// Join wrapped title lines, de-hyphenating a trailing `-` when the next
+/// line resumes lowercase (same heuristic as [`super::chi`] uses, for
+/// the same reason: good enough for a fuzzy-match threshold, not meant
+/// to be typeset-perfect).
+fn join_title_lines(lines: &[String]) -> String {
+    let mut out = String::new();
+    for line in lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(stripped) = out.strip_suffix('-') {
+            let starts_lower = line.chars().next().is_some_and(|c| c.is_lowercase());
+            if starts_lower {
+                out = format!("{stripped}{line}");
+                continue;
+            }
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+enum State {
+    CollectingTitle,
+    ExpectingAuthors,
+}
+
+/// Parse extracted PDF text from a PVLDB issue's front matter into
+/// publication records. `source_tag` is the provenance string to store
+/// on each record, e.g. `"vldb2026-v19n9"`.
+pub fn parse_table_of_contents(text: &str, source_tag: &str) -> Vec<NewPublication> {
+    let mut out = Vec::new();
+    let mut state = State::CollectingTitle;
+    let mut title_lines: Vec<String> = Vec::new();
+    let mut pending_title: Option<String> = None;
+
+    for raw_line in text.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || PAGE_STAMP.is_match(line) || STANDALONE_PAGE_NUM.is_match(line) {
+            continue;
+        }
+
+        match state {
+            State::CollectingTitle => {
+                if title_lines.is_empty() && SECTION_HEADERS.contains(&line) {
+                    continue;
+                }
+                if let Some(caps) = DOT_LEADER.captures(line) {
+                    title_lines.push(caps[1].to_string());
+                    let title = join_title_lines(&title_lines);
+                    title_lines.clear();
+                    if !title.is_empty() {
+                        pending_title = Some(title);
+                        state = State::ExpectingAuthors;
+                    }
+                    // else: a stray dot-leader-only line with no title
+                    // text at all (shouldn't happen in practice) — stay
+                    // in CollectingTitle and keep accumulating.
+                } else {
+                    title_lines.push(line.to_string());
+                }
+            }
+            State::ExpectingAuthors => {
+                let authors: Vec<String> = line
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                if let (Some(title), false) = (pending_title.take(), authors.is_empty()) {
+                    out.push(NewPublication {
+                        title,
+                        authors,
+                        url: None,
+                        source: source_tag.to_string(),
+                    });
+                }
+                state = State::CollectingTitle;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+Research Papers
+
+  Secure Join Operations in Multi-Identifier Databases: Performance and Practicality ....................................... 1854
+  Wen-Jie Lu, Yongchuan Niu, Yongjun Zhao, Wei Dai, Donghang Lu, Li Wang, Qiang Yan
+
+  A Resource-centric Analysis and Optimization of NoSQL Workloads using Distressed Resource Volume
+  Metric ......................................................................................................................................................................................................... 1867
+  Gunika Verma, Aashutosh A V, Pooja Srinivas, Yogesh Simmhan
+
+  A Comparative Evaluation of Schema Subsetting for LLM-based NL-to-SQL over Large-Schema Databases
+  ....................................................................................................................................................................................................................... 2019
+
+ PVLDB Vol. 19, No. 9                                                                                      ii
+ Kyle Luoma, Arun Kumar
+";
+
+    #[test]
+    fn test_single_line_title_and_authors() {
+        let out = parse_table_of_contents(SAMPLE, "vldb2026-v19n9");
+        assert_eq!(
+            out[0].title,
+            "Secure Join Operations in Multi-Identifier Databases: Performance and Practicality"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec![
+                "Wen-Jie Lu",
+                "Yongchuan Niu",
+                "Yongjun Zhao",
+                "Wei Dai",
+                "Donghang Lu",
+                "Li Wang",
+                "Qiang Yan"
+            ]
+        );
+        assert_eq!(out[0].source, "vldb2026-v19n9");
+    }
+
+    #[test]
+    fn test_title_wraps_before_dot_leader() {
+        let out = parse_table_of_contents(SAMPLE, "vldb2026-v19n9");
+        assert_eq!(
+            out[1].title,
+            "A Resource-centric Analysis and Optimization of NoSQL Workloads using Distressed Resource Volume Metric"
+        );
+        assert_eq!(out[1].authors.len(), 4);
+    }
+
+    #[test]
+    fn test_page_stamp_between_dot_leader_and_authors_skipped() {
+        // The dot-leader line for entry 3 has NO title text on it at all
+        // (title fully consumed the previous line) — and a page-footer
+        // stamp lands between it and the author line. Neither should
+        // break the title/author association.
+        let out = parse_table_of_contents(SAMPLE, "vldb2026-v19n9");
+        assert_eq!(out.len(), 3);
+        assert_eq!(
+            out[2].title,
+            "A Comparative Evaluation of Schema Subsetting for LLM-based NL-to-SQL over Large-Schema Databases"
+        );
+        assert_eq!(out[2].authors, vec!["Kyle Luoma", "Arun Kumar"]);
+    }
+
+    // Regression: real hallucinator-pdf-mupdf output (not poppler's
+    // `pdftotext -layout`, which is what the SAMPLE above mirrors) splits
+    // "PVLDB Vol. 19, No. 9" and its trailing roman-numeral page number
+    // onto *separate* lines, e.g. from the actual VLDB v19n9 front matter:
+    //
+    //   PVLDB Vol. 19, No. 9
+    //    iii
+    //
+    // A bare "iii" line isn't matched by PAGE_STAMP (`^PVLDB Vol\.`), so
+    // without STANDALONE_PAGE_NUM it gets mistaken for the entry's author
+    // line — and that entry's *real* author line then gets mistaken for
+    // the start of the next title, corrupting two consecutive entries
+    // from one missed line.
+    const MUPDF_SPLIT_PAGE_STAMP_SAMPLE: &str = "\
+A Comparative Evaluation of Schema Subsetting for LLM-based NL-to-SQL over Large-Schema Databases
+ ....................................................................................................................................................................................................................... 2019
+
+
+
+PVLDB Vol. 19, No. 9
+
+ iii
+
+
+
+Kyle Luoma, Arun Kumar
+
+IncreQueryFusion: On-demand Data Fusion Framework in Dynamic Data Lakes .............................................. 2032
+Wenhao Liu, Sai Wu, Xiu Tang, Yitong Zhang, Dong Peng, Guolong Huang, Gang Chen
+";
+
+    #[test]
+    fn test_mupdf_split_page_stamp_does_not_corrupt_two_entries() {
+        let out = parse_table_of_contents(MUPDF_SPLIT_PAGE_STAMP_SAMPLE, "vldb2026-v19n9");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "A Comparative Evaluation of Schema Subsetting for LLM-based NL-to-SQL over Large-Schema Databases"
+        );
+        assert_eq!(out[0].authors, vec!["Kyle Luoma", "Arun Kumar"]);
+        assert_eq!(
+            out[1].title,
+            "IncreQueryFusion: On-demand Data Fusion Framework in Dynamic Data Lakes"
+        );
+        assert_eq!(out[1].authors.len(), 7);
+    }
+
+    #[test]
+    fn test_parse_empty_text() {
+        assert!(parse_table_of_contents("", "vldb2026-v19n9").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/www.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/www.rs
@@ -1,0 +1,112 @@
+//! Parse a WWW ("The Web Conference") accepted-papers track page into
+//! corpus records.
+//!
+//! One page per track per year, e.g.
+//! `www<year>.thewebconf.org/accepted/research-tracks.html` (separate
+//! pages exist for industry/short-papers/etc — call this once per page
+//! you want indexed). Structure: `li` → `span.paper-id` (a submission ID
+//! we don't need, e.g. `"(rfp0110)"`) + direct text (the title, followed
+//! by a trailing em dash separator) + `span.paper-authors` (a flat
+//! comma-and-"and"-separated name list — `"Name, Name and Name"`, **no**
+//! parenthesized affiliations, unlike most venues here, so this splits
+//! on comma/" and " directly rather than using
+//! [`super::author_parsing::parse_paren_grouped_names`], the same
+//! approach [`super::icml`] and [`super::imc`] use for the same reason).
+
+use scraper::{Html, Selector};
+
+use crate::db::NewPublication;
+use crate::ingest::dom_text::direct_text;
+
+/// Parse a WWW accepted-papers track page into publication records.
+///
+/// `source_tag` is the provenance string to store on each record, e.g.
+/// `"www2026"`.
+pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let item_sel = Selector::parse("li").unwrap();
+    let authors_sel = Selector::parse("span.paper-authors").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let Some(authors_el) = item.select(&authors_sel).next() else {
+            continue;
+        };
+
+        let raw_title = direct_text(&item);
+        let title = raw_title
+            .trim_end_matches(['\u{2014}', ' ']) // trailing " — " separator
+            .trim()
+            .to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let authors_text: String = authors_el.text().collect();
+        let authors: Vec<String> = authors_text
+            .replace(" and ", ", ")
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+        <ul>
+        <li><span class="paper-id">(rfp0110)</span> Opinion Dynamics with Multiple Adversaries — <span class="paper-authors">Akhil Jalan and Marios Papachristou</span></li>
+        <li><span class="paper-id">(rfp0366)</span> Auto-bidding under Return-on-Spend Constraints — <span class="paper-authors">Jiale Han, Chun Gan, Zhangang Lin, Ching Law and Xiaowu Dai</span></li>
+        <li><span class="paper-id">(rfp0434)</span> Deterring A Small Collusion is All You Need — <span class="paper-authors">Yotam Gafni</span></li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_title_excludes_paper_id_and_trailing_dash() {
+        let out = parse_accepted_papers(SAMPLE, "www2026");
+        assert_eq!(out[0].title, "Opinion Dynamics with Multiple Adversaries");
+        assert_eq!(out[0].authors, vec!["Akhil Jalan", "Marios Papachristou"]);
+        assert_eq!(out[0].source, "www2026");
+    }
+
+    #[test]
+    fn test_oxford_less_and_before_last_author() {
+        let out = parse_accepted_papers(SAMPLE, "www2026");
+        assert_eq!(
+            out[1].authors,
+            vec![
+                "Jiale Han",
+                "Chun Gan",
+                "Zhangang Lin",
+                "Ching Law",
+                "Xiaowu Dai"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_solo_author() {
+        let out = parse_accepted_papers(SAMPLE, "www2026");
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[2].authors, vec!["Yotam Gafni"]);
+    }
+
+    #[test]
+    fn test_parse_empty_html() {
+        assert!(parse_accepted_papers("<html></html>", "www2026").is_empty());
+    }
+}

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/query.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/query.rs
@@ -50,6 +50,23 @@ fn get_query_words(title: &str) -> Vec<String> {
         .collect()
 }
 
+/// Quote a single word for safe use inside an FTS5 MATCH query string.
+///
+/// `get_query_words` keeps internal hyphens/apostrophes as part of one
+/// token (e.g. "Branch-Guided" -> `branch-guided`), but FTS5's own query
+/// mini-language treats bareword `-` as an operator character — an
+/// unquoted term like `branch-guided` fails to parse as the literal token
+/// and errors out instead of matching. That error was silently swallowed
+/// by `fts_match`'s `.filter_map(|r| r.ok())`, making a query containing
+/// any hyphenated word look like "zero candidates" instead of a query
+/// syntax error — a real, silent false-negative bug (confirmed: FTS5
+/// happily finds "Bulbasaur: Branch-Guided ..." via `MATCH 'bulbasaur AND
+/// "branch-guided"'` but errors on the unquoted form). Wrapping each term
+/// in double quotes makes FTS5 treat it as a literal string instead.
+fn quote_fts_term(word: &str) -> String {
+    format!("\"{}\"", word.replace('"', "\"\""))
+}
+
 /// Query the FTS5 index for a title, returning the best match above the threshold.
 ///
 /// Three-tier fallback (mirrors `hallucinator_dblp::query::query_fts_with_authors`):
@@ -79,14 +96,22 @@ pub fn query_fts(
         return Ok(None);
     }
 
-    let fts_query = words.join(" ");
+    let fts_query = words
+        .iter()
+        .map(|w| quote_fts_term(w))
+        .collect::<Vec<_>>()
+        .join(" ");
     let result = fts_match(conn, &fts_query, &norm_query, threshold)?;
     if result.is_some() {
         return Ok(result);
     }
 
     if words.len() > 3 {
-        let fallback_query = words[..3].join(" ");
+        let fallback_query = words[..3]
+            .iter()
+            .map(|w| quote_fts_term(w))
+            .collect::<Vec<_>>()
+            .join(" ");
         let result = fts_match(conn, &fallback_query, &norm_query, threshold)?;
         if result.is_some() {
             return Ok(result);
@@ -96,7 +121,11 @@ pub fn query_fts(
     if words.len() >= 2 {
         let take = words.len().min(4);
         let or_words = select_or_fallback_words(conn, &words, take);
-        let or_query = or_words.join(" OR ");
+        let or_query = or_words
+            .iter()
+            .map(|w| quote_fts_term(w))
+            .collect::<Vec<_>>()
+            .join(" OR ");
         return fts_match(conn, &or_query, &norm_query, threshold);
     }
 
@@ -332,6 +361,47 @@ mod tests {
         let conn = setup_db_with_data();
         let result = query_fts(&conn, "", DEFAULT_THRESHOLD).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_hyphenated_word_in_title_does_not_break_the_query() {
+        // Regression: FTS5's bareword query parser treats an unquoted
+        // internal `-` as an operator character, so a query word like
+        // "branch-guided" (kept as one token by `get_query_words` because
+        // WORD_RE treats hyphens as word-internal) failed to parse at all
+        // when joined unquoted into the MATCH string — and that parse
+        // error was silently swallowed by `fts_match`'s
+        // `.filter_map(|r| r.ok())`, making a real, indexed title look
+        // like "zero candidates". Confirmed against production data:
+        // "Bulbasaur: Branch-Guided Online Mutator Generation for Greybox
+        // Fuzzing" (real USENIX Security 2026 paper) was unfindable via
+        // `CorpusPool::query` despite `MATCH 'bulbasaur'` finding it
+        // trivially at the raw SQL level.
+        let conn = Connection::open_in_memory().unwrap();
+        db::init_database(&conn).unwrap();
+        db::insert_publication(
+            &conn,
+            &db::NewPublication {
+                title: "Bulbasaur: Branch-Guided Online Mutator Generation for Greybox Fuzzing"
+                    .to_string(),
+                authors: vec!["A. Researcher".to_string()],
+                url: None,
+                source: "usenix2026".to_string(),
+            },
+        )
+        .unwrap();
+
+        let result = query_fts(
+            &conn,
+            "Bulbasaur: Branch-Guided Online Mutator Generation for Greybox Fuzzing",
+            DEFAULT_THRESHOLD,
+        )
+        .unwrap();
+        assert!(
+            result.is_some(),
+            "a title containing a hyphenated word must still be found, not silently dropped"
+        );
+        assert_eq!(result.unwrap().score, 1.0);
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-openalex/src/builder.rs
+++ b/hallucinator-rs/crates/hallucinator-openalex/src/builder.rs
@@ -402,8 +402,24 @@ pub async fn build(
         .unwrap_or_default()
         .as_secs();
 
-    let total_in_index =
-        existing_meta.and_then(|m| m.publication_count).unwrap_or(0) + total_records;
+    // Read the real post-dedup doc count from the index itself rather than
+    // adding this run's record count onto the old stored count. Every
+    // upsert here does `delete_term` + `add_document` on `openalex_id`, so
+    // re-processing an already-indexed work (routine on any incremental
+    // update, and near-universal on a full historical rebuild) does not
+    // create a second document — but naively summing old + new here would
+    // count it as if it had, badly inflating the figure over time.
+    let total_in_index = {
+        let reader = index
+            .reader_builder()
+            .reload_policy(tantivy::ReloadPolicy::Manual)
+            .try_into()
+            .map_err(|e: tantivy::TantivyError| OpenAlexError::Index(e.to_string()))?;
+        reader
+            .reload()
+            .map_err(|e| OpenAlexError::Index(e.to_string()))?;
+        reader.searcher().num_docs()
+    };
 
     let sync_watermark = safe_watermark(
         &ok_partition_dates,


### PR DESCRIPTION
## Summary

- **Fix a silent FTS5 false-negative bug** in `hallucinator-local-corpus`: query words containing a hyphen (e.g. "Branch-Guided") were joined unquoted into the FTS5 `MATCH` string. FTS5's own query-syntax parser treats a bareword `-` as an operator character, so the term failed to parse — and that error was silently swallowed by `.filter_map(|r| r.ok())`, making any title with a hyphenated word look like "zero candidates" instead of a real match. Fixed by quoting every query term. Verified against production `local-corpus.db`: **+520 previously-missed titles now correctly matched, zero regressions**, measured via an isolated before/after rerun on the same input.
- **Add 8 new local-corpus venue importers**: SOSP, ASPLOS, ISCA, ICML, ICLR (via Paper Digest's papers-with-code page), PETS/PoPETs, INFOCOM, SIGCOMM, IMC, DSN, EuroSys, SIGMOD, WWW, KDD, CHI (PDF front-matter), VLDB (PDF front-matter — includes a regression test for a real MuPDF-vs-poppler layout divergence bug found and fixed during import).
- **Fix a CrossRef book-review false-negative**: the `is_likely_book_review` heuristic was discarding real short-titled journal articles by checking query-title wording instead of item-level signals (`relation.is-review-of`, `type`, `subtype`).
- **Fix OpenAlex offline index `publication_count` metadata inflation**: naive `old + new` summation didn't account for upsert dedup; now reads the real `searcher.num_docs()`.

## Measured impact

Full two-pass recheck of the NDSS27-fall corpus (1,465 papers, 75,815 references) with all fixes applied, zero human curation:

| | raw not_found + mismatch | rate |
|---|---|---|
| baseline (pre-session) | 4,031 | 6.38% |
| after this branch | 741 | 1.17% |

**81.6% fewer references would need manual review**, entirely from automated fixes.

## Test plan

- `cargo test --workspace` — 779 tests passing, including new regression tests for the FTS5 hyphen bug and the VLDB MuPDF page-stamp-splitting bug.
- `cargo fmt --all` clean.
- Every importer run for real against production `local-corpus.db`, spot-checked via direct SQL, not just CLI-reported counts.
- FTS5 fix verified against production `local-corpus.db` directly (not just the in-memory test DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)