### PR TITLE
Fix reference-parsing and author-matching edge cases

### DIFF
--- a/hallucinator-rs/crates/hallucinator-parsing/src/authors.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/authors.rs
@@ -2,6 +2,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::config::ParsingConfig;
+use crate::text_processing::is_single_uppercase_initial;
 
 /// Special sentinel value indicating the reference uses em-dashes to
 /// indicate "same authors as previous entry."
@@ -53,8 +54,20 @@ pub(crate) fn extract_authors_from_reference_with_config(
 
     // Fix "word{and}" patterns where a space was lost between a name and "and"
     // e.g., "E. Dasand J. W. Burdick" → "E. Das and J. W. Burdick"
-    static MERGED_AND_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"([a-z])and ([A-Z])").unwrap());
-    let ref_text = MERGED_AND_RE.replace_all(ref_text, "$1 and $2");
+    //
+    // Regression: a bare `([a-z])and ([A-Z])` also matches inside any real
+    // name that happens to end in "...and" — e.g. "Roland H. C. Yap"
+    // contains "l" + "and" + " " + "H", which is structurally identical to
+    // the genuine merge artifact and got split into two bogus authors
+    // (`"Rol"`, `"H. C. Yap"`). The intended case only ever follows a
+    // single-letter initial directly ("E. Dasand...", "X.Y.Zand..."), so
+    // requiring that immediately before the merged word — real surnames
+    // like "Roland" that start a *new* author (preceded by ", " or "and ",
+    // not "X.") never match, while a genuinely glued "Initial.Surnameand"
+    // still does.
+    static MERGED_AND_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"([A-Z]\.\s*)([A-Za-z]*[a-z])and ([A-Z])").unwrap());
+    let ref_text = MERGED_AND_RE.replace_all(ref_text, "$1$2 and $3");
     let ref_text = ref_text.as_ref();
 
     // Check for em-dash pattern meaning "same authors as previous"
@@ -74,11 +87,32 @@ pub(crate) fn extract_authors_from_reference_with_config(
     // parsing format check and comes back with zero authors, even though
     // the real author list at the very start was simple and well-formed.
     //
+    // The `/\s*` after the DOI prefix and the optional trailing group both
+    // cover a DOI wrapped across a PDF line break that's already been
+    // collapsed to a plain space by an earlier pipeline stage:
+    //   - "doi: 10.1109/ SP61157.2025.00134" — the wrap lands right after
+    //     the slash. Without `\s*` there, `\S+` requires a non-whitespace
+    //     character immediately after the slash and the whole alternation
+    //     fails to match at all, leaving the *entire* DOI unmasked.
+    //   - "doi:10.14722/usec.2024. 23039" — the wrap lands mid-suffix.
+    //     Without the trailing optional group, `\S+` only masks up through
+    //     the space, leaving the wrapped remainder's own embedded
+    //     ".YYYY."-shaped digits exposed.
+    // Both leave a DOI's internal digit-dot structure exposed to the same
+    // spurious-boundary problem this masking exists to prevent — same
+    // underlying issue as the title-extraction fix in `extract_doi`
+    // (hallucinator-core), just unmasked here instead. The trailing group
+    // is deliberately narrow (a short alnum token then 1-4 ".digits"
+    // groups) so it only ever matches a DOI's own wrapped tail, never the
+    // start of a genuine next sentence.
+    //
     // Positions must stay aligned with `ref_text` for the later
     // `ref_text[..author_end]` slice, so matched bytes are replaced with
     // a same-length run of a filler character rather than removed.
-    static DOI_ARXIV_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?i)(?:10\.\d{4,}/|arxiv:\s*)\S+").unwrap());
+    static DOI_ARXIV_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)(?:10\.\d{4,}/\s*|arxiv:\s*)\S+(?:\s+[a-z0-9]{0,4}(?:\.\d+){1,4}\.?)?")
+            .unwrap()
+    });
     let boundary_text =
         DOI_ARXIV_RE.replace_all(ref_text, |caps: &regex::Captures| "#".repeat(caps[0].len()));
     let boundary_text = boundary_text.as_ref();
