### PR TITLE
Extend venue-backfill parsers for historical accepted-papers formats

### DIFF
--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/asplos.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/asplos.rs
@@ -10,17 +10,49 @@
 //! nested inside collapsible per-session panels, but selecting `div.paper`
 //! directly (rather than walking the session structure) picks up every
 //! paper regardless of which session panel it's under.
+//!
+//! ISCA reuses this same template (`iscaconf.org/isca<year>/program/`),
+//! but its `div.paper-authors` text drops affiliations entirely on the
+//! 2023-2025 pages (`"Name, Name, Name"`, no parens at all — only the
+//! 2026 page includes them), so authors are parsed with
+//! [`parse_names_maybe_with_affiliations`], which falls back to a plain
+//! comma split when no `(` is present.
+//!
+//! ASPLOS 2024's page (`asplos-conference.org/asplos2024/main-program/`)
+//! predates this `div.paper` template and uses a WordPress Gutenberg
+//! table instead: `table tbody td` → one direct-child `<strong>` (title —
+//! a `[Best Paper]` badge, if present, is wrapped in its own `<span>` so
+//! it isn't a direct child and is skipped automatically) → raw HTML up to
+//! the next `<a` link (the "Paper . Abstract . Lightning Talk" row) holds
+//! `"Name (Affiliation); Name (Affiliation)"` text, tags-and-all — same
+//! shape [`parse_paren_grouped_names`] handles once stripped. Tried as a
+//! fallback in [`parse_wp_table_template`] when the `div.paper` template
+//! finds nothing.
 
+use once_cell::sync::Lazy;
+use regex::Regex;
 use scraper::{Html, Selector};
 
 use crate::db::NewPublication;
-use crate::ingest::author_parsing::parse_paren_grouped_names;
+use crate::ingest::author_parsing::{
+    parse_names_maybe_with_affiliations, parse_paren_grouped_names,
+};
 
 /// Parse an ASPLOS program page into publication records.
 ///
 /// `source_tag` is the provenance string to store on each record, e.g.
 /// `"asplos2026"`.
 pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let out = parse_paper_div_template(html, source_tag);
+    if !out.is_empty() {
+        return out;
+    }
+    parse_wp_table_template(html, source_tag)
+}
+
+/// Current/ISCA-shared template: `div.paper` → `div.paper-title` +
+/// `div.paper-authors`.
+fn parse_paper_div_template(html: &str, source_tag: &str) -> Vec<NewPublication> {
     let document = Html::parse_document(html);
     let paper_sel = Selector::parse("div.paper").unwrap();
     let title_sel = Selector::parse("div.paper-title").unwrap();
@@ -40,7 +72,59 @@ pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication
             continue;
         };
         let authors_text: String = authors_el.text().collect();
-        let authors = parse_paren_grouped_names(&authors_text);
+        let authors = parse_names_maybe_with_affiliations(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+/// ASPLOS 2024's WordPress-table template: `table tbody td` → direct-child
+/// `<strong>` (title) → `"Name (Affiliation); ..."` text up to the next
+/// link.
+fn parse_wp_table_template(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    static TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"<[^>]+>").unwrap());
+
+    let document = Html::parse_document(html);
+    let td_sel = Selector::parse("td").unwrap();
+    let title_sel = Selector::parse("td > strong").unwrap();
+
+    let mut out = Vec::new();
+    for td in document.select(&td_sel) {
+        let Some(title_el) = td.select(&title_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        // Locate the title element's own serialized HTML within the
+        // td's HTML (rather than the first "</strong>", which could
+        // belong to a preceding `[Best Paper]` badge) to correctly find
+        // where the author text starts, then cut it off at the first
+        // link — the "Paper . Abstract . Lightning Talk" row that
+        // follows, which has no analog before this point since author
+        // names here are never themselves hyperlinked.
+        let td_html = td.html();
+        let title_html = title_el.html();
+        let Some(pos) = td_html.find(title_html.as_str()) else {
+            continue;
+        };
+        let after_title = &td_html[pos + title_html.len()..];
+        let authors_html = after_title
+            .find("<a")
+            .map_or(after_title, |i| &after_title[..i]);
+        let plain = TAG_RE.replace_all(authors_html, " ");
+        let authors = parse_paren_grouped_names(&plain);
         if authors.is_empty() {
             continue;
         }
@@ -106,5 +190,64 @@ mod tests {
     #[test]
     fn test_parse_empty_html() {
         assert!(parse_accepted_papers("<html></html>", "asplos2026").is_empty());
+    }
+
+    const ISCA_NO_AFFILIATIONS_SAMPLE: &str = r#"
+        <div class="panel-body">
+          <div class="paper">
+            <div class="paper-title">
+              A Systolic Array-Based Accelerator
+            </div>
+            <div class="paper-authors">
+              Cong Guo, Jiaming Tang, Weiming Hu, Yuhao Zhu
+            </div>
+          </div>
+        </div>
+    "#;
+
+    #[test]
+    fn test_parse_isca_style_authors_without_affiliations() {
+        // ISCA 2023-2025 pages reuse this template but drop affiliations
+        // from div.paper-authors entirely.
+        let out = parse_accepted_papers(ISCA_NO_AFFILIATIONS_SAMPLE, "isca2024");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].authors,
+            vec!["Cong Guo", "Jiaming Tang", "Weiming Hu", "Yuhao Zhu"]
+        );
+    }
+
+    const WP_TABLE_SAMPLE: &str = r##"
+        <figure class="wp-block-table"><table><thead><tr><th>1A: Synthesis</th></tr></thead><tbody>
+        <tr><td><strong>Explainable Port Mapping Inference with Sparse Performance Counters</strong><br><br>
+        <span class="has-inline-color has-danger-color">Fabian Ritter</span> and Sebastian Hack <span style="color: gray; font-style: italic;">(Saarland University)</span><br><br>
+        <a href="https://doi.org/10.1145/3620666.3651363">Paper</a> <strong>.</strong> <a href="abstracts/index.html#1A">Abstract</a></td></tr>
+        <tr><td><span class="has-inline-color has-success-color"><strong>[Best Paper] </strong></span><strong>Centauri: Enabling Efficient Scheduling</strong><br><br>
+        <span class="has-inline-color has-danger-color">Chang Chen</span>, Xiuhong Li, and <span class="has-inline-color has-danger-color">Qianchao Zhu</span> <span style="color: gray; font-style: italic;">(Peking University)</span>; Jiangfei Duan <span style="color: gray; font-style: italic;">(Chinese University of Hong Kong)</span><br><br>
+        <a href="https://doi.org/10.1145/3620666.3651379">Paper</a> <strong>.</strong> <a href="abstracts/index.html#1B">Abstract</a></td></tr>
+        </tbody></table></figure>
+    "##;
+
+    #[test]
+    fn test_parse_wp_table_fallback_plain_title() {
+        let out = parse_accepted_papers(WP_TABLE_SAMPLE, "asplos2024");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "Explainable Port Mapping Inference with Sparse Performance Counters"
+        );
+        assert_eq!(out[0].authors, vec!["Fabian Ritter", "Sebastian Hack"]);
+        assert_eq!(out[0].source, "asplos2024");
+    }
+
+    #[test]
+    fn test_parse_wp_table_fallback_best_paper_badge_excluded_from_title() {
+        let out = parse_accepted_papers(WP_TABLE_SAMPLE, "asplos2024");
+        assert_eq!(out[1].title, "Centauri: Enabling Efficient Scheduling");
+        assert!(!out[1].title.contains("Best Paper"));
+        assert_eq!(
+            out[1].authors,
+            vec!["Chang Chen", "Xiuhong Li", "Qianchao Zhu", "Jiangfei Duan"]
+        );
     }
 }

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/author_parsing.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/author_parsing.rs
@@ -15,17 +15,19 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+/// Matches a `name-group (affiliation)` unit directly — a non-greedy run of
+/// non-paren characters followed by a parenthesized group — rather than
+/// splitting on a separator first, since names/affiliations never contain
+/// `(`/`)` but affiliations often contain the same punctuation (commas,
+/// semicolons) used to separate entries. Shared between
+/// [`parse_paren_grouped_names`] and the heuristic in
+/// [`parse_names_maybe_with_affiliations`] that decides whether a list's
+/// parens are affiliations at all.
+static PAIR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"([^()]+?)\(([^()]*)\)").unwrap());
+
 /// Parse `"Name (Affiliation), Name and Name (Affiliation); ..."` into
 /// just the names, dropping every affiliation.
