### PR TITLE
Fix: '?' help overlay never renders on the File Picker screen

### DIFF
--- a/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
@@ -718,6 +718,9 @@ impl App {
         // File picker renders without activity panel
         if self.screen == Screen::FilePicker {
             crate::view::file_picker::render_in(f, self, area);
+            if self.show_help {
+                crate::view::help::render(f, &self.theme);
+            }
             if self.confirm_quit {
                 crate::view::quit_confirm::render(f, &self.theme);
             }


### PR DESCRIPTION
## Bug

Pressing `?` on the File Picker (add files) screen doesn't open the help overlay, even though the footer hint says `?:help`.

## Root cause

`Action::ToggleHelp` is dispatched and handled correctly for this screen — `update_file_picker.rs`'s `handle_file_picker_action` sets `show_help = true`, exactly like every other screen. The bug is in the *view* layer: `App::view()` has an early-return branch specifically for `Screen::FilePicker` that renders the file picker, checks only `confirm_quit`, and returns — it never checks `show_help`, so the overlay's internal state gets set correctly but can never actually be painted while on this screen.

```rust
// hallucinator-rs/crates/hallucinator-tui/src/app/mod.rs
// File picker renders without activity panel
if self.screen == Screen::FilePicker {
    crate::view::file_picker::render_in(f, self, area);
    if self.confirm_quit {
        crate::view::quit_confirm::render(f, &self.theme);
    }
    return;   // <- bails out before ever reaching the show_help check
              //    that every other screen falls through to below
}
```

## Fix

Add the same `show_help` check the other screens get, before the early return:

```rust
if self.screen == Screen::FilePicker {
    crate::view::file_picker::render_in(f, self, area);
    if self.show_help {
        crate::view::help::render(f, &self.theme);
    }
    if self.confirm_quit {
        crate::view::quit_confirm::render(f, &self.theme);
    }
    return;
}
```

## Verification

Reproduced and verified headlessly with a scripted tmux repro (start `hallucinator-tui`, wait past the 2s startup banner so the app has settled on the File Picker screen, send `?`, `capture-pane`, grep for `"Keyboard Shortcuts"`):

- Unmodified binary (both the current release tag and `main`): help never appears.
- Patched binary: help overlay renders correctly on top of the File Picker screen.

Confirmed on both the release build and the actual `cargo install`ed binary. No other behavior changes.