@@ -187,10 +221,13 @@ fn find_first_real_period(text: &str) -> Option<usize> {
         if pos == 0 {
             continue;
         }
-        let char_before = text.as_bytes()[pos - 1];
-        if char_before.is_ascii_uppercase()
-            && (pos == 1 || !text.as_bytes()[pos - 2].is_ascii_alphabetic())
-        {
+        // Check if period follows a single capital letter (potential initial).
+        // Unicode-aware so accented initials (Ö., É., Ł., Ø., Ñ., ...) are
+        // recognized too, not just ASCII A-Z — an ASCII-only check silently
+        // misses these (and would even inspect a raw UTF-8 continuation
+        // byte for a multi-byte character), so the period after e.g. "Ö."
+        // gets mistaken for the end of the author list.
+        if is_single_uppercase_initial(text, pos) {
             // This is likely an initial — skip
             continue;
         }
@@ -203,6 +240,33 @@ fn find_first_real_period(text: &str) -> Option<usize> {
         let word_before = &text[word_start..pos];
         if SUFFIX_WORDS.contains(word_before) {
             continue;
+        }
+
+        // Check for a short Title-Case name-prefix/patronymic initial, e.g.
+        // "Md." (a common South Asian first-name prefix) or "Yu."
+        // (Russian/Chinese patronymic), immediately followed by what looks
+        // like the rest of a name. Gated on the word being Title Case (not
+        // an ALL-CAPS acronym like "USA." or "IBM.") and on what follows
+        // having the same "more of a name list" shape required by
+        // `NAME_PREFIX_CONTINUATION` (2-4 capitalized words, comma, "and",
+        // capital) — NOT just "the next word starts with a capital
+        // letter", which would also swallow a genuine short final surname
+        // like "Wu." right before a title, since titles almost always
+        // start with a capital letter too.
+        //
+        // "Md" specifically gets the more permissive `MD_PREFIX_CONTINUATION`
+        // instead (no comma required before "and", and additional full
+        // names allowed before it) — see that regex's doc comment for why
+        // it's safe to relax only for this exact word.
+        let word_len = word_before.chars().count();
+        if (2..=3).contains(&word_len)
+            && word_before.chars().next().is_some_and(|c| c.is_uppercase())
+            && word_before.chars().skip(1).all(|c| c.is_lowercase())
+            && (crate::title::NAME_PREFIX_CONTINUATION.is_match(&text[m.end()..])
+                || (word_before == "Md"
+                    && crate::title::MD_PREFIX_CONTINUATION.is_match(&text[m.end()..])))
+        {
+            continue; // Likely a name-prefix initial, not a sentence end
         }
 
         return Some(pos);
@@ -450,6 +514,135 @@ mod tests {
             "Alice Author and Bob Author. A perfectly ordinary title here. arXiv:2020.12345";
         let authors = extract_authors_from_reference(ref_text);
         assert_eq!(authors, vec!["Alice Author", "Bob Author"]);
+    }
+
+    // Regression: "Md." (a common South Asian first-name prefix, e.g.
+    // "Md. Kabir Rahman Chowdhury") was treated the same as a full
+    // surname, so the author-boundary detector cut the author list right
+    // after it — dropping the rest of that author's name and everyone
+    // listed after them.
+    #[test]
+    fn test_name_prefix_initial_does_not_truncate_author_list() {
+        let ref_text = "Farid Chen, Md. Kabir Rahman Chowdhury, and Priya Wu. \
+            A perfectly ordinary title here. In Some Conference, 2024.";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(
+            authors,
+            vec!["Farid Chen", "Md. Kabir Rahman Chowdhury", "Priya Wu"]
+        );
+    }
+
+    // Regression: an accented initial (Ö, É, Ł, Ø, Ñ, ...) wasn't
+    // recognized as an initial at all — the ASCII-only check inspected a
+    // raw UTF-8 continuation byte instead of the actual character — so the
+    // author-boundary detector treated the period after it as the real
+    // end of the author list, dropping every author listed afterward.
+    #[test]
+    fn test_non_ascii_initial_does_not_truncate_author_list() {
+        let ref_text = "Farid Chen, Selin Ö. Yilmaz, and Priya Wu. \
+            A perfectly ordinary title here. In Some Conference, 2024.";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(authors, vec!["Farid Chen", "Selin Ö. Yilmaz", "Priya Wu"]);
+    }
+
+    // Regression guard: a genuine short (2-3 letter) surname at the real
+    // end of the author list — e.g. "Wu", a common East Asian surname —
+    // must not be mistaken for a name-prefix like "Md." just because the
+    // title that follows starts with a capital letter (nearly all do).
+    #[test]
+    fn test_short_surname_at_end_of_author_list_not_mistaken_for_prefix() {
+        let ref_text = "Farid Chen and Priya Wu. \
+            A perfectly ordinary title here. In Some Conference, 2024.";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(authors, vec!["Farid Chen", "Priya Wu"]);
+    }
+
+    // Regression: "Md." at the very start of a bare 2-author list with no
+    // Oxford comma ("Md. First Last and First2 Last2.") wasn't recognized
+    // as a continuation — the general name-prefix check requires a comma
+    // before "and", which a 2-author list never has.
+    #[test]
+    fn test_md_prefix_two_author_list_with_no_oxford_comma() {
+        let ref_text = "Md. Kabir Chen and Priya Wu. \
+            A perfectly ordinary title here. In Some Conference, 2024.";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(authors, vec!["Md. Kabir Chen", "Priya Wu"]);
+    }
+
+    // Regression: "Md." prefixing an author who ISN'T last in the list —
+    // one more full name appears before the closing ", and Lastauthor."
+    // — wasn't recognized either, since the general check only allows a
+    // single multi-word name between the prefix and "and".
+    #[test]
+    fn test_md_prefix_not_last_in_author_list() {
+        let ref_text = "Md. Kabir Rahman Chowdhury, Farid Haddad, and Priya Wu. \
+            A perfectly ordinary title here. In Some Conference, 2024.";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(
+            authors,
+            vec!["Md. Kabir Rahman Chowdhury", "Farid Haddad", "Priya Wu"]
+        );
+    }
+
+    // Regression guard: the permissive "Md" continuation check must stay
+    // scoped to the exact word "Md" — a genuine short surname like "Wu"
+    // must still require a comma before "and" (the general check), so a
+    // real title with no Oxford comma isn't swallowed.
+    #[test]
+    fn test_short_surname_with_bare_and_title_not_mistaken_for_md_prefix() {
+        let ref_text = "Farid Chen and Priya Wu. \
+            Fair Systems Analysis and Practical Deployment Considerations. \
+            In Proceedings of Some Conference.";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(authors, vec!["Farid Chen", "Priya Wu"]);
+    }
+
+    // Regression: a DOI wrapped across a PDF line break (already collapsed
+    // to a plain space by an earlier pipeline stage) left its own embedded
+    // ".YYYY."-shaped tail unmasked, spuriously matching the ACM-style
+    // "authors end at '. YYYY.'" boundary heuristic deep inside the venue
+    // clause. That dropped the true last author and admitted venue
+    // fragments (city/state/country) as pseudo-authors.
+    #[test]
+    fn test_wrapped_doi_does_not_leak_venue_into_author_list() {
+        let ref_text = "Farid Chen, Priya Wu, and Kabir Rahman. \
+            A perfectly ordinary title here. In Some Symposium, Some City, ST, USA, \
+            May 1-3, 2024, pages 1-10. Some Publisher, 2024. \
+            doi:10.1109/TFOO5534 2.2024.10545393";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(authors, vec!["Farid Chen", "Priya Wu", "Kabir Rahman"]);
+    }
+
+    // Regression: a DOI wrapped right after the slash (rather than
+    // mid-suffix, as in the test above) wasn't masked at all — `\S+`
+    // requires a non-whitespace character immediately after "10.NNNN/",
+    // so when a space follows the slash itself the whole alternation
+    // failed to match, leaving the entire DOI (and its embedded
+    // ".YYYY.") exposed to the same spurious-boundary problem.
+    #[test]
+    fn test_doi_wrapped_right_after_slash_does_not_leak_venue_into_author_list() {
+        let ref_text = "Farid Chen, Priya Wu, and Kabir Rahman. \
+            A perfectly ordinary title here. In Some Symposium, Some City, ST, USA, \
+            May 1-3, 2024, pages 1-10. Some Publisher, 2024. \
+            doi: 10.1109/ TFOO5534.2024.10545393";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(authors, vec!["Farid Chen", "Priya Wu", "Kabir Rahman"]);
+    }
+
+    // Regression: `MERGED_AND_RE` (below) also matched inside any real
+    // name ending in "...and" — e.g. "Ferdinand" contains "n" + "and" +
+    // " " + the next author's capital initial, structurally identical to
+    // the genuine missing-space artifact it's meant to fix — splitting it
+    // into two bogus authors.
+    #[test]
+    fn test_merged_and_regex_does_not_split_name_ending_in_and() {
+        let ref_text = "Priya Wu, Farid Ferdinand Haddad, and Kabir Rahman. \
+            A perfectly ordinary title here. In Some Conference, 2024.";
+        let authors = extract_authors_from_reference(ref_text);
+        assert_eq!(
+            authors,
+            vec!["Priya Wu", "Farid Ferdinand Haddad", "Kabir Rahman"]
+        );
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-parsing/src/text_processing.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/text_processing.rs
@@ -517,6 +517,29 @@ pub(crate) fn fix_hyphenation_with_config(text: &str, config: &ParsingConfig) ->
     RE_NO_SPACE.replace_all(&result, "$1$2$3").into_owned()
 }
 
+/// Whether the character immediately before `period_pos` in `text` is a
+/// single Unicode uppercase letter forming its own "word" — i.e. a likely
+/// initial like "J." or an accented initial like "Ö." — rather than the
+/// last letter of a longer word.
+///
+/// Unicode-aware (`char::is_uppercase()`) rather than an ASCII-only check,
+/// so accented initials (Ö, É, Ł, Ø, Ñ, ...) are recognized as initials
+/// too. An ASCII-only byte check misses these entirely — worse, indexing
+/// `text.as_bytes()[period_pos - 1]` on a multi-byte character reads a raw
+/// UTF-8 continuation byte, not the character itself, so the check silently
+/// never fires for author names containing one.
+///
+/// `period_pos` must be a valid char boundary in `text` (true for any
+/// position located by matching a literal `.` in `text`, since `.` is a
+/// single-byte ASCII character).
+pub(crate) fn is_single_uppercase_initial(text: &str, period_pos: usize) -> bool {
+    let mut chars = text[..period_pos].chars().rev();
+    match chars.next() {
+        Some(c) if c.is_uppercase() => !chars.next().is_some_and(|prev| prev.is_alphabetic()),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
+++ b/hallucinator-rs/crates/hallucinator-parsing/src/title.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::collections::HashSet;
 
 use crate::config::ParsingConfig;
-use crate::text_processing::fix_hyphenation;
+use crate::text_processing::{fix_hyphenation, is_single_uppercase_initial};
 
 /// Abbreviations that should NEVER be sentence boundaries (mid-title abbreviations).
 static MID_SENTENCE_ABBREVIATIONS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
@@ -2404,6 +2404,86 @@ fn truncate_at_venue_marker(text: &str) -> &str {
 
 // ───────────────── Sentence splitting ─────────────────
 
+/// Continuation check used only for the "2-3 letter name-prefix" case: a
+/// short Title-Case word like "Md." or a patronymic initial like "Yu.",
+/// immediately followed by more of that author's name. Matches a
+/// normal-order "First [Particle] Middle Last, and Next..." name with the
+/// comma directly touching the last name — e.g. "Md. Kabir Rahman
+/// Chowdhury, and Priya Wu." — which the general `AUTHOR_AFTER` patterns
+/// miss (they either require a space before that comma, or don't allow
+/// this many consecutive name words). Optional particle covers names like
+/// "Maarten van Steen,". Used by both [`split_sentences_skip_initials`]
+/// (title-boundary detection) and `authors::find_first_real_period`
+/// (author-boundary detection) — see the 2-3 letter check in each.
+///
+/// Deliberately NOT added to `AUTHOR_AFTER`, and deliberately not just
+/// "the next word starts with a capital letter": either would also match
+/// right after an ordinary short surname (e.g. "Wu." — a common East
+/// Asian surname), where this same syntactic shape is a real risk — a
+/// title beginning "Fair Systems Analysis, and Practical Deployment
+/// Considerations" would otherwise be mistaken for more authors, and a
+/// title starting with any capitalized word (nearly all of them) would
+/// make a genuine last author's period look like a name-prefix. Requiring
+/// the specific "2-4 capitalized words, comma, and, capital" shape (a
+/// title practically never starts this way) keeps that blast radius
+/// contained.
+///
+/// The comma before "and" is deliberately REQUIRED here (not optional):
+/// dropping it was tried and reverted — see [`MD_PREFIX_CONTINUATION`] for
+/// why a comma-free "X and Y" needs a narrower, name-specific check
+/// instead of widening this one.
+pub(crate) static NAME_PREFIX_CONTINUATION: Lazy<Regex> = Lazy::new(|| {
+    let sc =
+        r"[a-zA-Z\u{00A0}-\u{017F}\u{02B0}-\u{02FF}\u{0300}-\u{036F}'\-`\u{00B4}\u{2018}\u{2019}]";
+    let uc = r"[A-Z\u{00C0}-\u{00D6}\u{00D8}-\u{00DE}\u{0100}-\u{0178}]";
+    let particle =
+        r"(?:van|von|de|del|della|di|da|le|la|den|der|ten|ter|dos|das|du|op|het|el|al|ben|ibn)";
+    Regex::new(&format!(
+        r"^{}{}+(?:\s+(?:{}\s+)?{}{}+){{1,3}}\s*,\s*and\s+{}",
+        uc, sc, particle, uc, sc, uc
+    ))
+    .unwrap()
+});
+
+/// Narrower cousin of [`NAME_PREFIX_CONTINUATION`], used ONLY when the
+/// 2-3 letter word immediately before the period is exactly "Md" (a South
+/// Asian first-name prefix, e.g. "Md. Kabir Rahman Chowdhury" or "Md.
+/// Imran Hossen and Xiali Hei").
+///
+/// "Md" is safe to treat much more permissively than the general 2-3
+/// letter case: unlike "Wu", "Yu", "Al", "Xu" and similar, it is
+/// essentially never itself a complete surname — it always prefixes more
+/// of the same author's name — so the comma-before-"and" requirement that
+/// protects the general case against swallowing a genuine short surname
+/// isn't needed here, and can be relaxed to also cover:
+///   - a bare "and" with no comma at all (a 2-author list has no Oxford
+///     comma) — "Md. Imran Hossen and Xiali Hei."
+///   - one or more *additional* full comma-separated names before the
+///     closing "and Lastauthor" — "Md. Mahmud Hossain, Maziar Fotouhi,
+///     and Ragib Hasan." — when the prefixed author isn't last in the
+///     list.
+///
+/// Widening the general check to cover these instead was tried first and
+/// reverted: it also matched a genuine short surname ("Wu.") followed by
+/// a real title with no Oxford comma ("Fair Systems Analysis and
+/// Practical Deployment Considerations"), breaking title extraction for
+/// that combination. Gating on the exact word "Md" avoids that ambiguity
+/// entirely: no title starts with the literal word "Md".
+pub(crate) static MD_PREFIX_CONTINUATION: Lazy<Regex> = Lazy::new(|| {
+    let sc =
+        r"[a-zA-Z\u{00A0}-\u{017F}\u{02B0}-\u{02FF}\u{0300}-\u{036F}'\-`\u{00B4}\u{2018}\u{2019}]";
+    let uc = r"[A-Z\u{00C0}-\u{00D6}\u{00D8}-\u{00DE}\u{0100}-\u{0178}]";
+    let particle =
+        r"(?:van|von|de|del|della|di|da|le|la|den|der|ten|ter|dos|das|du|op|het|el|al|ben|ibn)";
+    // {0}=uc, {1}=sc, {2}=particle (indexed so each can repeat without
+    // re-listing it in the format! args).
+    Regex::new(&format!(
+        r"^{0}{1}+(?:\s+(?:{2}\s+)?{0}{1}+){{1,3}}(?:\s*,\s*{0}{1}+(?:\s+(?:{2}\s+)?{0}{1}+){{0,2}})*\s*(?:,\s*)?and\s+{0}",
+        uc, sc, particle
+    ))
+    .unwrap()
+});
+
 /// Split text into sentences, but skip periods that are author initials
 /// (e.g., "M." "J.") or mid-sentence abbreviations (e.g., "vs.").
 pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
@@ -2527,16 +2607,23 @@ pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
             .unwrap(),
             // Surname, Firstname [Middlenames...] I. (inverted format with middle names + initial)
             // Handles "Oliveira, Ana Flávia C. Moura" after split at "P."
+            // Optional particle before each middle/last name component so a
+            // Dutch/German/French particle (van, von, de, ...) inside the
+            // name — e.g. "Oliveira, Ana van Someren C. Moura" — doesn't
+            // break the match (every word here was previously required to
+            // start with an uppercase letter).
             Regex::new(&format!(
-                r"^([A-Z]{}+)\s*,\s*[A-Z]{}+(?:\s+[A-Z]{}+)+\s+[A-Z]\.\s*[A-Z]",
-                sc, sc, sc
+                r"^([A-Z]{}+)\s*,\s*[A-Z]{}+(?:\s+(?:{}\s+)?[A-Z]{}+)+\s+[A-Z]\.\s*[A-Z]",
+                sc, sc, particle, sc
             ))
             .unwrap(),
             // Surname, Firstname [Middle...] Lastname, (inverted format in comma-separated author list)
             // Handles "Mazurek, Aron Laszka," and "Klemmer, Stefan Albert Horstmann,"
+            // Optional particle before each middle/last name component —
+            // see comment on the pattern above for why.
             Regex::new(&format!(
-                r"^([A-Z]{}+)\s*,\s*[A-Z]{}+(?:\s+[A-Z]{}+)+\s*,",
-                sc, sc, sc
+                r"^([A-Z]{}+)\s*,\s*[A-Z]{}+(?:\s+(?:{}\s+)?[A-Z]{}+)+\s*,",
+                sc, sc, particle, sc
             ))
             .unwrap(),
             // Surname, Firstname, (inverted format with single first name)
@@ -2544,9 +2631,11 @@ pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
             Regex::new(&format!(r"^({}{}+)\s*,\s*{}{}{{2,}}\s*,", uc, sc, uc, sc)).unwrap(),
             // Surname, Firstname Lastname, and Firstname (inverted format with full names)
             // Handles "Gomez, Łukasz Kaiser, and Illia" after split at "N."
+            // Optional particle between the first and last name for the
+            // same reason as the patterns above.
             Regex::new(&format!(
-                r"^({}{}+)\s*,\s*{}{}+\s+{}{}+\s*,\s*and\s+{}",
-                uc, sc, uc, sc, uc, sc, uc
+                r"^({}{}+)\s*,\s*{}{}+\s+(?:{}\s+)?{}{}+\s*,\s*and\s+{}",
+                uc, sc, uc, sc, particle, uc, sc, uc
             ))
             .unwrap(),
             // Surname, et al (inverted format with et al)
@@ -2638,10 +2727,10 @@ pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
 
         let char_before = text.as_bytes()[pos - 1];
 
-        // Check if period follows a single capital letter (potential initial)
-        if char_before.is_ascii_uppercase()
-            && (pos == 1 || !text.as_bytes()[pos - 2].is_ascii_alphabetic())
-        {
+        // Check if period follows a single capital letter (potential initial).
+        // Unicode-aware so accented initials (Ö., É., Ł., Ø., Ñ., ...) are
+        // recognized too, not just ASCII A-Z.
+        if is_single_uppercase_initial(text, pos) {
             let after_period = &text[next_start..];
             let is_author = AUTHOR_AFTER.iter().any(|re| re.is_match(after_period));
             if is_author {
@@ -2649,7 +2738,8 @@ pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
             }
         }
 
-        // Check for multi-letter initials (2-3 chars like "Yu." in Russian/Chinese names)
+        // Check for multi-letter initials (2-3 chars like "Yu." in Russian/Chinese names,
+        // or "Md." — a common South Asian first-name prefix)
         // e.g., "A. Yu. Veretennikov" where "Yu." is a patronymic initial
         {
             let mut word_start = pos - 1;
@@ -2660,7 +2750,10 @@ pub(crate) fn split_sentences_skip_initials(text: &str) -> Vec<String> {
             // Short words (2-3 chars) starting with capital followed by surname
             if (2..=3).contains(&word_len) && text.as_bytes()[word_start].is_ascii_uppercase() {
                 let after_period = &text[next_start..];
-                let is_author = AUTHOR_AFTER.iter().any(|re| re.is_match(after_period));
+                let is_author = AUTHOR_AFTER.iter().any(|re| re.is_match(after_period))
+                    || NAME_PREFIX_CONTINUATION.is_match(after_period)
+                    || (&text[word_start..pos] == "Md"
+                        && MD_PREFIX_CONTINUATION.is_match(after_period));
                 if is_author {
                     continue; // Skip — this is a multi-letter initial
                 }
@@ -2951,6 +3044,135 @@ mod tests {
         let (title, from_quotes) = extract_title_from_reference(ref_text);
         assert!(!from_quotes);
         assert_eq!(title, "How do fixes become bugs?");
+    }
+
+    // Regression: an author list containing a lowercase name particle
+    // (van/von/de/...) in the middle of a "First Particle Last" name broke
+    // every multi-word-name continuation pattern in `AUTHOR_AFTER` (they
+    // all required every name token to start uppercase), causing a
+    // spurious sentence split right before the true title and leaving the
+    // tail of the author list as the extracted "title".
+    #[test]
+    fn test_particle_name_in_author_list_not_mistaken_for_title() {
+        let ref_text = "Amara Osei, Brice Fontaine, Farid Haddad, Junko Watanabe, \
+            Daniel J. Kowalski, Martina Lindberg, David R. Sanchez, Maarten van Steen, \
+            and Andreas Berg. Systemname: A framework for evaluating something. \
+            In 27th Annual Some Symposium, 2020.";
+        let (title, from_quotes) = extract_title_from_reference(ref_text);
+        assert!(!from_quotes);
+        assert_eq!(title, "Systemname: A framework for evaluating something");
+    }
+
+    // Regression: a short Title-Case name-prefix like "Md." (a common South
+    // Asian first-name abbreviation) was treated the same as a full
+    // surname, so the sentence splitter cut the author list right after it
+    // instead of continuing through the rest of that author's name.
+    #[test]
+    fn test_name_prefix_initial_in_author_list_not_mistaken_for_title() {
+        let ref_text = "Ana Beltran, Farrukh Yu Nazari, Md. Kabir Rahman Chowdhury, \
+            and Priya Wu. Systemtitle: A framework for evaluating something important. \
+            In Some Conference, 2024, pages 1-10.";
+        let (title, from_quotes) = extract_title_from_reference(ref_text);
+        assert!(!from_quotes);
+        assert_eq!(
+            title,
+            "Systemtitle: A framework for evaluating something important"
+        );
+    }
+
+    // Regression: an accented initial (Ö, É, Ł, Ø, Ñ, ...) wasn't
+    // recognized as an initial at all — an ASCII-only check inspected a
+    // raw UTF-8 continuation byte instead of the actual character — so the
+    // sentence splitter treated the period after it as a real boundary and
+    // returned the tail of the author list as the title.
+    #[test]
+    fn test_non_ascii_initial_in_author_list_not_mistaken_for_title() {
+        let ref_text = "Farid Chen, Selin Ö. Yilmaz, and Priya Wu. \
+            Systemtitle: A framework for evaluating something important. \
+            In Some Conference, 2024.";
+        let (title, from_quotes) = extract_title_from_reference(ref_text);
+        assert!(!from_quotes);
+        assert_eq!(
+            title,
+            "Systemtitle: A framework for evaluating something important"
+        );
+    }
+
+    // Regression guard: a title beginning with "CapWord CapWord CapWord,
+    // and CapWord..." has the exact same syntactic shape as the
+    // name-prefix-continuation fix above (e.g. "Md. Kabir Rahman
+    // Chowdhury, and Priya Wu."). It must NOT be mistaken for more
+    // authors just because it follows an ordinary (non-prefix) surname.
+    #[test]
+    fn test_title_starting_with_comma_and_not_mistaken_for_more_authors() {
+        let ref_text = "Jane Smith and John Miller. \
+            Fair Systems Analysis, and Practical Deployment Considerations. \
+            In Proceedings of Some Conference.";
+        let (title, _) = extract_title_from_reference(ref_text);
+        assert_eq!(
+            title,
+            "Fair Systems Analysis, and Practical Deployment Considerations"
+        );
+    }
+
+    #[test]
+    fn test_title_starting_with_comma_and_after_initials_not_mistaken_for_more_authors() {
+        let ref_text = "A. Author, B. Author, and C. Author. \
+            Deep Learning Systems, and Fairness Considerations in Practice. \
+            In Some Symposium.";
+        let (title, _) = extract_title_from_reference(ref_text);
+        assert_eq!(
+            title,
+            "Deep Learning Systems, and Fairness Considerations in Practice"
+        );
+    }
+
+    // Regression: "Md." at the start of a bare 2-author list with no
+    // Oxford comma ("Md. First Last and First2 Last2.") wasn't recognized
+    // as a name-prefix continuation, so the sentence splitter cut right
+    // after it and returned the rest of the author list as the title.
+    #[test]
+    fn test_md_prefix_two_author_no_comma_not_mistaken_for_title() {
+        let ref_text = "Md. Kabir Chen and Priya Wu. \
+            Systemtitle: A framework for evaluating something important. \
+            In Some Conference, 2024.";
+        let (title, from_quotes) = extract_title_from_reference(ref_text);
+        assert!(!from_quotes);
+        assert_eq!(
+            title,
+            "Systemtitle: A framework for evaluating something important"
+        );
+    }
+
+    // Regression: "Md." prefixing an author who isn't last in the list —
+    // one more full name appears before the closing ", and Lastauthor."
+    #[test]
+    fn test_md_prefix_not_last_in_list_not_mistaken_for_title() {
+        let ref_text = "Md. Kabir Rahman Chowdhury, Farid Haddad, and Priya Wu. \
+            Systemtitle: A framework for evaluating something important. \
+            In Some Conference, 2024.";
+        let (title, from_quotes) = extract_title_from_reference(ref_text);
+        assert!(!from_quotes);
+        assert_eq!(
+            title,
+            "Systemtitle: A framework for evaluating something important"
+        );
+    }
+
+    // Regression guard: the permissive "Md" continuation must stay scoped
+    // to the exact word "Md" — a genuine short surname like "Wu" at the
+    // real end of the author list, followed by a real title with no
+    // Oxford comma, must not be swallowed as "more authors".
+    #[test]
+    fn test_short_surname_with_bare_and_title_not_mistaken_for_md_prefix() {
+        let ref_text = "Farid Chen and Priya Wu. \
+            Fair Systems Analysis and Practical Deployment Considerations. \
+            In Proceedings of Some Conference.";
+        let (title, _) = extract_title_from_reference(ref_text);
+        assert_eq!(
+            title,
+            "Fair Systems Analysis and Practical Deployment Considerations"
+        );
     }
 
     #[test]

--- a/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
+++ b/hallucinator-rs/crates/hallucinator-tui/src/view/detail.rs
@@ -4,6 +4,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
+use hallucinator_core::authors::get_last_name_public;
 use hallucinator_core::{DbStatus, MismatchKind, Status};
 
 use crate::app::App;
@@ -165,22 +166,7 @@ pub fn render_in(
 
             // DB Authors (what the database returned) — always show, even if empty
             if !result.found_authors.is_empty() {
-                let overlap = if !result.ref_authors.is_empty() {
-                    let ref_set: std::collections::HashSet<_> = result
-                        .ref_authors
-                        .iter()
-                        .map(|a| a.to_lowercase())
-                        .collect();
-                    let found_set: std::collections::HashSet<_> = result
-                        .found_authors
-                        .iter()
-                        .map(|a| a.to_lowercase())
-                        .collect();
-                    let overlap_count = ref_set.intersection(&found_set).count();
-                    format!(" ({}/{})", overlap_count, result.ref_authors.len())
-                } else {
-                    String::new()
-                };
+                let overlap = author_overlap_label(&result.ref_authors, &result.found_authors);
                 labeled_line(
                     &mut lines,
                     "DB Authors",
@@ -411,6 +397,37 @@ fn labeled_line<'a>(lines: &mut Vec<Line<'a>>, label: &'a str, value: &str, them
         Span::styled(format!("  {label:<16}"), Style::default().fg(theme.dim)),
         Span::styled(value.to_string(), Style::default().fg(theme.text)),
     ]));
+}
+
+/// Build the trailing " (N/M)" overlap count shown after the "DB Authors"
+/// line on a mismatch, or "" if `ref_authors` is empty.
+///
+/// Compares by surname (via the same `get_last_name_public` the real
+/// matcher uses), not the raw lowercased full name string. A naive
+/// full-string comparison called any formatting difference — a DBLP
+/// disambiguation suffix ("Wenbo Guo 0001"), an initial vs. a full first
+/// name ("J. Smith" vs "John Smith"), a diacritic — a non-match, so this
+/// count routinely showed something alarming like "(0/7)" for authors that
+/// actually agree. That's misleading on its own, and disconnected from
+/// `validate_authors_with_source` (the real mismatch decision), which
+/// already normalizes all of this — surname comparison is a much closer
+/// approximation of what that function actually considers a match.
+fn author_overlap_label(ref_authors: &[String], found_authors: &[String]) -> String {
+    if ref_authors.is_empty() {
+        return String::new();
+    }
+    let ref_set: std::collections::HashSet<String> = ref_authors
+        .iter()
+        .map(|a| get_last_name_public(a))
+        .filter(|s| !s.is_empty())
+        .collect();
+    let found_set: std::collections::HashSet<String> = found_authors
+        .iter()
+        .map(|a| get_last_name_public(a))
+        .filter(|s| !s.is_empty())
+        .collect();
+    let overlap_count = ref_set.intersection(&found_set).count();
+    format!(" ({}/{})", overlap_count, ref_authors.len())
 }
 
 /// Scan the rendered buffer inside a bordered content area for link display text
@@ -768,5 +785,36 @@ mod tests {
         let links = collect_links(&rs);
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].label, "URL: https://github.com/a/b");
+    }
+
+    // Regression: the "(N/M)" overlap count used a naive lowercased
+    // full-string comparison, so a DBLP disambiguation suffix made a
+    // genuinely-matching author show as zero overlap.
+    #[test]
+    fn overlap_label_ignores_dblp_disambiguation_suffix() {
+        let ref_authors = vec!["Wenbo Guo".to_string()];
+        let found_authors = vec!["Wenbo Guo 0001".to_string()];
+        assert_eq!(author_overlap_label(&ref_authors, &found_authors), " (1/1)");
+    }
+
+    // Regression: same naive comparison also called an initial vs. a full
+    // first name a non-match, even though it's the same person.
+    #[test]
+    fn overlap_label_ignores_initial_vs_full_first_name() {
+        let ref_authors = vec!["J. Smith".to_string()];
+        let found_authors = vec!["John Smith".to_string()];
+        assert_eq!(author_overlap_label(&ref_authors, &found_authors), " (1/1)");
+    }
+
+    #[test]
+    fn overlap_label_counts_genuine_non_overlap() {
+        let ref_authors = vec!["Alice Jones".to_string()];
+        let found_authors = vec!["Bob Kim".to_string()];
+        assert_eq!(author_overlap_label(&ref_authors, &found_authors), " (0/1)");
+    }
+
+    #[test]
+    fn overlap_label_empty_ref_authors_is_empty_string() {
+        assert_eq!(author_overlap_label(&[], &["Someone".to_string()]), "");
     }
 }


### PR DESCRIPTION
## Summary

Three commits, each fixing a distinct class of bug found while auditing why human-confirmed-real references from a large real-world corpus (USENIX Security cycle-1) still weren't being verified automatically:

1. **Title extraction** dropped to an author-list fragment for three specific author-name shapes: accented initials (`Ö.`), embedded lowercase particles (`van`/`von`/`de`/...), and the `Md.` South Asian first-name prefix.
2. **Author-list extraction** had the same three bugs, plus a DOI wrapped right after the slash (left completely unmasked, corrupting the author list with venue fragments) and a substring trap in the "fix missing space before and" heuristic that split real names like Roland/Ferdinand/Bertrand in two.
3. **TUI author-overlap display** used naive full-string comparison, so a DBLP disambiguation suffix like `"Wenbo Guo 0001"` made a genuinely-matching author show as `(0/7)` overlap — misleading, though the actual mismatch decision was never wrong.

## Impact

Measured on the 2027 cycle-1 corpus (2,323 papers, ~120k references):
- 10 previously-garbled titles now extract correctly and all verify against a real database.
- 497 references got a materially corrected author list; of the 38 that were actually flagged `not_found`/`mismatch`, all 38 now verify (28 against DBLP/arXiv, not just local-corpus memory).

## Testing

Each commit stands alone (verified individually via `git stash` + rebuild/retest between commits). All new regression tests use synthetic placeholder names — no real citation content.

- `cargo test --workspace`: 0 failures
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets`: clean (one pre-existing, unrelated warning in `hallucinator-local-corpus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)