-///
-/// Matches each `name-group (affiliation)` unit directly — a non-greedy
-/// run of non-paren characters followed by a parenthesized group — rather
-/// than splitting on a separator first, since names/affiliations never
-/// contain `(`/`)` but affiliations often contain the same punctuation
-/// (commas, semicolons) used to separate entries.
 pub fn parse_paren_grouped_names(text: &str) -> Vec<String> {
-    static PAIR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"([^()]+?)\(([^()]*)\)").unwrap());
-
     let mut names = Vec::new();
     for cap in PAIR_RE.captures_iter(text) {
         let group = strip_leading_separator(&cap[1]).replace(" and ", ", ");
@@ -37,6 +39,55 @@ pub fn parse_paren_grouped_names(text: &str) -> Vec<String> {
         }
     }
     names
+}
+
+/// Parse an author list that may or may not carry parenthesized
+/// affiliations: `"Name (Affiliation), Name (Affiliation)"` delegates to
+/// [`parse_paren_grouped_names`]; plain `"Name, Name, Name"` with no
+/// affiliations at all (e.g. ISCA's 2023-2025 program pages, unlike its
+/// 2026 page or ASPLOS's, which always include them) is split directly on
+/// `,`/`;`.
+///
+/// The two shapes can't be told apart just by "does the text contain a
+/// `(`" — ISCA's plain lists occasionally wrap an author's nickname in
+/// parens mid-name (`"Boyang (Tony) Yu"`), which [`parse_paren_grouped_names`]
+/// would otherwise misparse as an affiliation and mangle. Distinguish them
+/// by what follows each `)`: a real affiliation is always followed by a
+/// separator (`,`, `;`, `"and "`) or the end of the string, e.g.
+/// `"Name (Aff), Name (Aff)"` or `"Name (Aff) and Name (Aff)"`. A nickname
+/// is followed directly by another bare word — the rest of the same
+/// name — which no genuine affiliation list does.
+pub fn parse_names_maybe_with_affiliations(text: &str) -> Vec<String> {
+    if parens_look_like_affiliations(text) {
+        return parse_paren_grouped_names(text);
+    }
+    text.split([',', ';'])
+        .map(|s| strip_leading_separator(s))
+        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("and"))
+        .collect()
+}
+
+/// Whether every parenthesized group in `text` is followed by a
+/// list-separator (or the end of the string) rather than a bare word —
+/// see [`parse_names_maybe_with_affiliations`]. `false` if there are no
+/// parens at all, so the caller still takes the plain-split path.
+fn parens_look_like_affiliations(text: &str) -> bool {
+    let mut found_any = false;
+    for m in PAIR_RE.find_iter(text) {
+        found_any = true;
+        let remainder = text[m.end()..].trim_start();
+        let is_separator = remainder.is_empty()
+            || remainder.starts_with(',')
+            || remainder.starts_with(';')
+            || remainder
+                .get(..4)
+                .is_some_and(|s| s.eq_ignore_ascii_case("and "))
+            || remainder.eq_ignore_ascii_case("and");
+        if !is_separator {
+            return false;
+        }
+    }
+    found_any
 }
 
 /// Trim a captured group's leading punctuation/conjunction left over from
