### PR TITLE
Release v0.2.3

### DIFF
--- a/hallucinator-rs/Cargo.lock
+++ b/hallucinator-rs/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-acl"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-arxiv-offline"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "dirs",
  "flate2",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-bbl"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "biblatex",
  "hallucinator-core",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-dblp"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "flate2",
  "futures-util",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-grobid"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "hallucinator-core",
  "quick-xml",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-iacr-eprint"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "once_cell",
  "quick-xml",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-ingest"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "flate2",
  "hallucinator-bbl",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-local-corpus"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "flate2",
  "once_cell",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-openalex"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-compression",
  "flate2",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-parsing"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-pdf-mupdf"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "hallucinator-core",
  "mupdf",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-reporting"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "hallucinator-core",
 ]
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "hallucinator-tui"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/hallucinator-rs/Cargo.toml
+++ b/hallucinator-rs/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/gianlucasb/hallucinator"

--- a/hallucinator-rs/crates/hallucinator-python/Cargo.toml
+++ b/hallucinator-rs/crates/hallucinator-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hallucinator-python"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 description = "Python bindings for hallucinator reference extraction"


### PR DESCRIPTION
## Summary

Version bump for the 0.2.3 release, covering the parsing/corpus fixes merged since 0.2.2:

- #316 — Fix reference-parsing bugs causing empty-title phantom references (standalone page-number footers, arbitrary-topic appendix headers)
- #317 — Fix `?` help overlay never rendering on the File Picker screen in the TUI
- Local corpus: backfilled historical years for INFOCOM, SIGCOMM, ASPLOS, RAID, SOSP, EuroS&P, NSDI, OSDI, SOUPS
- #321 — Fix DOI line-wrap regex blanking titles for bare `doi:10.xxxx/` citations
- #322 — Fix DOI-embedded year spuriously matching the author-list boundary
- #323 — Fix title-boundary detection dropping question/exclamation marks (`?`/`!`-ending titles no longer get the venue clause glued on)

## Test plan

`cargo build --workspace --release` and `cargo test --workspace` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)