@@ -115,6 +166,51 @@ mod tests {
     #[test]
     fn test_empty_input() {
         assert!(parse_paren_grouped_names("").is_empty());
+    }
+
+    #[test]
+    fn test_maybe_with_affiliations_falls_back_to_plain_comma_list() {
+        // ISCA 2023-2025-style: no parenthesized affiliations at all.
+        let names = parse_names_maybe_with_affiliations(
+            "Cong Guo, Jiaming Tang, Weiming Hu, Jingwen Leng, Yuhao Zhu",
+        );
+        assert_eq!(
+            names,
+            vec![
+                "Cong Guo",
+                "Jiaming Tang",
+                "Weiming Hu",
+                "Jingwen Leng",
+                "Yuhao Zhu"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_maybe_with_affiliations_not_fooled_by_embedded_nickname() {
+        // ISCA 2023/2025-style: a mid-name nickname in parens, not an
+        // affiliation — must not be misparsed as one.
+        let names = parse_names_maybe_with_affiliations(
+            "Sixu Li, Chaojian Li, Wenbo Zhu, Boyang (Tony) Yu, Yingyan (Celine) Lin",
+        );
+        assert_eq!(
+            names,
+            vec![
+                "Sixu Li",
+                "Chaojian Li",
+                "Wenbo Zhu",
+                "Boyang (Tony) Yu",
+                "Yingyan (Celine) Lin"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_maybe_with_affiliations_delegates_when_parens_present() {
+        let names = parse_names_maybe_with_affiliations(
+            "Weihao Cui (Shanghai Jiao Tong University), Yukang Chen (Shanghai Jiao Tong University)",
+        );
+        assert_eq!(names, vec!["Weihao Cui", "Yukang Chen"]);
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/infocom.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/infocom.rs
@@ -1,23 +1,39 @@
 //! Parse the IEEE INFOCOM "Accepted Paper List" page into corpus records.
 //!
-//! Unlike every other venue here, INFOCOM's ComSoc "minisite" theme
-//! doesn't wrap each paper in its own element at all — the entire list
-//! lives inside one giant `<p>`, formatted as repeated
-//! `<strong>N. Title</strong><br>Author, Author and Author
-//! (Affiliation); Author (Affiliation)&nbsp;<br><br>` runs with no
-//! per-paper container to select. So instead of a CSS selector per
-//! paper, this walks the DOM directly: select every `<strong>` (each one
-//! *is* its own real element, just a sibling of all the others rather
-//! than a child of a per-paper wrapper), then for each one walks forward
-//! through [`ElementRef::next_siblings`] — collecting text nodes,
-//! stopping at the next `<strong>` — to gather that paper's author text
-//! before the following `<strong>` starts the next entry.
+//! INFOCOM's ComSoc "minisite" theme doesn't wrap each paper in a
+//! consistent per-paper container with a stable class name, and the exact
+//! markup has churned release to release:
+//!
+//! - **2026, 2019, 2022-2024**: flat — the whole list lives inside one
+//!   shared container, formatted as repeated `<strong>N. Title</strong>
+//!   <br>Author, Author and Author (Affiliation); Author (Affiliation)
+//!   &nbsp;<br><br>` runs (or, for 2019/2022-2024, the same shape one
+//!   level down inside a shared `<li>` per paper). The author text sits
+//!   as plain sibling text nodes of the `<strong>` itself.
+//! - **2025**: each paper is `<li><p><strong>Title</strong></p>
+//!   <p>Authors</p></li>` — the title is wrapped in its own `<p>`, and
+//!   the author text is a *sibling of that wrapping `<p>`*, not of the
+//!   `<strong>` directly.
+//! - **2020, 2021**: each paper is `<ol><li><strong>Title</strong></li>
+//!   </ol><p class="rteindent1">Authors</p>` — title and authors aren't
+//!   even in the same list item; the author `<p>` is a sibling of the
+//!   whole single-item `<ol>`, two levels up from the `<strong>`.
+//!
+//! Rather than a CSS selector per paper, this walks the DOM directly:
+//! select every `<strong>` (each one *is* its own real element — a title
+//! — regardless of how deep it's nested for a given year), then look for
+//! that paper's author text starting from the `<strong>` itself and
+//! climbing up to two ancestor levels ([`collect_following_text`]),
+//! stopping as soon as one level's forward-sibling text actually parses
+//! into real author names. Each level's sibling walk stops at the next
+//! `<strong>` (however deeply it's nested in *its* wrapper) so a later
+//! paper's title/authors never bleed into an earlier one's.
 //!
 //! Authors are grouped per-affiliation and semicolon-separated —
 //! `"Name, Name and Name (Affiliation); Name (Affiliation); ..."` — the
 //! same shape [`parse_paren_grouped_names`] already handles.
 
-use scraper::{Html, Selector};
+use scraper::{ElementRef, Html, Selector};
 use std::ops::Deref;
 
 use crate::db::NewPublication;
@@ -36,6 +52,37 @@ fn strip_ordinal_prefix(s: &str) -> &str {
     }
 }
 
+/// True if `el` is a `<strong>` itself or has one somewhere among its
+/// descendants — i.e. it looks like it starts (or wraps) the next
+/// paper's title, and the forward sibling walk should stop before it.
+fn is_or_wraps_strong(el: ElementRef) -> bool {
+    el.value().name() == "strong"
+        || el
+            .descendent_elements()
+            .any(|d| d.value().name() == "strong")
+}
+
+/// Walk forward through `start`'s siblings, collecting visible text,
+/// stopping at the first sibling that is (or contains) a `<strong>` —
+/// that's the next paper's title, however deeply nested in its own
+/// wrapper. Handles both plain text siblings (the flat, single-shared-
+/// container layout) and element siblings that wrap the author text in
+/// their own tag (a `<p>`, e.g.).
+fn collect_following_text(start: ElementRef) -> String {
+    let mut text = String::new();
+    for sibling in start.next_siblings() {
+        if let Some(el) = ElementRef::wrap(sibling) {
+            if is_or_wraps_strong(el) {
+                break;
+            }
+            text.push_str(&el.text().collect::<String>());
+        } else if let Some(t) = sibling.value().as_text() {
+            text.push_str(t.deref());
+        }
+    }
+    text
+}
+
 /// Parse an INFOCOM accepted-paper-list page into publication records.
 ///
 /// `source_tag` is the provenance string to store on each record, e.g.
@@ -52,24 +99,25 @@ pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication
             continue;
         }
 
-        // Walk forward through this <strong>'s siblings, collecting text
-        // (skipping element nodes like <br>), until the next <strong>
-        // starts the following paper.
-        let mut authors_text = String::new();
-        for sibling in strong.next_siblings() {
-            let is_next_strong = sibling
-                .value()
-                .as_element()
-                .is_some_and(|e| e.name() == "strong");
-            if is_next_strong {
+        // Author placement relative to the title varies by year (see
+        // module docs). Try the <strong> itself, then climb up to two
+        // ancestor levels, stopping as soon as a level's forward text
+        // actually parses into real author names — a heading like "List
+        // of Accepted Papers..." never does, at any level, and is
+        // dropped below.
+        let mut authors = Vec::new();
+        let mut node = strong;
+        for _ in 0..3 {
+            let candidate = parse_paren_grouped_names(&collect_following_text(node));
+            if !candidate.is_empty() {
+                authors = candidate;
                 break;
             }
-            if let Some(t) = sibling.value().as_text() {
-                authors_text.push_str(t.deref());
-            }
+            node = match node.parent().and_then(ElementRef::wrap) {
+                Some(parent) => parent,
+                None => break,
+            };
         }
-
-        let authors = parse_paren_grouped_names(&authors_text);
         if authors.is_empty() {
             continue;
         }
@@ -128,5 +176,69 @@ mod tests {
     #[test]
     fn test_parse_empty_html() {
         assert!(parse_accepted_papers("<html></html>", "infocom2026").is_empty());
+    }
+
+    /// 2025's shape: title wrapped in its own `<p>`, authors a sibling
+    /// `<p>` of that wrapper (not of the `<strong>` directly).
+    const SAMPLE_2025: &str = r#"
+        <div class="field-item"><div class="rtecenter"><strong>List of Accepted Papers in IEEE INFOCOM 2025&nbsp;Main Conference</strong></div>
+        <p class="rtecenter">&nbsp;</p>
+        <ol>
+        <li>
+        <p><strong>Achieving Efficient Multipath Validation in Software-Defined Networks </strong></p>
+        <p>Bing Hu and Yuanguo Bi (Northeastern University, China); Kui Wu (University of Victoria, Canada)</p>
+        </li>
+        <br />
+        <li>
+        <p><strong>Oracle: QoS-aware Online Service Provisioning</strong></p>
+        <p>Shengyu Zhang (Singapore University of Technology and Design, Singapore)</p>
+        </li>
+        </ol>
+        </div>
+    "#;
+
+    #[test]
+    fn test_2025_shape_title_wrapped_in_own_paragraph() {
+        let out = parse_accepted_papers(SAMPLE_2025, "infocom2025");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "Achieving Efficient Multipath Validation in Software-Defined Networks"
+        );
+        assert_eq!(out[0].authors, vec!["Bing Hu", "Yuanguo Bi", "Kui Wu"]);
+        assert_eq!(
+            out[1].title,
+            "Oracle: QoS-aware Online Service Provisioning"
+        );
+        assert_eq!(out[1].authors, vec!["Shengyu Zhang"]);
+    }
+
+    /// 2020/2021's shape: title inside its own single-item `<ol><li>`,
+    /// authors a sibling `<p>` of the whole `<ol>` — two levels up from
+    /// the `<strong>`.
+    const SAMPLE_2020: &str = r#"
+        <div class="field-item"><p align="center"><strong>List of Accepted Papers in IEEE INFOCOM 2020 Main Conference</strong></p>
+        <ol>
+        <li><strong>(How Much) Does a Private WAN Improve Cloud Performance?</strong></li>
+        </ol>
+        <p class="rteindent1">Ege Gurmericliler (Columbia University, USA); Arpit Gupta (Columbia University)</p>
+        <ol>
+        <li value="2"><strong>A Converse Result on Convergence Time</strong></li>
+        </ol>
+        <p class="rteindent1">Michael Neely (University of Southern California, USA)</p>
+        </div>
+    "#;
+
+    #[test]
+    fn test_2020_shape_authors_sibling_of_whole_ol() {
+        let out = parse_accepted_papers(SAMPLE_2020, "infocom2020");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "(How Much) Does a Private WAN Improve Cloud Performance?"
+        );
+        assert_eq!(out[0].authors, vec!["Ege Gurmericliler", "Arpit Gupta"]);
+        assert_eq!(out[1].title, "A Converse Result on Convergence Time");
+        assert_eq!(out[1].authors, vec!["Michael Neely"]);
     }
 }

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/raid.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/raid.rs
@@ -1,12 +1,11 @@
 //! Parse RAID's accepted-papers page into corpus records.
 //!
 //! `raidYYYY.github.io` publishes no BibTeX/CSV/JSON export. 2024 and
-//! 2025 share one identical format (this module) — the cleanest of the
-//! five newest venues added here, no bot-blocking, no per-year format
-//! churn between those two. 2023 used a different, ACM-DL-embedded page
-//! and 2026 (not yet held) has switched to a CSV data file
-//! (`data/accepted_papers.csv`) — both out of scope for now, same
-//! current-edition-only pattern as everywhere else.
+//! 2025 share one identical format ([`parse_accepted_papers`]) — the
+//! cleanest of the five newest venues added here, no bot-blocking, no
+//! per-year format churn between those two. 2026 (not yet held) has
+//! switched to a CSV data file (`data/accepted_papers.csv`) — out of
+//! scope for now, same current-edition-only pattern as everywhere else.
 //!
 //! Structure: `<p><b> Title <a>[PDF]</a></b><br/> Name, Affiliation; Name,
 //! Affiliation; </p>` — note the title's trailing `[PDF]` link has real
@@ -14,6 +13,14 @@
 //! authors use `"Name, Affiliation"` with **no parentheses**, semicolon-
 //! separated — a different shape from the `parse_paren_grouped_names`
 //! pattern used elsewhere, handled by [`split_semicolon_name_affiliation`].
+//!
+//! 2022 and 2023 instead embed the standard ACM Digital Library
+//! "Open Access" TOC widget directly into the page (rather than a
+//! hand-rolled listing): `h3 > a.DLtitleLink` (title) followed by a
+//! sibling `ul.DLauthors > li.nameList` (one `<li>` per author, plain
+//! name text, no affiliations at all — nothing to strip). Tried as a
+//! fallback in [`parse_dl_widget_papers`] when the primary format finds
+//! nothing.
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -26,6 +33,16 @@ use crate::db::NewPublication;
 /// `source_tag` is the provenance string to store on each record, e.g.
 /// `"raid2025"`.
 pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let out = parse_hand_rolled_papers(html, source_tag);
+    if !out.is_empty() {
+        return out;
+    }
+    parse_dl_widget_papers(html, source_tag)
+}
+
+/// 2024/2025 hand-rolled template: `p > b` (title) + plain text after it
+/// (authors).
+fn parse_hand_rolled_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
     static TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"<[^>]+>").unwrap());
 
     let document = Html::parse_document(html);
@@ -56,6 +73,56 @@ pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication
         let after_title = &p_html[idx + 4..];
         let plain = TAG_RE.replace_all(after_title, " ");
         let authors = split_semicolon_name_affiliation(&plain);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+/// 2022/2023 ACM Digital Library "Open Access" TOC widget: `h3 >
+/// a.DLtitleLink` (title) + the following sibling `ul.DLauthors >
+/// li.nameList` (authors, one per `<li>`, plain names — no affiliations
+/// to strip).
+fn parse_dl_widget_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let document = Html::parse_document(html);
+    let title_link_sel = Selector::parse("h3 > a.DLtitleLink").unwrap();
+    let authors_list_sel = Selector::parse("ul.DLauthors").unwrap();
+    let name_sel = Selector::parse("li.nameList").unwrap();
+
+    let mut out = Vec::new();
+    for title_link in document.select(&title_link_sel) {
+        let title = title_link.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        // The authors list is the h3's next-sibling ul.DLauthors, not a
+        // descendant of anything title-related — walk sibling elements
+        // from the enclosing <h3> until one matches.
+        let Some(h3) = title_link.parent().and_then(scraper::ElementRef::wrap) else {
+            continue;
+        };
+        let authors_list = h3
+            .next_siblings()
+            .filter_map(scraper::ElementRef::wrap)
+            .find(|el| authors_list_sel.matches(el));
+        let Some(authors_list) = authors_list else {
+            continue;
+        };
+
+        let authors: Vec<String> = authors_list
+            .select(&name_sel)
+            .map(|li| li.text().collect::<String>().trim().to_string())
+            .filter(|name| !name.is_empty())
+            .collect();
         if authors.is_empty() {
             continue;
         }
@@ -138,5 +205,37 @@ mod tests {
     #[test]
     fn test_parse_empty_html() {
         assert!(parse_accepted_papers("<html></html>", "raid2025").is_empty());
+    }
+
+    const DL_WIDGET_SAMPLE: &str = r##"
+        <div id="DLcontent"><div class="text-center"><h2>SESSION: IoT / Firmware / Binaries</h2></div>
+            <h3><a class="DLtitleLink" href="https://dl.acm.org/doi/10.1145/3607199.3607200">Black-box Attacks Against Neural Binary Function Detection</a></h3>
+            <ul class="DLauthors"><li class="nameList">Joshua Bundt</li><li class="nameList">Michael Davinroy</li><li class="nameList Last">William Robertson</li></ul>
+            <div class="DLabstract"><div style="display:inline"><p>Some abstract text.</p></div></div>
+
+            <h3><a class="DLtitleLink" href="https://dl.acm.org/doi/10.1145/3607199.3607211">Extracting Threat Intelligence From Cheat Binaries</a></h3>
+            <ul class="DLauthors"><li class="nameList">Md Sakib Anwar</li><li class="nameList Last">Zhiqiang Lin</li></ul>
+            <div class="DLabstract"><div style="display:inline"><p>Some abstract text.</p></div></div>
+        </div>
+    "##;
+
+    #[test]
+    fn test_parse_dl_widget_fallback_two_papers() {
+        let out = parse_accepted_papers(DL_WIDGET_SAMPLE, "raid2023");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "Black-box Attacks Against Neural Binary Function Detection"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec!["Joshua Bundt", "Michael Davinroy", "William Robertson"]
+        );
+        assert_eq!(out[0].source, "raid2023");
+        assert_eq!(
+            out[1].title,
+            "Extracting Threat Intelligence From Cheat Binaries"
+        );
+        assert_eq!(out[1].authors, vec!["Md Sakib Anwar", "Zhiqiang Lin"]);
     }
 }

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sigcomm.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sigcomm.rs
@@ -1,16 +1,38 @@
 //! Parse ACM SIGCOMM's accepted-papers page into corpus records.
 //!
-//! One page per year at `conferences.sigcomm.org/sigcomm/<year>/accepted-papers/`,
-//! covering both "Full papers" and "Short papers" sections identically.
-//! Structure: `li` → `p > span.text-color-primary` (title) +
-//! `p.style_italic` (authors, `"Name (Affiliation); Name, Name
-//! (Affiliation); ..."` — the same shape [`parse_paren_grouped_names`]
-//! already handles).
+//! Three templates, tried in order:
+//!
+//! - **Current (2025+)**, one page per year at
+//!   `conferences.sigcomm.org/sigcomm/<year>/accepted-papers/`, covering
+//!   both "Full papers" and "Short papers" sections identically.
+//!   Structure: `li` → `p > span.text-color-primary` (title) +
+//!   `p.style_italic` (authors, `"Name (Affiliation); Name, Name
+//!   (Affiliation); ..."` — the same shape [`parse_paren_grouped_names`]
+//!   already handles).
+//! - **2024's Next.js template**, `.../2024/accepted-papers/`: `li` →
+//!   `p.font-bold` (title as a direct text node, followed by a nested
+//!   `<span>` track badge like "Research Track" that must *not* be
+//!   included) + `p.text-base` (authors, same `"Name (Affiliation); ..."`
+//!   shape as the current template).
+//! - **Legacy (pre-2024) jQuery-Mobile listing**, e.g.
+//!   `conferences.sigcomm.org/sigcomm/2018/accepted-papers.html` or
+//!   `.../2023/list-accepted.html` — these are dedicated
+//!   accepted-papers-only listings (not the full multi-day program page,
+//!   which mixes in workshops/breaks/keynotes too unpredictably to parse
+//!   safely). Structure: `li.prog-item` → `p.paper-header` or `h2`
+//!   (title) + a plain sibling `p` containing `"Name, Name
+//!   (Affiliation), ..."` (again handled by
+//!   [`parse_paren_grouped_names`]). Note some years (2019's
+//!   `accepted-papers.html` and all of 2020-2022) don't statically render
+//!   a papers list at all — server response has an empty/absent list and
+//!   this parser correctly yields nothing for those, rather than
+//!   guessing.
 
-use scraper::{Html, Selector};
+use scraper::{ElementRef, Html, Selector};
 
 use crate::db::NewPublication;
 use crate::ingest::author_parsing::parse_paren_grouped_names;
+use crate::ingest::dom_text::direct_text;
 
 /// Parse a SIGCOMM accepted-papers page into publication records.
 ///
@@ -18,6 +40,19 @@ use crate::ingest::author_parsing::parse_paren_grouped_names;
 /// `"sigcomm2026"`.
 pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
     let document = Html::parse_document(html);
+    let mut out = parse_current_template(&document, source_tag);
+    if out.is_empty() {
+        out = parse_2024_template(&document, source_tag);
+    }
+    if out.is_empty() {
+        out = parse_legacy_template(&document, source_tag);
+    }
+    out
+}
+
+/// Current (2025+) template: `li` → `span.text-color-primary` (title) +
+/// `p.style_italic` (authors).
+fn parse_current_template(document: &Html, source_tag: &str) -> Vec<NewPublication> {
     let item_sel = Selector::parse("li").unwrap();
     let title_sel = Selector::parse("span.text-color-primary").unwrap();
     let authors_sel = Selector::parse("p.style_italic").unwrap();
@@ -51,6 +86,105 @@ pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication
     out
 }
 
+/// 2024's Next.js template: `li` → `p.font-bold` (title as a direct text
+/// node — a sibling `<span>` track badge like "Research Track" must be
+/// excluded) + `p.text-base` (authors).
+fn parse_2024_template(document: &Html, source_tag: &str) -> Vec<NewPublication> {
+    let item_sel = Selector::parse("li").unwrap();
+    let title_sel = Selector::parse("p.font-bold").unwrap();
+    let authors_sel = Selector::parse("p.text-base").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let Some(title_el) = item.select(&title_sel).next() else {
+            continue;
+        };
+        let title = direct_text(&title_el);
+        if title.is_empty() {
+            continue;
+        }
+
+        let Some(authors_el) = item.select(&authors_sel).next() else {
+            continue;
+        };
+        let authors_text: String = authors_el.text().collect();
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+/// Legacy (pre-2024) jQuery-Mobile listing template: `li.prog-item` →
+/// `p.paper-header` or `h2` (title) + a plain sibling `p` (authors).
+fn parse_legacy_template(document: &Html, source_tag: &str) -> Vec<NewPublication> {
+    let item_sel = Selector::parse("li.prog-item").unwrap();
+    let paper_header_sel = Selector::parse("p.paper-header").unwrap();
+    let h2_sel = Selector::parse("h2").unwrap();
+    let p_sel = Selector::parse("p").unwrap();
+
+    let mut out = Vec::new();
+    for item in document.select(&item_sel) {
+        let title = item
+            .select(&paper_header_sel)
+            .next()
+            .or_else(|| item.select(&h2_sel).next())
+            .map(|el| normalize_whitespace(&el.text().collect::<String>()))
+            .unwrap_or_default();
+        if title.is_empty() {
+            continue;
+        }
+
+        // The author line is the first plain (unclassed) `p` in the item
+        // that looks like a `"Name (Affiliation), ..."` list — skipping
+        // `p.paper-header` itself and anything without a parenthesized
+        // affiliation (badges, links, session metadata, etc.). These
+        // pages hard-wrap long entries across lines, so the raw text can
+        // carry newlines/indentation mid-name; collapse it before
+        // splitting on names.
+        let authors_text = item
+            .select(&p_sel)
+            .find(|el| !is_paper_header(el) && el.text().collect::<String>().contains('('))
+            .map(|el| normalize_whitespace(&el.text().collect::<String>()));
+        let Some(authors_text) = authors_text else {
+            continue;
+        };
+        let authors = parse_paren_grouped_names(&authors_text);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
+    }
+    out
+}
+
+fn is_paper_header(el: &ElementRef) -> bool {
+    el.value()
+        .attr("class")
+        .is_some_and(|c| c.split_whitespace().any(|t| t == "paper-header"))
+}
+
+/// Collapse runs of whitespace (including the newlines/indentation these
+/// hard-wrapped legacy pages embed mid-title/mid-name) into single spaces,
+/// and trim the ends.
+fn normalize_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,6 +205,33 @@ mod tests {
             </li>
         </ul>
     "#;
+
+    // 2024's Next.js template: `p.font-bold` title with a nested track
+    // badge `<span>` that must not leak into the title, plus a React
+    // hydration comment between the title text and the badge.
+    const NEXTJS_2024_SAMPLE: &str = r#"
+        <ul class="list-disc pb-2 pl-4 text-left">
+            <li>
+                <p class="font-bold mb-0 text-lg">In-Network Address Caching for Virtual Networks<!-- --> <span class="font-semibold inline-flex items-center rounded-md text-base bg-green-100 px-1 text-green-700">Research Track</span></p>
+                <p class="text-base">Lior Zeno (Technion); Ang Chen (University of Michigan); Mark Silberstein (Technion)</p>
+            </li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_2024_nextjs_template() {
+        let out = parse_accepted_papers(NEXTJS_2024_SAMPLE, "sigcomm2024");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].title,
+            "In-Network Address Caching for Virtual Networks"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec!["Lior Zeno", "Ang Chen", "Mark Silberstein"]
+        );
+        assert_eq!(out[0].source, "sigcomm2024");
+    }
 
     #[test]
     fn test_full_papers_section() {
@@ -94,5 +255,109 @@ mod tests {
     #[test]
     fn test_parse_empty_html() {
         assert!(parse_accepted_papers("<html></html>", "sigcomm2026").is_empty());
+    }
+
+    // 2018-style: `p.paper-header` title + plain `p` authors with `<em>`
+    // affiliations.
+    const LEGACY_PAPER_HEADER_SAMPLE: &str = r#"
+        <ul>
+            <li data-icon="false" class="prog-item ">
+                <table><tr><td style="width:100%;text-align:left;">
+                    <p class="paper-header">
+                        Elastic Sketch: Adaptive and Fast Network-wide Measurements
+                    </p>
+                    <p>Tong Yang, Jie Jiang, Peng Liu <em>(PKU, China)</em>, Qun Huang <em>(CAS, China)</em></p>
+                </td></tr></table>
+            </li>
+        </ul>
+    "#;
+
+    // 2023-style: `h2` title + plain `p` authors, no `<em>`.
+    const LEGACY_H2_SAMPLE: &str = r#"
+        <ul>
+            <li data-icon="false" class="prog-item prog-friday">
+                <div style="width: 100%">
+                    <p class="keynote-header"></p>
+                    <table><tr><td style="width: 100%; text-align: left">
+                        <h2>A Formal Framework for End-to-End DNS Resolution</h2>
+                        <p>Si Liu, Huayi Duan, and David Basin (ETH Zurich)</p>
+                    </td></tr></table>
+                </div>
+            </li>
+        </ul>
+    "#;
+
+    #[test]
+    fn test_legacy_paper_header_template() {
+        let out = parse_accepted_papers(LEGACY_PAPER_HEADER_SAMPLE, "sigcomm2018");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].title,
+            "Elastic Sketch: Adaptive and Fast Network-wide Measurements"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec!["Tong Yang", "Jie Jiang", "Peng Liu", "Qun Huang"]
+        );
+        assert_eq!(out[0].source, "sigcomm2018");
+    }
+
+    #[test]
+    fn test_legacy_h2_template() {
+        let out = parse_accepted_papers(LEGACY_H2_SAMPLE, "sigcomm2023");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].title,
+            "A Formal Framework for End-to-End DNS Resolution"
+        );
+        assert_eq!(out[0].authors, vec!["Si Liu", "Huayi Duan", "David Basin"]);
+    }
+
+    #[test]
+    fn test_legacy_template_skips_non_paper_prog_items() {
+        // A session/workshop-announcement item with no author line at all
+        // shouldn't be picked up as a paper.
+        let html = r#"
+            <ul>
+                <li class="prog-item ">
+                    <p class="paper-header"><strong>NAI'21: Workshop on Network-Application Integration</strong></p>
+                    <p>(<a href="details.html">Details</a>)</p>
+                </li>
+            </ul>
+        "#;
+        assert!(parse_accepted_papers(html, "sigcomm2021").is_empty());
+    }
+
+    #[test]
+    fn test_legacy_h2_template_collapses_hard_wrapped_whitespace() {
+        // Regression: 2023's page hard-wraps long titles/names across
+        // lines with deep indentation, which must collapse to single
+        // spaces rather than leaking newlines/runs of spaces into the
+        // stored title/author names.
+        let html = "
+            <ul>
+                <li class=\"prog-item prog-friday\">
+                    <h2>A Millimeter Wave Backscatter Network for Two-Way
+                    Communication and Localization</h2>
+                    <p>Haofan Lu, Mohammad Hossein Mazaheri, Reza Rezvani, Omid
+                    Abari (UCLA)</p>
+                </li>
+            </ul>
+        ";
+        let out = parse_accepted_papers(html, "sigcomm2023");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].title,
+            "A Millimeter Wave Backscatter Network for Two-Way Communication and Localization"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec![
+                "Haofan Lu",
+                "Mohammad Hossein Mazaheri",
+                "Reza Rezvani",
+                "Omid Abari"
+            ]
+        );
     }
 }

--- a/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sosp.rs
+++ b/hallucinator-rs/crates/hallucinator-local-corpus/src/ingest/sosp.rs
@@ -1,16 +1,25 @@
 //! Parse SOSP's (ACM SIGOPS Symposium on Operating Systems Principles)
 //! accepted-papers page into corpus records.
 //!
-//! Hosted on sigops.org (not ACM's own site), one static page per year at
-//! `sigops.org/s/conferences/sosp/<year>/accepted.html`. Structure:
-//! `ul.paperlist` → `li` → `b` (title) → `br` → `em` (authors, the same
-//! `"Name (Affiliation), Name (Affiliation)"` shape
-//! [`parse_paren_grouped_names`] already handles — trailing entries in a
-//! shared affiliation group without their own parenthesized affiliation,
-//! e.g. `"Yanyan Shen, Linpeng Huang, Hong Mei (Shanghai Jiao Tong
-//! University)"`, still parse fine since the helper doesn't require every
-//! name to have its own affiliation).
+//! Two templates, tried in order:
+//!
+//! - **Current**, hosted on sigops.org (not ACM's own site), one static
+//!   page per year at `sigops.org/s/conferences/sosp/<year>/accepted.html`.
+//!   Structure: `ul.paperlist` → `li` → `b` (title) → `br` → `em`
+//!   (authors, the same `"Name (Affiliation), Name (Affiliation)"` shape
+//!   [`parse_paren_grouped_names`] already handles — trailing entries in a
+//!   shared affiliation group without their own parenthesized affiliation,
+//!   e.g. `"Yanyan Shen, Linpeng Huang, Hong Mei (Shanghai Jiao Tong
+//!   University)"`, still parse fine since the helper doesn't require
+//!   every name to have its own affiliation).
+//! - **2021/2023's mpi-sws.org-hosted page** (`sosp<year>.mpi-sws.org/accepted.html`):
+//!   no `ul.paperlist`/`em` wrapper — `div.welcome-middle > p` holds
+//!   `<b>Title</b> by Name (Affiliation), Name (Affiliation) and Name
+//!   (Affiliation)` as one flat paragraph. Same
+//!   `"Name (Affiliation)"` shape once the leading `"by "` is stripped.
 
+use once_cell::sync::Lazy;
+use regex::Regex;
 use scraper::{Html, Selector};
 
 use crate::db::NewPublication;
@@ -21,6 +30,15 @@ use crate::ingest::author_parsing::parse_paren_grouped_names;
 /// `source_tag` is the provenance string to store on each record, e.g.
 /// `"sosp2025"`.
 pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    let out = parse_paperlist_papers(html, source_tag);
+    if !out.is_empty() {
+        return out;
+    }
+    parse_by_line_papers(html, source_tag)
+}
+
+/// Current template: `ul.paperlist` → `li` → `b` (title) → `em` (authors).
+fn parse_paperlist_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
     let document = Html::parse_document(html);
     let list_sel = Selector::parse("ul.paperlist").unwrap();
     let item_sel = Selector::parse("li").unwrap();
@@ -54,6 +72,48 @@ pub fn parse_accepted_papers(html: &str, source_tag: &str) -> Vec<NewPublication
                 source: source_tag.to_string(),
             });
         }
+    }
+    out
+}
+
+/// 2021/2023 mpi-sws.org template: `p > b` (title) followed in the same
+/// paragraph by plain `" by Name (Affiliation), ..."` text.
+fn parse_by_line_papers(html: &str, source_tag: &str) -> Vec<NewPublication> {
+    static TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"<[^>]+>").unwrap());
+    static BY_PREFIX_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)^by\s+").unwrap());
+
+    let document = Html::parse_document(html);
+    let p_sel = Selector::parse("p").unwrap();
+    let bold_sel = Selector::parse("b").unwrap();
+
+    let mut out = Vec::new();
+    for p in document.select(&p_sel) {
+        let Some(title_el) = p.select(&bold_sel).next() else {
+            continue;
+        };
+        let title: String = title_el.text().collect::<String>().trim().to_string();
+        if title.is_empty() {
+            continue;
+        }
+
+        let p_html = p.html();
+        let Some(idx) = p_html.find("</b>") else {
+            continue;
+        };
+        let after_title = &p_html[idx + 4..];
+        let plain = TAG_RE.replace_all(after_title, " ");
+        let plain = BY_PREFIX_RE.replace(plain.trim(), "");
+        let authors = parse_paren_grouped_names(&plain);
+        if authors.is_empty() {
+            continue;
+        }
+
+        out.push(NewPublication {
+            title,
+            authors,
+            url: None,
+            source: source_tag.to_string(),
+        });
     }
     out
 }
@@ -107,5 +167,37 @@ mod tests {
     #[test]
     fn test_parse_empty_html() {
         assert!(parse_accepted_papers("<html></html>", "sosp2025").is_empty());
+    }
+
+    const BY_LINE_SAMPLE: &str = r#"
+        <div class="col-md-12 welcome-middle"><p>
+        <b>Using Lightweight Formal Methods to Validate a Key-Value Storage Node in Amazon S3</b> by
+        James Bornholt (Amazon Web Services &amp; The University of Texas at Austin), Rajeev Joshi (Amazon Web Services), and Andrew Warfield (Amazon Web Services)
+        </p></div>
+
+        <div class="col-md-12 welcome-middle"><p>
+        <b>Boki: Stateful Serverless Computing with Shared Logs</b> by
+        Zhipeng Jia (The University of Texas at Austin) and Emmett Witchel (The University of Texas at Austin and Katana Graph)
+        </p></div>
+    "#;
+
+    #[test]
+    fn test_parse_by_line_fallback_two_papers() {
+        let out = parse_accepted_papers(BY_LINE_SAMPLE, "sosp2021");
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0].title,
+            "Using Lightweight Formal Methods to Validate a Key-Value Storage Node in Amazon S3"
+        );
+        assert_eq!(
+            out[0].authors,
+            vec!["James Bornholt", "Rajeev Joshi", "Andrew Warfield"]
+        );
+        assert_eq!(out[0].source, "sosp2021");
+        assert_eq!(
+            out[1].title,
+            "Boki: Stateful Serverless Computing with Shared Logs"
+        );
+        assert_eq!(out[1].authors, vec!["Zhipeng Jia", "Emmett Witchel"]);
     }
 }


### PR DESCRIPTION
## Summary

Backfilled historical years for INFOCOM, SIGCOMM, ASPLOS, RAID, and SOSP into the local corpus. Doing so surfaced that each importer's parser only handled the current/latest year's page template — this extends each with fallback parsers for the historical formats actually encountered:

- **infocom.rs**: author text placement relative to the title varies by year (sibling of the `<strong>` directly in some years, of a wrapping `<p>` in others, or two ancestor levels up in others) — now climbs up to two ancestor levels looking for text that parses into real names.
- **sigcomm.rs**: added parsers for 2024's Next.js template and the legacy (pre-2024) jQuery-Mobile listing template, tried as fallbacks after the current template.
- **asplos.rs**: added a fallback parser for 2024's one-off WordPress table page.
- **raid.rs**: added a fallback parser for the ACM DL "Open Access" embedded widget format used by RAID 2022/2023.
- **sosp.rs**: added a fallback parser for the mpi-sws.org-hosted paragraph format used by SOSP 2021/2023.
- **author_parsing.rs**: new `parse_names_maybe_with_affiliations()` falls back to plain comma-split when an author list has no true parenthesized affiliations, distinguishing real affiliations from mid-name nicknames-in-parens (e.g. "Boyang (Tony) Yu").

(Supersedes #318, which got accidentally closed when its branch was force-deleted mid-merge-attempt — same content, rebased cleanly onto current main.)

## Test plan

- All new parsers verified against real historical accepted-papers pages, and each is covered by a regression test built from that real markup.
- `cargo test -p hallucinator-local-corpus` — 155 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)